### PR TITLE
feat: build player profile page (issue #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ export REDIS_URL="redis://localhost:6379"
 
 # Run database migrations
 psql $DATABASE_URL -f db/migrations/001_create_players.sql
+psql $DATABASE_URL -f db/migrations/002_create_profile_and_games.sql
 
 # Start the server (default port 3000)
 npm start
@@ -68,6 +69,43 @@ Unit tests run without any external services. Integration tests require `DATABAS
 ## API Routes
 
 All routes are under `/api/`. Responses always use `{ ... }` JSON. Auth routes use headers `x-session-id`, `x-player-id`, `x-table-id` where applicable.
+
+### Player Profiles
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/profile/:playerId` | Get a player's public profile (username, avatar, career stats, recent games, cosmetics). |
+
+#### `GET /api/profile/:playerId`
+
+**Responses**
+
+| Status | Meaning |
+|---|---|
+| `200` | Profile found. Body: `{ playerId, username, avatar, cosmetics, career, recentGames }` |
+| `400` | `playerId` is not a valid UUID |
+| `404` | Player not found |
+
+**Response body**
+```json
+{
+  "playerId": "uuid",
+  "username": "alice",
+  "avatar": { "icon": 3 },
+  "cosmetics": { "feltColor": "green", "cardBack": "standard-red" },
+  "career": { "wins": 10, "losses": 5 },
+  "recentGames": [
+    {
+      "gameId": "uuid",
+      "playedAt": "2026-03-01T12:00:00Z",
+      "won": true,
+      "scoreNs": 260,
+      "scoreEw": 150,
+      "seat": "north"
+    }
+  ]
+}
+```
 
 ### Authentication
 
@@ -110,14 +148,18 @@ server/
   auth/
     registration.js — Registration and email-verification logic
     email.js        — Verification email builder and sender
+  social/
+    profile.js      — Player profile data access
 db/
   migrations/
     001_create_players.sql
+    002_create_profile_and_games.sql
 test/
   unit/
     auth/           — Pure logic tests (no DB required)
   integration/
     auth/           — API route tests (requires DATABASE_URL)
+    social/         — Profile API route tests (requires DATABASE_URL)
 docs/
   spades_prd.md   — Product requirements (source of truth for all rules)
   TASKS.md        — Task checklist

--- a/db/migrations/002_create_profile_and_games.sql
+++ b/db/migrations/002_create_profile_and_games.sql
@@ -1,0 +1,30 @@
+-- Migration 002: player profiles, games, and game_players
+-- Run once against the primary database before starting the server.
+
+CREATE TABLE IF NOT EXISTS player_profiles (
+  player_id   UUID        PRIMARY KEY REFERENCES players(id) ON DELETE CASCADE,
+  avatar_icon SMALLINT    NOT NULL DEFAULT 1,
+  felt_color  VARCHAR(20) NOT NULL DEFAULT 'green',
+  card_back   VARCHAR(20) NOT NULL DEFAULT 'standard-red',
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS games (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMPTZ,
+  score_ns     INTEGER     NOT NULL DEFAULT 0,
+  score_ew     INTEGER     NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS game_players (
+  game_id   UUID       NOT NULL REFERENCES games(id) ON DELETE CASCADE,
+  player_id UUID       NOT NULL REFERENCES players(id) ON DELETE CASCADE,
+  seat      VARCHAR(10) NOT NULL,
+  team      CHAR(2)    NOT NULL,
+  won       BOOLEAN    NOT NULL,
+  PRIMARY KEY (game_id, player_id)
+);
+
+-- Index for fast profile lookups by player
+CREATE INDEX IF NOT EXISTS idx_game_players_player_id ON game_players(player_id);

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -35,7 +35,7 @@ Complete P0 tasks in this order. Tasks within the same group are independent and
 - [ ] `P0` Implement login and session management
 - [ ] `P0` Apply rate limiting on all authentication endpoints
 - [ ] `P1` Add optional 2FA via authenticator app
-- [ ] `P1` Build player profile page (username, avatar, career win/loss record, recent 20 games, cosmetics)
+- [x] `P1` Build player profile page (username, avatar, career win/loss record, recent 20 games, cosmetics)
 
 ---
 

--- a/server/server.js
+++ b/server/server.js
@@ -1,5 +1,6 @@
 import { registerPlayer, verifyEmailToken } from './auth/registration.js'
 import { sendVerificationEmail as defaultMailer } from './auth/email.js'
+import { getPlayerProfile, isValidUuid } from './social/profile.js'
 import { getDb } from './db.js'
 
 function sendJSON(res, statusCode, data) {
@@ -30,6 +31,23 @@ export function handler(app, { mailer } = {}) {
       if (err.code === 'DUPLICATE_EMAIL') return sendJSON(res, 409, { error: err.message })
       if (err.code === 'DUPLICATE_USERNAME') return sendJSON(res, 409, { error: err.message })
       console.error('Registration error:', { error: err.message })
+      sendJSON(res, 500, { error: 'Internal server error' })
+    }
+  })
+
+  // GET /api/profile/:playerId
+  app.get('/api/profile/:playerId', async (req, res) => {
+    const { playerId } = req.params
+    if (!isValidUuid(playerId)) {
+      return sendJSON(res, 400, { error: 'invalid playerId format' })
+    }
+    try {
+      const db = getDb()
+      const profile = await getPlayerProfile(db, playerId)
+      sendJSON(res, 200, profile)
+    } catch (err) {
+      if (err.code === 'NOT_FOUND') return sendJSON(res, 404, { error: err.message })
+      console.error('Profile fetch error:', { playerId, error: err.message })
       sendJSON(res, 500, { error: 'Internal server error' })
     }
   })

--- a/server/social/profile.js
+++ b/server/social/profile.js
@@ -1,0 +1,88 @@
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/**
+ * Return true if the given string is a valid UUID.
+ *
+ * @param {string} value
+ * @returns {boolean}
+ */
+export function isValidUuid(value) {
+  return typeof value === 'string' && UUID_RE.test(value)
+}
+
+/**
+ * Fetch the public profile for a player.
+ *
+ * @param {object} db - pg Pool (or compatible query interface)
+ * @param {string} playerId - UUID of the player
+ * @returns {Promise<object>} Profile data
+ */
+export async function getPlayerProfile(db, playerId) {
+  const playerResult = await db.query(
+    `SELECT id, username FROM players WHERE id = $1`,
+    [playerId],
+  )
+  if (playerResult.rows.length === 0) {
+    throw Object.assign(new Error('player not found'), { code: 'NOT_FOUND' })
+  }
+  const player = playerResult.rows[0]
+
+  const profileResult = await db.query(
+    `SELECT avatar_icon, felt_color, card_back FROM player_profiles WHERE player_id = $1`,
+    [playerId],
+  )
+  const profile = profileResult.rows[0] ?? {
+    avatar_icon: 1,
+    felt_color: 'green',
+    card_back: 'standard-red',
+  }
+
+  const statsResult = await db.query(
+    `SELECT
+       COUNT(*) FILTER (WHERE won = TRUE)  AS wins,
+       COUNT(*) FILTER (WHERE won = FALSE) AS losses
+     FROM game_players
+     WHERE player_id = $1`,
+    [playerId],
+  )
+  const stats = statsResult.rows[0]
+
+  const gamesResult = await db.query(
+    `SELECT
+       g.id           AS game_id,
+       g.completed_at AS played_at,
+       gp.won,
+       g.score_ns,
+       g.score_ew,
+       gp.seat
+     FROM game_players gp
+     JOIN games g ON g.id = gp.game_id
+     WHERE gp.player_id = $1
+       AND g.completed_at IS NOT NULL
+     ORDER BY g.completed_at DESC
+     LIMIT 20`,
+    [playerId],
+  )
+
+  return {
+    playerId: player.id,
+    username: player.username,
+    avatar: { icon: profile.avatar_icon },
+    cosmetics: {
+      feltColor: profile.felt_color,
+      cardBack: profile.card_back,
+    },
+    career: {
+      wins: parseInt(stats.wins, 10),
+      losses: parseInt(stats.losses, 10),
+    },
+    recentGames: gamesResult.rows.map((row) => ({
+      gameId: row.game_id,
+      playedAt: row.played_at,
+      won: row.won,
+      scoreNs: row.score_ns,
+      scoreEw: row.score_ew,
+      seat: row.seat,
+    })),
+  }
+}

--- a/test/integration/social/profile.test.js
+++ b/test/integration/social/profile.test.js
@@ -1,0 +1,257 @@
+/**
+ * Integration tests for the player profile endpoint.
+ * Requires a real PostgreSQL instance via DATABASE_URL.
+ * Tests are skipped when DATABASE_URL is not set.
+ */
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import express from 'express'
+import { handler } from '../../../server/server.js'
+import { getDb, closeDb } from '../../../server/db.js'
+
+const skip = !process.env.DATABASE_URL ? 'DATABASE_URL not set' : false
+
+async function startTestServer() {
+  const app = express()
+  app.use(express.json())
+  handler(app)
+
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address()
+      resolve({
+        baseUrl: `http://127.0.0.1:${port}`,
+        close: () => new Promise((res) => server.close(res)),
+      })
+    })
+  })
+}
+
+async function resetTestSchema(db) {
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS players (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      email VARCHAR(255) UNIQUE NOT NULL,
+      username VARCHAR(50) UNIQUE NOT NULL,
+      password_hash VARCHAR(255) NOT NULL,
+      is_verified BOOLEAN NOT NULL DEFAULT FALSE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `)
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS player_profiles (
+      player_id UUID PRIMARY KEY REFERENCES players(id) ON DELETE CASCADE,
+      avatar_icon SMALLINT NOT NULL DEFAULT 1,
+      felt_color VARCHAR(20) NOT NULL DEFAULT 'green',
+      card_back VARCHAR(20) NOT NULL DEFAULT 'standard-red',
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `)
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS games (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      completed_at TIMESTAMPTZ,
+      score_ns INTEGER NOT NULL DEFAULT 0,
+      score_ew INTEGER NOT NULL DEFAULT 0
+    )
+  `)
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS game_players (
+      game_id UUID NOT NULL REFERENCES games(id) ON DELETE CASCADE,
+      player_id UUID NOT NULL REFERENCES players(id) ON DELETE CASCADE,
+      seat VARCHAR(10) NOT NULL,
+      team CHAR(2) NOT NULL,
+      won BOOLEAN NOT NULL,
+      PRIMARY KEY (game_id, player_id)
+    )
+  `)
+  await db.query(`DELETE FROM game_players WHERE player_id IN (
+    SELECT id FROM players WHERE email LIKE '%@test.spades.invalid'
+  )`)
+  await db.query(`DELETE FROM player_profiles WHERE player_id IN (
+    SELECT id FROM players WHERE email LIKE '%@test.spades.invalid'
+  )`)
+  await db.query(`DELETE FROM players WHERE email LIKE '%@test.spades.invalid'`)
+}
+
+async function insertTestPlayer(db, { email, username }) {
+  const result = await db.query(
+    `INSERT INTO players (email, username, password_hash, is_verified)
+     VALUES ($1, $2, 'hash', TRUE) RETURNING id`,
+    [email, username],
+  )
+  return result.rows[0].id
+}
+
+async function insertTestGame(db, playerId, { won, scoreNs, scoreEw, seat, completedAt }) {
+  const gameResult = await db.query(
+    `INSERT INTO games (score_ns, score_ew, completed_at) VALUES ($1, $2, $3) RETURNING id`,
+    [scoreNs, scoreEw, completedAt ?? new Date()],
+  )
+  const gameId = gameResult.rows[0].id
+  const team = seat === 'north' || seat === 'south' ? 'ns' : 'ew'
+  await db.query(
+    `INSERT INTO game_players (game_id, player_id, seat, team, won) VALUES ($1, $2, $3, $4, $5)`,
+    [gameId, playerId, seat, team, won],
+  )
+  return gameId
+}
+
+describe('GET /api/profile/:playerId', { skip }, () => {
+  let server
+  let db
+
+  before(async () => {
+    db = getDb()
+    await resetTestSchema(db)
+    server = await startTestServer()
+  })
+
+  after(async () => {
+    await server.close()
+    await closeDb()
+  })
+
+  it('returns 200 with profile data for a known player', async () => {
+    const playerId = await insertTestPlayer(db, {
+      email: 'profile_basic@test.spades.invalid',
+      username: 'profile_basic',
+    })
+
+    const res = await fetch(`${server.baseUrl}/api/profile/${playerId}`)
+    assert.equal(res.status, 200)
+
+    const body = await res.json()
+    assert.equal(body.playerId, playerId)
+    assert.equal(body.username, 'profile_basic')
+    assert.ok(body.avatar, 'response should include avatar')
+    assert.ok(body.cosmetics, 'response should include cosmetics')
+    assert.ok(body.career, 'response should include career')
+    assert.ok(Array.isArray(body.recentGames), 'recentGames should be an array')
+  })
+
+  it('returns default avatar and cosmetics for a player with no profile record', async () => {
+    const playerId = await insertTestPlayer(db, {
+      email: 'profile_defaults@test.spades.invalid',
+      username: 'profile_defaults',
+    })
+
+    const res = await fetch(`${server.baseUrl}/api/profile/${playerId}`)
+    const body = await res.json()
+
+    assert.equal(body.avatar.icon, 1)
+    assert.equal(body.cosmetics.feltColor, 'green')
+    assert.equal(body.cosmetics.cardBack, 'standard-red')
+  })
+
+  it('returns custom avatar and cosmetics when a profile record exists', async () => {
+    const playerId = await insertTestPlayer(db, {
+      email: 'profile_custom@test.spades.invalid',
+      username: 'profile_custom',
+    })
+    await db.query(
+      `INSERT INTO player_profiles (player_id, avatar_icon, felt_color, card_back)
+       VALUES ($1, $2, $3, $4)`,
+      [playerId, 5, 'navy', 'minimal'],
+    )
+
+    const res = await fetch(`${server.baseUrl}/api/profile/${playerId}`)
+    const body = await res.json()
+
+    assert.equal(body.avatar.icon, 5)
+    assert.equal(body.cosmetics.feltColor, 'navy')
+    assert.equal(body.cosmetics.cardBack, 'minimal')
+  })
+
+  it('returns correct career win/loss counts', async () => {
+    const playerId = await insertTestPlayer(db, {
+      email: 'profile_career@test.spades.invalid',
+      username: 'profile_career',
+    })
+    await insertTestGame(db, playerId, { won: true, scoreNs: 260, scoreEw: 150, seat: 'north' })
+    await insertTestGame(db, playerId, { won: true, scoreNs: 270, scoreEw: 100, seat: 'south' })
+    await insertTestGame(db, playerId, { won: false, scoreNs: 120, scoreEw: 260, seat: 'north' })
+
+    const res = await fetch(`${server.baseUrl}/api/profile/${playerId}`)
+    const body = await res.json()
+
+    assert.equal(body.career.wins, 2)
+    assert.equal(body.career.losses, 1)
+  })
+
+  it('returns zero wins and losses for a player with no games', async () => {
+    const playerId = await insertTestPlayer(db, {
+      email: 'profile_nogames@test.spades.invalid',
+      username: 'profile_nogames',
+    })
+
+    const res = await fetch(`${server.baseUrl}/api/profile/${playerId}`)
+    const body = await res.json()
+
+    assert.equal(body.career.wins, 0)
+    assert.equal(body.career.losses, 0)
+    assert.deepEqual(body.recentGames, [])
+  })
+
+  it('returns at most 20 recent games ordered most recent first', async () => {
+    const playerId = await insertTestPlayer(db, {
+      email: 'profile_history@test.spades.invalid',
+      username: 'profile_history',
+    })
+    // Insert 25 games with distinct timestamps
+    for (let i = 0; i < 25; i++) {
+      const completedAt = new Date(Date.now() - i * 60 * 1000) // i minutes ago
+      await insertTestGame(db, playerId, {
+        won: i % 2 === 0,
+        scoreNs: 260,
+        scoreEw: 150,
+        seat: 'north',
+        completedAt,
+      })
+    }
+
+    const res = await fetch(`${server.baseUrl}/api/profile/${playerId}`)
+    const body = await res.json()
+
+    assert.equal(body.recentGames.length, 20)
+    // Verify ordering: most recent first
+    for (let i = 0; i < body.recentGames.length - 1; i++) {
+      const a = new Date(body.recentGames[i].playedAt)
+      const b = new Date(body.recentGames[i + 1].playedAt)
+      assert.ok(a >= b, 'games should be ordered most recent first')
+    }
+  })
+
+  it('recent games include gameId, playedAt, won, scoreNs, scoreEw, seat', async () => {
+    const playerId = await insertTestPlayer(db, {
+      email: 'profile_gamefields@test.spades.invalid',
+      username: 'profile_gamefields',
+    })
+    await insertTestGame(db, playerId, { won: true, scoreNs: 260, scoreEw: 150, seat: 'east' })
+
+    const res = await fetch(`${server.baseUrl}/api/profile/${playerId}`)
+    const body = await res.json()
+
+    assert.equal(body.recentGames.length, 1)
+    const game = body.recentGames[0]
+    assert.ok(game.gameId, 'game should have gameId')
+    assert.ok(game.playedAt, 'game should have playedAt')
+    assert.equal(game.won, true)
+    assert.equal(game.scoreNs, 260)
+    assert.equal(game.scoreEw, 150)
+    assert.equal(game.seat, 'east')
+  })
+
+  it('returns 404 for an unknown playerId', async () => {
+    const res = await fetch(
+      `${server.baseUrl}/api/profile/00000000-0000-4000-8000-000000000000`,
+    )
+    assert.equal(res.status, 404)
+  })
+
+  it('returns 400 for a non-UUID playerId', async () => {
+    const res = await fetch(`${server.baseUrl}/api/profile/not-a-uuid`)
+    assert.equal(res.status, 400)
+  })
+})


### PR DESCRIPTION
Implements the player profile page API endpoint (issue #6).

Adds `GET /api/profile/:playerId` returning username, avatar, career win/loss record, recent 20 games, and equipped cosmetics. Profile is publicly viewable by any player.

Closes #6

Generated with [Claude Code](https://claude.ai/code)