### PR TITLE
feat(auth): email/password registration with email verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,134 @@
+# Spades Online
+
+Real-time multiplayer Spades card game — web and mobile.
+
+## Architecture
+
+| Layer | Technology |
+|---|---|
+| Server | Node.js + Express (ES Modules, no build step) |
+| Real-time | WebSocket (WS_PORT, defaults to 3001) |
+| Session / Lobby / Presence | Redis |
+| Persistent storage | PostgreSQL |
+| Mobile | React Native / Flutter (iOS 15+, Android 10+) |
+
+## Local Development
+
+### Prerequisites
+
+- Node.js 18+
+- PostgreSQL
+- Redis
+
+### Setup
+
+```bash
+# Install dependencies
+npm install
+
+# Set required environment variables (copy and edit as needed)
+export DATABASE_URL="postgresql://user:password@localhost:5432/spades"
+export REDIS_URL="redis://localhost:6379"
+
+# Run database migrations
+psql $DATABASE_URL -f db/migrations/001_create_players.sql
+
+# Start the server (default port 3000)
+npm start
+```
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `DATABASE_URL` | Yes | — | PostgreSQL connection string |
+| `REDIS_URL` | Yes | — | Redis connection string |
+| `PORT` | No | `3000` | HTTP server port |
+| `WS_PORT` | No | `3001` | WebSocket server port (can share with HTTP) |
+| `NODE_ENV` | No | — | Environment name (`development`, `production`) |
+| `APP_URL` | No | `http://localhost:3000` | Public base URL (used in verification emails) |
+| `EMAIL_HOST` | No | — | SMTP host. If unset, verification emails are logged to stdout |
+| `EMAIL_PORT` | No | `587` | SMTP port |
+| `EMAIL_SECURE` | No | `false` | Set `true` for TLS on port 465 |
+| `EMAIL_USER` | No | — | SMTP username |
+| `EMAIL_PASS` | No | — | SMTP password |
+| `EMAIL_FROM` | No | `noreply@spades.online` | From address for outbound email |
+| `PUSH_API_KEY` | No | — | Push notification service API key |
+| `GIT_BRANCH` | No | — | Current branch (set by CI) |
+| `GIT_COMMIT_SHA` | No | — | Current commit SHA (set by CI) |
+
+### Running Tests
+
+```bash
+npm test
+```
+
+Unit tests run without any external services. Integration tests require `DATABASE_URL` to be set and will be skipped otherwise.
+
+## API Routes
+
+All routes are under `/api/`. Responses always use `{ ... }` JSON. Auth routes use headers `x-session-id`, `x-player-id`, `x-table-id` where applicable.
+
+### Authentication
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/api/auth/register` | Register with email, username, password. Sends a verification email. |
+| `GET` | `/api/auth/verify-email?token=<uuid>` | Verify email address using the token from the registration email. |
+
+#### `POST /api/auth/register`
+
+**Body**
+```json
+{ "email": "alice@example.com", "username": "alice", "password": "hunter2abc" }
+```
+
+**Responses**
+
+| Status | Meaning |
+|---|---|
+| `201` | Registered. Verification email sent. Body: `{ message, playerId }` |
+| `400` | Missing or invalid fields (e.g. password < 8 chars) |
+| `409` | Email or username already in use |
+
+#### `GET /api/auth/verify-email?token=<uuid>`
+
+**Responses**
+
+| Status | Meaning |
+|---|---|
+| `200` | Email verified. Account is now active. |
+| `400` | Missing, invalid, expired, or already-used token |
+
+## Project Structure
+
+```
+server/
+  app.js          — Express entry point
+  server.js       — All API route handlers
+  db.js           — Shared PostgreSQL pool
+  auth/
+    registration.js — Registration and email-verification logic
+    email.js        — Verification email builder and sender
+db/
+  migrations/
+    001_create_players.sql
+test/
+  unit/
+    auth/           — Pure logic tests (no DB required)
+  integration/
+    auth/           — API route tests (requires DATABASE_URL)
+docs/
+  spades_prd.md   — Product requirements (source of truth for all rules)
+  TASKS.md        — Task checklist
+```
+
+## Branch Strategy
+
+| Branch | Purpose |
+|---|---|
+| `main` | Production — do not commit directly |
+| `dev` | Primary integration branch |
+| `qa` | Pre-prod validation |
+
+All PRs target `dev`.

--- a/db/migrations/001_create_players.sql
+++ b/db/migrations/001_create_players.sql
@@ -1,0 +1,21 @@
+-- Migration 001: players and email verification tokens
+-- Run once against the primary database before starting the server.
+
+CREATE TABLE IF NOT EXISTS players (
+  id            UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  email         VARCHAR(255) UNIQUE NOT NULL,
+  username      VARCHAR(50)  UNIQUE NOT NULL,
+  password_hash VARCHAR(255) NOT NULL,
+  is_verified   BOOLEAN      NOT NULL DEFAULT FALSE,
+  created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS email_verification_tokens (
+  token      UUID        PRIMARY KEY,
+  player_id  UUID        NOT NULL REFERENCES players(id) ON DELETE CASCADE,
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index for fast token lookup during email verification
+CREATE INDEX IF NOT EXISTS idx_evt_player_id ON email_verification_tokens(player_id);

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -31,7 +31,7 @@ Complete P0 tasks in this order. Tasks within the same group are independent and
 
 ## Authentication & Accounts
 
-- [ ] `P0` Implement email/password registration with required email verification
+- [x] `P0` Implement email/password registration with required email verification
 - [ ] `P0` Implement login and session management
 - [ ] `P0` Apply rate limiting on all authentication endpoints
 - [ ] `P1` Add optional 2FA via authenticator app

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1106 @@
+{
+  "name": "spades-online",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "spades-online",
+      "version": "1.0.0",
+      "dependencies": {
+        "bcryptjs": "^2.4.3",
+        "express": "^4.18.2",
+        "nodemailer": "^6.9.7",
+        "pg": "^8.11.3",
+        "redis": "^4.6.10",
+        "uuid": "^9.0.1"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "spades-online",
+  "version": "1.0.0",
+  "description": "Real-time multiplayer Spades card game — server",
+  "type": "module",
+  "main": "server/app.js",
+  "scripts": {
+    "start": "node server/app.js",
+    "test": "node --test 'test/**/*.test.js'"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "express": "^4.18.2",
+    "nodemailer": "^6.9.7",
+    "pg": "^8.11.3",
+    "redis": "^4.6.10",
+    "uuid": "^9.0.1"
+  }
+}

--- a/server/app.js
+++ b/server/app.js
@@ -1,0 +1,29 @@
+import express from 'express'
+import { handler } from './server.js'
+
+const app = express()
+const PORT = process.env.PORT || 3000
+
+app.use(express.json())
+
+// CORS headers are set manually on every request per project conventions.
+app.use((req, res, next) => {
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
+  res.setHeader(
+    'Access-Control-Allow-Headers',
+    'Content-Type, x-session-id, x-player-id, x-table-id',
+  )
+  if (req.method === 'OPTIONS') {
+    return res.status(204).end()
+  }
+  next()
+})
+
+handler(app)
+
+app.listen(PORT, () => {
+  console.log(`Spades Online server listening on port ${PORT}`)
+})
+
+export default app

--- a/server/auth/email.js
+++ b/server/auth/email.js
@@ -1,0 +1,84 @@
+import nodemailer from 'nodemailer'
+
+/**
+ * Build the subject, plain-text, and HTML content for a verification email.
+ *
+ * @param {string} token
+ * @param {string} appUrl - Public base URL of the application (no trailing slash)
+ * @returns {{ subject: string, text: string, html: string }}
+ */
+export function buildVerificationEmailContent(token, appUrl) {
+  const verificationUrl = `${appUrl}/api/auth/verify-email?token=${token}`
+
+  const subject = 'Verify your Spades Online account'
+
+  const text = [
+    'Welcome to Spades Online!',
+    '',
+    'Please verify your email address by visiting the link below:',
+    '',
+    verificationUrl,
+    '',
+    'This link expires in 24 hours.',
+    '',
+    'If you did not create an account, you can safely ignore this email.',
+  ].join('\n')
+
+  const html = `
+    <p>Welcome to <strong>Spades Online</strong>!</p>
+    <p>Please verify your email address by clicking the button below:</p>
+    <p>
+      <a href="${verificationUrl}"
+         style="display:inline-block;padding:10px 20px;background:#1a73e8;color:#fff;
+                text-decoration:none;border-radius:4px;font-weight:bold;">
+        Verify Email Address
+      </a>
+    </p>
+    <p>Or copy and paste this URL into your browser:</p>
+    <p>${verificationUrl}</p>
+    <p>This link expires in 24 hours.</p>
+    <p><small>If you did not create an account, you can safely ignore this email.</small></p>
+  `.trim()
+
+  return { subject, text, html }
+}
+
+function createTransport() {
+  if (!process.env.EMAIL_HOST) return null
+
+  return nodemailer.createTransport({
+    host: process.env.EMAIL_HOST,
+    port: parseInt(process.env.EMAIL_PORT || '587', 10),
+    secure: process.env.EMAIL_SECURE === 'true',
+    auth: {
+      user: process.env.EMAIL_USER,
+      pass: process.env.EMAIL_PASS,
+    },
+  })
+}
+
+/**
+ * Send a verification email to the given address.
+ * Falls back to console logging when EMAIL_HOST is not configured.
+ *
+ * @param {string} toEmail
+ * @param {string} token
+ */
+export async function sendVerificationEmail(toEmail, token) {
+  const appUrl = (process.env.APP_URL || 'http://localhost:3000').replace(/\/$/, '')
+  const fromAddress = process.env.EMAIL_FROM || 'noreply@spades.online'
+  const { subject, text, html } = buildVerificationEmailContent(token, appUrl)
+
+  const transport = createTransport()
+
+  if (!transport) {
+    console.log('Verification email (EMAIL_HOST not configured — logging instead):', {
+      to: toEmail,
+      subject,
+      verificationUrl: `${appUrl}/api/auth/verify-email?token=${token}`,
+    })
+    return
+  }
+
+  await transport.sendMail({ from: fromAddress, to: toEmail, subject, text, html })
+}

--- a/server/auth/registration.js
+++ b/server/auth/registration.js
@@ -1,0 +1,130 @@
+import { v4 as uuidv4 } from 'uuid'
+import bcrypt from 'bcryptjs'
+
+const BCRYPT_ROUNDS = 12
+const VERIFICATION_TOKEN_TTL_HOURS = 24
+
+export async function hashPassword(password) {
+  return bcrypt.hash(password, BCRYPT_ROUNDS)
+}
+
+export async function verifyPassword(password, hash) {
+  return bcrypt.compare(password, hash)
+}
+
+export function generateVerificationToken() {
+  return uuidv4()
+}
+
+/**
+ * Register a new player.
+ *
+ * @param {object} db - pg Pool (or compatible query interface)
+ * @param {{ email: string, username: string, password: string }} fields
+ * @param {(email: string, token: string) => Promise<void>} sendVerificationEmail
+ * @returns {{ playerId: string }}
+ */
+export async function registerPlayer(db, { email, username, password }, sendVerificationEmail) {
+  if (!email) {
+    throw Object.assign(new Error('email is required'), { code: 'VALIDATION_ERROR' })
+  }
+  if (!username) {
+    throw Object.assign(new Error('username is required'), { code: 'VALIDATION_ERROR' })
+  }
+  if (!password) {
+    throw Object.assign(new Error('password is required'), { code: 'VALIDATION_ERROR' })
+  }
+  if (password.length < 8) {
+    throw Object.assign(new Error('password must be at least 8 characters'), {
+      code: 'VALIDATION_ERROR',
+    })
+  }
+
+  const normalizedEmail = email.toLowerCase().trim()
+  const trimmedUsername = username.trim()
+  const passwordHash = await hashPassword(password)
+
+  let player
+  try {
+    const result = await db.query(
+      `INSERT INTO players (email, username, password_hash, is_verified)
+       VALUES ($1, $2, $3, FALSE)
+       RETURNING id`,
+      [normalizedEmail, trimmedUsername, passwordHash],
+    )
+    player = result.rows[0]
+  } catch (err) {
+    if (err.code === '23505') {
+      // unique_violation
+      if (err.constraint && err.constraint.includes('email')) {
+        throw Object.assign(new Error('email already registered'), { code: 'DUPLICATE_EMAIL' })
+      }
+      if (err.constraint && err.constraint.includes('username')) {
+        throw Object.assign(new Error('username already taken'), { code: 'DUPLICATE_USERNAME' })
+      }
+    }
+    throw err
+  }
+
+  const token = generateVerificationToken()
+  const expiresAt = new Date(Date.now() + VERIFICATION_TOKEN_TTL_HOURS * 60 * 60 * 1000)
+
+  await db.query(
+    `INSERT INTO email_verification_tokens (token, player_id, expires_at)
+     VALUES ($1, $2, $3)`,
+    [token, player.id, expiresAt],
+  )
+
+  await sendVerificationEmail(normalizedEmail, token)
+
+  return { playerId: player.id }
+}
+
+/**
+ * Verify an email verification token.
+ * Marks the associated player as verified and deletes the token (single-use).
+ *
+ * @param {object} db - pg Pool (or compatible query interface)
+ * @param {string} token
+ * @returns {{ playerId: string }}
+ */
+export async function verifyEmailToken(db, token) {
+  if (!token) {
+    throw Object.assign(new Error('token is required'), { code: 'VALIDATION_ERROR' })
+  }
+
+  const result = await db.query(
+    `SELECT player_id, expires_at FROM email_verification_tokens WHERE token = $1`,
+    [token],
+  )
+
+  if (result.rows.length === 0) {
+    throw Object.assign(new Error('invalid or already used verification token'), {
+      code: 'INVALID_TOKEN',
+    })
+  }
+
+  const { player_id, expires_at } = result.rows[0]
+
+  if (new Date() > new Date(expires_at)) {
+    throw Object.assign(new Error('verification token has expired'), { code: 'EXPIRED_TOKEN' })
+  }
+
+  await db.query(`UPDATE players SET is_verified = TRUE WHERE id = $1`, [player_id])
+  await db.query(`DELETE FROM email_verification_tokens WHERE token = $1`, [token])
+
+  return { playerId: player_id }
+}
+
+/**
+ * Check whether a player has verified their email.
+ *
+ * @param {object} db
+ * @param {string} playerId
+ * @returns {Promise<boolean>}
+ */
+export async function isPlayerVerified(db, playerId) {
+  const result = await db.query(`SELECT is_verified FROM players WHERE id = $1`, [playerId])
+  if (result.rows.length === 0) return false
+  return result.rows[0].is_verified
+}

--- a/server/db.js
+++ b/server/db.js
@@ -1,0 +1,28 @@
+import pg from 'pg'
+
+const { Pool } = pg
+
+let pool = null
+
+/**
+ * Returns a shared pg Pool instance, creating one on first call.
+ * Requires DATABASE_URL to be set in the environment.
+ *
+ * @returns {pg.Pool}
+ */
+export function getDb() {
+  if (!pool) {
+    pool = new Pool({ connectionString: process.env.DATABASE_URL })
+  }
+  return pool
+}
+
+/**
+ * Close the shared pool (used in tests and graceful shutdown).
+ */
+export async function closeDb() {
+  if (pool) {
+    await pool.end()
+    pool = null
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,52 @@
+import { registerPlayer, verifyEmailToken } from './auth/registration.js'
+import { sendVerificationEmail as defaultMailer } from './auth/email.js'
+import { getDb } from './db.js'
+
+function sendJSON(res, statusCode, data) {
+  res.status(statusCode).json(data)
+}
+
+/**
+ * Register all API route handlers on the given Express app.
+ *
+ * @param {import('express').Application} app
+ * @param {{ mailer?: (email: string, token: string) => Promise<void> }} [opts]
+ */
+export function handler(app, { mailer } = {}) {
+  const emailer = mailer ?? defaultMailer
+
+  // POST /api/auth/register
+  app.post('/api/auth/register', async (req, res) => {
+    const { email, username, password } = req.body ?? {}
+    try {
+      const db = getDb()
+      const result = await registerPlayer(db, { email, username, password }, emailer)
+      sendJSON(res, 201, {
+        message: 'Registration successful. Please check your email to verify your account.',
+        playerId: result.playerId,
+      })
+    } catch (err) {
+      if (err.code === 'VALIDATION_ERROR') return sendJSON(res, 400, { error: err.message })
+      if (err.code === 'DUPLICATE_EMAIL') return sendJSON(res, 409, { error: err.message })
+      if (err.code === 'DUPLICATE_USERNAME') return sendJSON(res, 409, { error: err.message })
+      console.error('Registration error:', { error: err.message })
+      sendJSON(res, 500, { error: 'Internal server error' })
+    }
+  })
+
+  // GET /api/auth/verify-email?token=<uuid>
+  app.get('/api/auth/verify-email', async (req, res) => {
+    const { token } = req.query
+    try {
+      const db = getDb()
+      await verifyEmailToken(db, token)
+      sendJSON(res, 200, { message: 'Email verified successfully. You may now log in.' })
+    } catch (err) {
+      if (err.code === 'VALIDATION_ERROR') return sendJSON(res, 400, { error: err.message })
+      if (err.code === 'INVALID_TOKEN') return sendJSON(res, 400, { error: err.message })
+      if (err.code === 'EXPIRED_TOKEN') return sendJSON(res, 400, { error: err.message })
+      console.error('Email verification error:', { error: err.message })
+      sendJSON(res, 500, { error: 'Internal server error' })
+    }
+  })
+}

--- a/test/integration/auth/registration.test.js
+++ b/test/integration/auth/registration.test.js
@@ -1,0 +1,258 @@
+/**
+ * Integration tests for the registration and email-verification endpoints.
+ * Requires a real PostgreSQL instance via DATABASE_URL.
+ * Tests are skipped when DATABASE_URL is not set.
+ */
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import express from 'express'
+import { handler } from '../../../server/server.js'
+import { getDb, closeDb } from '../../../server/db.js'
+
+const skip = !process.env.DATABASE_URL ? 'DATABASE_URL not set' : false
+
+/**
+ * Start an ephemeral Express server on a random port and return
+ * { baseUrl, close } so tests can make real HTTP calls via fetch.
+ */
+async function startTestServer() {
+  const sentEmails = []
+  const testMailer = async (email, token) => sentEmails.push({ email, token })
+
+  const app = express()
+  app.use(express.json())
+  handler(app, { mailer: testMailer })
+
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address()
+      resolve({
+        baseUrl: `http://127.0.0.1:${port}`,
+        sentEmails,
+        close: () => new Promise((res) => server.close(res)),
+      })
+    })
+  })
+}
+
+/** Ensure the schema exists and clear out test data before each run. */
+async function resetTestSchema(db) {
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS players (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      email VARCHAR(255) UNIQUE NOT NULL,
+      username VARCHAR(50) UNIQUE NOT NULL,
+      password_hash VARCHAR(255) NOT NULL,
+      is_verified BOOLEAN NOT NULL DEFAULT FALSE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `)
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS email_verification_tokens (
+      token UUID PRIMARY KEY,
+      player_id UUID NOT NULL REFERENCES players(id) ON DELETE CASCADE,
+      expires_at TIMESTAMPTZ NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `)
+  // Remove any leftover test data (emails using the sentinel domain)
+  await db.query(`DELETE FROM players WHERE email LIKE '%@test.spades.invalid'`)
+}
+
+describe('POST /api/auth/register', { skip }, () => {
+  let server
+  let db
+
+  before(async () => {
+    db = getDb()
+    await resetTestSchema(db)
+    server = await startTestServer()
+  })
+
+  after(async () => {
+    await server.close()
+    await closeDb()
+  })
+
+  it('returns 201 and a playerId on valid registration', async () => {
+    const res = await fetch(`${server.baseUrl}/api/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'alice@test.spades.invalid',
+        username: 'alice_test',
+        password: 'password123',
+      }),
+    })
+    assert.equal(res.status, 201)
+    const body = await res.json()
+    assert.ok(body.playerId, 'response should include playerId')
+    assert.ok(body.message, 'response should include a message')
+  })
+
+  it('sends a verification email on registration', async () => {
+    server.sentEmails.length = 0
+    await fetch(`${server.baseUrl}/api/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'bob@test.spades.invalid',
+        username: 'bob_test',
+        password: 'password123',
+      }),
+    })
+    assert.equal(server.sentEmails.length, 1)
+    assert.equal(server.sentEmails[0].email, 'bob@test.spades.invalid')
+    assert.ok(server.sentEmails[0].token, 'email should carry a verification token')
+  })
+
+  it('stores account as unverified after registration', async () => {
+    await fetch(`${server.baseUrl}/api/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'carol@test.spades.invalid',
+        username: 'carol_test',
+        password: 'password123',
+      }),
+    })
+    const result = await db.query(
+      `SELECT is_verified FROM players WHERE email = $1`,
+      ['carol@test.spades.invalid'],
+    )
+    assert.equal(result.rows[0].is_verified, false)
+  })
+
+  it('returns 400 when email is missing', async () => {
+    const res = await fetch(`${server.baseUrl}/api/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'dave_test', password: 'password123' }),
+    })
+    assert.equal(res.status, 400)
+  })
+
+  it('returns 400 when password is too short', async () => {
+    const res = await fetch(`${server.baseUrl}/api/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'dave@test.spades.invalid',
+        username: 'dave_test',
+        password: 'short',
+      }),
+    })
+    assert.equal(res.status, 400)
+  })
+
+  it('returns 409 when email is already registered', async () => {
+    const payload = {
+      email: 'dup@test.spades.invalid',
+      username: 'dup_test',
+      password: 'password123',
+    }
+    await fetch(`${server.baseUrl}/api/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    const res = await fetch(`${server.baseUrl}/api/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...payload, username: 'dup_test_2' }),
+    })
+    assert.equal(res.status, 409)
+  })
+
+  it('returns 409 when username is already taken', async () => {
+    await fetch(`${server.baseUrl}/api/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'unique1@test.spades.invalid',
+        username: 'same_username',
+        password: 'password123',
+      }),
+    })
+    const res = await fetch(`${server.baseUrl}/api/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'unique2@test.spades.invalid',
+        username: 'same_username',
+        password: 'password123',
+      }),
+    })
+    assert.equal(res.status, 409)
+  })
+})
+
+describe('GET /api/auth/verify-email', { skip }, () => {
+  let server
+  let db
+
+  before(async () => {
+    db = getDb()
+    await resetTestSchema(db)
+    server = await startTestServer()
+  })
+
+  after(async () => {
+    await server.close()
+    await closeDb()
+  })
+
+  it('returns 200 and marks account verified with a valid token', async () => {
+    // Register a player to get a real token
+    server.sentEmails.length = 0
+    await fetch(`${server.baseUrl}/api/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'verify_ok@test.spades.invalid',
+        username: 'verify_ok',
+        password: 'password123',
+      }),
+    })
+    const { token } = server.sentEmails[0]
+
+    const res = await fetch(`${server.baseUrl}/api/auth/verify-email?token=${token}`)
+    assert.equal(res.status, 200)
+
+    const result = await db.query(
+      `SELECT is_verified FROM players WHERE email = $1`,
+      ['verify_ok@test.spades.invalid'],
+    )
+    assert.equal(result.rows[0].is_verified, true)
+  })
+
+  it('returns 400 for an invalid token', async () => {
+    const res = await fetch(
+      `${server.baseUrl}/api/auth/verify-email?token=00000000-0000-4000-8000-000000000000`,
+    )
+    assert.equal(res.status, 400)
+  })
+
+  it('returns 400 when no token is provided', async () => {
+    const res = await fetch(`${server.baseUrl}/api/auth/verify-email`)
+    assert.equal(res.status, 400)
+  })
+
+  it('returns 400 when the same token is used twice (single use)', async () => {
+    server.sentEmails.length = 0
+    await fetch(`${server.baseUrl}/api/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'singleuse@test.spades.invalid',
+        username: 'singleuse_test',
+        password: 'password123',
+      }),
+    })
+    const { token } = server.sentEmails[0]
+
+    await fetch(`${server.baseUrl}/api/auth/verify-email?token=${token}`)
+    const res = await fetch(`${server.baseUrl}/api/auth/verify-email?token=${token}`)
+    assert.equal(res.status, 400)
+  })
+})

--- a/test/unit/auth/email.test.js
+++ b/test/unit/auth/email.test.js
@@ -1,0 +1,35 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildVerificationEmailContent } from '../../../server/auth/email.js'
+
+describe('buildVerificationEmailContent', () => {
+  it('includes the full verification URL in the plain-text body', () => {
+    const token = 'abc-123-token'
+    const appUrl = 'https://spades.example.com'
+    const { text } = buildVerificationEmailContent(token, appUrl)
+    assert.ok(
+      text.includes(`${appUrl}/api/auth/verify-email?token=${token}`),
+      'plain text should contain the verification URL',
+    )
+  })
+
+  it('includes the full verification URL in the HTML body', () => {
+    const token = 'abc-123-token'
+    const appUrl = 'https://spades.example.com'
+    const { html } = buildVerificationEmailContent(token, appUrl)
+    assert.ok(
+      html.includes(`${appUrl}/api/auth/verify-email?token=${token}`),
+      'HTML body should contain the verification URL',
+    )
+  })
+
+  it('has a non-empty subject line', () => {
+    const { subject } = buildVerificationEmailContent('tok', 'https://example.com')
+    assert.ok(typeof subject === 'string' && subject.length > 0)
+  })
+
+  it('mentions the 24-hour expiry window', () => {
+    const { text } = buildVerificationEmailContent('tok', 'https://example.com')
+    assert.ok(text.includes('24 hours'), 'should tell the user the link expires in 24 hours')
+  })
+})

--- a/test/unit/auth/registration.test.js
+++ b/test/unit/auth/registration.test.js
@@ -1,0 +1,162 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  hashPassword,
+  verifyPassword,
+  generateVerificationToken,
+  registerPlayer,
+  verifyEmailToken,
+} from '../../../server/auth/registration.js'
+
+describe('hashPassword', () => {
+  it('produces a non-empty hash', async () => {
+    const hash = await hashPassword('hunter2')
+    assert.ok(hash.length > 0)
+  })
+
+  it('produces different hashes for the same password (bcrypt salting)', async () => {
+    const hash1 = await hashPassword('hunter2')
+    const hash2 = await hashPassword('hunter2')
+    assert.notEqual(hash1, hash2)
+  })
+})
+
+describe('verifyPassword', () => {
+  it('returns true for correct password', async () => {
+    const hash = await hashPassword('correcthorse')
+    assert.ok(await verifyPassword('correcthorse', hash))
+  })
+
+  it('returns false for wrong password', async () => {
+    const hash = await hashPassword('correcthorse')
+    assert.ok(!(await verifyPassword('wrongpassword', hash)))
+  })
+})
+
+describe('generateVerificationToken', () => {
+  it('returns a UUID v4-formatted string', () => {
+    const token = generateVerificationToken()
+    assert.match(
+      token,
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    )
+  })
+
+  it('returns unique tokens on each call', () => {
+    const tokens = new Set(Array.from({ length: 100 }, generateVerificationToken))
+    assert.equal(tokens.size, 100)
+  })
+})
+
+describe('registerPlayer — input validation', () => {
+  const noop = async () => {}
+
+  it('throws VALIDATION_ERROR when email is missing', async () => {
+    const db = {}
+    await assert.rejects(
+      () => registerPlayer(db, { username: 'alice', password: 'password123' }, noop),
+      (err) => {
+        assert.equal(err.code, 'VALIDATION_ERROR')
+        return true
+      },
+    )
+  })
+
+  it('throws VALIDATION_ERROR when username is missing', async () => {
+    const db = {}
+    await assert.rejects(
+      () => registerPlayer(db, { email: 'a@b.com', password: 'password123' }, noop),
+      (err) => {
+        assert.equal(err.code, 'VALIDATION_ERROR')
+        return true
+      },
+    )
+  })
+
+  it('throws VALIDATION_ERROR when password is missing', async () => {
+    const db = {}
+    await assert.rejects(
+      () => registerPlayer(db, { email: 'a@b.com', username: 'alice' }, noop),
+      (err) => {
+        assert.equal(err.code, 'VALIDATION_ERROR')
+        return true
+      },
+    )
+  })
+
+  it('throws VALIDATION_ERROR when password is too short', async () => {
+    const db = {}
+    await assert.rejects(
+      () => registerPlayer(db, { email: 'a@b.com', username: 'alice', password: 'short' }, noop),
+      (err) => {
+        assert.equal(err.code, 'VALIDATION_ERROR')
+        return true
+      },
+    )
+  })
+
+  it('normalises email to lowercase before insert', async () => {
+    let capturedEmail
+    const db = {
+      query: async (sql, params) => {
+        if (sql.includes('INSERT INTO players')) {
+          capturedEmail = params[0]
+          return { rows: [{ id: 'fake-id' }] }
+        }
+        return { rows: [] }
+      },
+    }
+    await registerPlayer(
+      db,
+      { email: 'Alice@Example.COM', username: 'alice', password: 'password123' },
+      async (email) => { capturedEmail = email },
+    )
+    assert.equal(capturedEmail, 'alice@example.com')
+  })
+})
+
+describe('verifyEmailToken — input validation', () => {
+  it('throws VALIDATION_ERROR when token is missing', async () => {
+    const db = {}
+    await assert.rejects(
+      () => verifyEmailToken(db, undefined),
+      (err) => {
+        assert.equal(err.code, 'VALIDATION_ERROR')
+        return true
+      },
+    )
+  })
+
+  it('throws INVALID_TOKEN when token is not found', async () => {
+    const db = {
+      query: async () => ({ rows: [] }),
+    }
+    await assert.rejects(
+      () => verifyEmailToken(db, 'nonexistent-token'),
+      (err) => {
+        assert.equal(err.code, 'INVALID_TOKEN')
+        return true
+      },
+    )
+  })
+
+  it('throws EXPIRED_TOKEN when token is past its expiry', async () => {
+    const db = {
+      query: async (sql) => {
+        if (sql.includes('SELECT')) {
+          return {
+            rows: [{ player_id: 'some-id', expires_at: new Date(Date.now() - 1000) }],
+          }
+        }
+        return { rows: [] }
+      },
+    }
+    await assert.rejects(
+      () => verifyEmailToken(db, 'expired-token'),
+      (err) => {
+        assert.equal(err.code, 'EXPIRED_TOKEN')
+        return true
+      },
+    )
+  })
+})


### PR DESCRIPTION
Implements issue #2 - email/password registration with required email verification.

## Changes
- `POST /api/auth/register`: validates input, hashes password with bcrypt, creates unverified account, sends verification email
- `GET /api/auth/verify-email?token=`: validates token, marks account verified, deletes token (single-use)
- DB migration for `players` and `email_verification_tokens` tables
- Unit and integration tests (TDD)
- README.md and TASKS.md updated

Closes #2

Generated with [Claude Code](https://claude.ai/code)