### PR TITLE
feat: apply rate limiting to all authentication endpoints

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -33,7 +33,7 @@ Complete P0 tasks in this order. Tasks within the same group are independent and
 
 - [x] `P0` Implement email/password registration with required email verification
 - [x] `P0` Implement login and session management
-- [ ] `P0` Apply rate limiting on all authentication endpoints
+- [x] `P0` Apply rate limiting on all authentication endpoints
 - [ ] `P1` Add optional 2FA via authenticator app
 - [ ] `P1` Build player profile page (username, avatar, career win/loss record, recent 20 games, cosmetics)
 

--- a/server/app.js
+++ b/server/app.js
@@ -1,5 +1,6 @@
 import express from 'express'
 import { handler } from './server.js'
+import { getRedis } from './redis.js'
 
 const app = express()
 const PORT = process.env.PORT || 3000
@@ -20,7 +21,8 @@ app.use((req, res, next) => {
   next()
 })
 
-handler(app)
+const redis = process.env.REDIS_URL ? await getRedis() : null
+handler(app, { redis })
 
 app.listen(PORT, () => {
   console.log(`Spades Online server listening on port ${PORT}`)

--- a/server/middleware/rateLimiter.js
+++ b/server/middleware/rateLimiter.js
@@ -1,0 +1,47 @@
+/**
+ * Redis-backed fixed-window rate limiter middleware factory.
+ *
+ * @param {import('redis').RedisClientType} redisClient
+ * @param {{ keyPrefix?: string, max?: number, windowSecs?: number }} [opts]
+ * @returns {import('express').RequestHandler}
+ */
+export function createRateLimiter(redisClient, opts = {}) {
+  const keyPrefix = opts.keyPrefix ?? 'rl'
+  const max = opts.max ?? parseInt(process.env.AUTH_RATE_LIMIT_MAX ?? '10', 10)
+  const windowSecs = opts.windowSecs ?? parseInt(process.env.AUTH_RATE_LIMIT_WINDOW ?? '900', 10)
+
+  return async function rateLimiter(req, res, next) {
+    if (!redisClient) {
+      return next()
+    }
+
+    const ip = req.ip ?? req.socket?.remoteAddress ?? 'unknown'
+    const key = `ratelimit:${keyPrefix}:${ip}`
+
+    try {
+      const count = await redisClient.incr(key)
+
+      if (count === 1) {
+        await redisClient.expire(key, windowSecs)
+      }
+
+      const ttl = await redisClient.ttl(key)
+      const resetAt = Math.floor(Date.now() / 1000) + (ttl > 0 ? ttl : windowSecs)
+      const remaining = Math.max(0, max - count)
+
+      res.setHeader('X-RateLimit-Limit', String(max))
+      res.setHeader('X-RateLimit-Remaining', String(remaining))
+      res.setHeader('X-RateLimit-Reset', String(resetAt))
+
+      if (count > max) {
+        res.setHeader('Retry-After', String(ttl > 0 ? ttl : windowSecs))
+        return res.status(429).json({ error: 'Too many requests. Please try again later.' })
+      }
+
+      next()
+    } catch (err) {
+      console.error('Rate limiter error:', { key, error: err.message })
+      next()
+    }
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -4,6 +4,7 @@ import { loginPlayer } from './auth/login.js'
 import { createSession, deleteSession } from './auth/session.js'
 import { getDb } from './db.js'
 import { getRedis } from './redis.js'
+import { createRateLimiter } from './middleware/rateLimiter.js'
 
 function sendJSON(res, statusCode, data) {
   res.status(statusCode).json(data)
@@ -13,13 +14,17 @@ function sendJSON(res, statusCode, data) {
  * Register all API route handlers on the given Express app.
  *
  * @param {import('express').Application} app
- * @param {{ mailer?: (email: string, token: string) => Promise<void> }} [opts]
+ * @param {{ mailer?: (email: string, token: string) => Promise<void>, redis?: object, rateLimitConfig?: { max?: number, windowSecs?: number } }} [opts]
  */
-export function handler(app, { mailer } = {}) {
+export function handler(app, { mailer, redis, rateLimitConfig } = {}) {
   const emailer = mailer ?? defaultMailer
+  const authRateLimiter = createRateLimiter(redis ?? null, {
+    keyPrefix: 'auth',
+    ...rateLimitConfig,
+  })
 
   // POST /api/auth/register
-  app.post('/api/auth/register', async (req, res) => {
+  app.post('/api/auth/register', authRateLimiter, async (req, res) => {
     const { email, username, password } = req.body ?? {}
     try {
       const db = getDb()
@@ -38,7 +43,7 @@ export function handler(app, { mailer } = {}) {
   })
 
   // GET /api/auth/verify-email?token=<uuid>
-  app.get('/api/auth/verify-email', async (req, res) => {
+  app.get('/api/auth/verify-email', authRateLimiter, async (req, res) => {
     const { token } = req.query
     try {
       const db = getDb()
@@ -54,7 +59,7 @@ export function handler(app, { mailer } = {}) {
   })
 
   // POST /api/auth/login
-  app.post('/api/auth/login', async (req, res) => {
+  app.post('/api/auth/login', authRateLimiter, async (req, res) => {
     const { email, password } = req.body ?? {}
     try {
       const db = getDb()

--- a/test/integration/auth/rateLimiter.test.js
+++ b/test/integration/auth/rateLimiter.test.js
@@ -1,0 +1,139 @@
+/**
+ * Integration tests for rate limiting on auth endpoints.
+ * Requires a real Redis instance (REDIS_URL).
+ * Tests are skipped when REDIS_URL is not set.
+ */
+import { describe, it, before, after, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import express from 'express'
+import { handler } from '../../../server/server.js'
+import { getRedis, closeRedis } from '../../../server/redis.js'
+
+const skip = !process.env.REDIS_URL ? 'REDIS_URL not set' : false
+
+async function startTestServer(redis) {
+  const app = express()
+  app.use(express.json())
+  // Use a very low limit so tests don't need many requests
+  handler(app, { redis, rateLimitConfig: { max: 3, windowSecs: 60 } })
+
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address()
+      resolve({
+        baseUrl: `http://127.0.0.1:${port}`,
+        close: () => new Promise((res) => server.close(res)),
+      })
+    })
+  })
+}
+
+async function flushRateLimitKeys(redis) {
+  // Remove only test rate limit keys to avoid affecting other data
+  const keys = await redis.keys('ratelimit:auth:*')
+  if (keys.length > 0) {
+    await redis.del(keys)
+  }
+}
+
+describe('Auth endpoint rate limiting', { skip }, () => {
+  let server
+  let redis
+
+  before(async () => {
+    redis = await getRedis()
+    await flushRateLimitKeys(redis)
+    server = await startTestServer(redis)
+  })
+
+  beforeEach(async () => {
+    await flushRateLimitKeys(redis)
+  })
+
+  after(async () => {
+    await server.close()
+    await closeRedis()
+  })
+
+  it('sets X-RateLimit-* headers on POST /api/auth/register', async () => {
+    const res = await fetch(`${server.baseUrl}/api/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'a@test.invalid', username: 'a_test', password: 'password123' }),
+    })
+    assert.ok(res.headers.get('x-ratelimit-limit'), 'X-RateLimit-Limit should be set')
+    assert.ok(res.headers.get('x-ratelimit-remaining'), 'X-RateLimit-Remaining should be set')
+    assert.ok(res.headers.get('x-ratelimit-reset'), 'X-RateLimit-Reset should be set')
+  })
+
+  it('returns 429 after limit is exceeded on POST /api/auth/register', async () => {
+    for (let i = 0; i < 3; i++) {
+      await fetch(`${server.baseUrl}/api/auth/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: `reg${i}@test.invalid`, username: `reg_u${i}`, password: 'password123' }),
+      })
+    }
+
+    const blocked = await fetch(`${server.baseUrl}/api/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'extra@test.invalid', username: 'extra_u', password: 'password123' }),
+    })
+    assert.equal(blocked.status, 429)
+    assert.ok(blocked.headers.get('retry-after'), 'Retry-After header should be set on 429')
+    const body = await blocked.json()
+    assert.ok(body.error, 'error message should be in response body')
+  })
+
+  it('returns 429 after limit is exceeded on POST /api/auth/login', async () => {
+    for (let i = 0; i < 3; i++) {
+      await fetch(`${server.baseUrl}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: `login${i}@test.invalid`, password: 'password123' }),
+      })
+    }
+
+    const blocked = await fetch(`${server.baseUrl}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'extra@test.invalid', password: 'password123' }),
+    })
+    assert.equal(blocked.status, 429)
+    assert.ok(blocked.headers.get('retry-after'), 'Retry-After header should be set on 429')
+  })
+
+  it('returns 429 after limit is exceeded on GET /api/auth/verify-email', async () => {
+    for (let i = 0; i < 3; i++) {
+      await fetch(`${server.baseUrl}/api/auth/verify-email?token=some-token-${i}`)
+    }
+
+    const blocked = await fetch(`${server.baseUrl}/api/auth/verify-email?token=extra-token`)
+    assert.equal(blocked.status, 429)
+    assert.ok(blocked.headers.get('retry-after'), 'Retry-After header should be set on 429')
+  })
+
+  it('shares a single counter across all auth endpoints (same IP)', async () => {
+    // Mix register, login, and verify-email — all share the same rate limit key per IP
+    await fetch(`${server.baseUrl}/api/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'x@test.invalid', username: 'x_test', password: 'password123' }),
+    })
+    await fetch(`${server.baseUrl}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'x@test.invalid', password: 'password123' }),
+    })
+    await fetch(`${server.baseUrl}/api/auth/verify-email?token=abc`)
+
+    // 4th request across any endpoint should be blocked
+    const blocked = await fetch(`${server.baseUrl}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'x@test.invalid', password: 'password123' }),
+    })
+    assert.equal(blocked.status, 429)
+  })
+})

--- a/test/unit/middleware/rateLimiter.test.js
+++ b/test/unit/middleware/rateLimiter.test.js
@@ -1,0 +1,201 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createRateLimiter } from '../../../server/middleware/rateLimiter.js'
+
+/**
+ * Minimal mock Redis client for unit tests.
+ * Stores key/value pairs and simulates INCR, EXPIRE, and TTL.
+ */
+function makeMockRedis() {
+  const store = new Map()
+  const ttls = new Map()
+
+  return {
+    async incr(key) {
+      const current = store.get(key) ?? 0
+      const next = current + 1
+      store.set(key, next)
+      return next
+    },
+    async expire(key, secs) {
+      ttls.set(key, secs)
+      return 1
+    },
+    async ttl(key) {
+      return ttls.get(key) ?? -1
+    },
+    _store: store,
+    _ttls: ttls,
+  }
+}
+
+/**
+ * Create a minimal mock Express req/res pair and a next() spy.
+ */
+function makeMockReqRes(ip = '127.0.0.1') {
+  const headers = {}
+  let statusCode = null
+  let jsonBody = null
+  let nextCalled = false
+
+  const req = { ip }
+  const res = {
+    setHeader(name, value) {
+      headers[name] = value
+    },
+    status(code) {
+      statusCode = code
+      return this
+    },
+    json(body) {
+      jsonBody = body
+      return this
+    },
+    _headers: headers,
+    get statusCode() {
+      return statusCode
+    },
+    get jsonBody() {
+      return jsonBody
+    },
+  }
+  const next = () => {
+    nextCalled = true
+  }
+
+  return { req, res, next, get nextCalled() { return nextCalled } }
+}
+
+describe('createRateLimiter', () => {
+  it('calls next() when under the limit', async () => {
+    const redis = makeMockRedis()
+    const limiter = createRateLimiter(redis, { keyPrefix: 'test', max: 5, windowSecs: 60 })
+
+    const { req, res, next, get: _ } = makeMockReqRes()
+    let called = false
+    await limiter(req, res, () => { called = true })
+
+    assert.ok(called, 'next() should be called when under limit')
+    assert.equal(res.statusCode, null)
+  })
+
+  it('sets X-RateLimit-* headers on each request', async () => {
+    const redis = makeMockRedis()
+    const limiter = createRateLimiter(redis, { keyPrefix: 'hdr', max: 10, windowSecs: 60 })
+
+    const { req, res } = makeMockReqRes()
+    await limiter(req, res, () => {})
+
+    assert.equal(res._headers['X-RateLimit-Limit'], '10')
+    assert.ok(res._headers['X-RateLimit-Remaining'] !== undefined)
+    assert.ok(res._headers['X-RateLimit-Reset'] !== undefined)
+  })
+
+  it('decrements X-RateLimit-Remaining with each request', async () => {
+    const redis = makeMockRedis()
+    const limiter = createRateLimiter(redis, { keyPrefix: 'rem', max: 3, windowSecs: 60 })
+    const ip = '10.0.0.1'
+
+    const results = []
+    for (let i = 0; i < 3; i++) {
+      const { req, res } = makeMockReqRes(ip)
+      await limiter(req, res, () => {})
+      results.push(Number(res._headers['X-RateLimit-Remaining']))
+    }
+
+    assert.deepEqual(results, [2, 1, 0])
+  })
+
+  it('returns 429 and sets Retry-After when the limit is exceeded', async () => {
+    const redis = makeMockRedis()
+    const limiter = createRateLimiter(redis, { keyPrefix: 'block', max: 2, windowSecs: 60 })
+    const ip = '10.0.0.2'
+
+    // Exhaust the limit
+    for (let i = 0; i < 2; i++) {
+      await limiter({ ip }, { setHeader: () => {}, status: () => ({ json: () => {} }), json: () => {} }, () => {})
+    }
+
+    // Next request should be blocked
+    const { req, res } = makeMockReqRes(ip)
+    let nextCalled = false
+    await limiter(req, res, () => { nextCalled = true })
+
+    assert.ok(!nextCalled, 'next() should not be called when limit is exceeded')
+    assert.equal(res.statusCode, 429)
+    assert.ok(res.jsonBody?.error, 'response should include an error message')
+    assert.ok(res._headers['Retry-After'] !== undefined, 'Retry-After header should be set')
+  })
+
+  it('uses separate counters per IP', async () => {
+    const redis = makeMockRedis()
+    const limiter = createRateLimiter(redis, { keyPrefix: 'ip', max: 1, windowSecs: 60 })
+
+    // IP A uses its one request
+    const { req: reqA, res: resA } = makeMockReqRes('1.1.1.1')
+    let aBlocked = false
+    await limiter(reqA, resA, () => {})
+
+    // IP A is now over limit
+    const { req: reqA2, res: resA2 } = makeMockReqRes('1.1.1.1')
+    await limiter(reqA2, resA2, () => {})
+    assert.equal(resA2.statusCode, 429)
+
+    // IP B should still pass through
+    const { req: reqB, res: resB } = makeMockReqRes('2.2.2.2')
+    let bPassed = false
+    await limiter(reqB, resB, () => { bPassed = true })
+    assert.ok(bPassed, 'IP B should not be rate limited by IP A exhausting their limit')
+  })
+
+  it('sets EXPIRE only on the first request (count === 1)', async () => {
+    const redis = makeMockRedis()
+    const limiter = createRateLimiter(redis, { keyPrefix: 'exp', max: 5, windowSecs: 60 })
+    const ip = '3.3.3.3'
+
+    await limiter({ ip }, { setHeader: () => {}, status: () => ({ json: () => {} }), json: () => {} }, () => {})
+    const ttlAfterFirst = redis._ttls.get(`ratelimit:exp:${ip}`)
+
+    await limiter({ ip }, { setHeader: () => {}, status: () => ({ json: () => {} }), json: () => {} }, () => {})
+    const ttlAfterSecond = redis._ttls.get(`ratelimit:exp:${ip}`)
+
+    assert.equal(ttlAfterFirst, 60)
+    assert.equal(ttlAfterSecond, 60, 'EXPIRE should only be called once — TTL should not be reset')
+    assert.equal(redis._ttls.size, 1, 'expire should only have been called once')
+  })
+
+  it('calls next() when no redis client is provided (graceful degradation)', async () => {
+    const limiter = createRateLimiter(null, { keyPrefix: 'null', max: 5, windowSecs: 60 })
+
+    let called = false
+    await limiter({ ip: '4.4.4.4' }, {}, () => { called = true })
+    assert.ok(called, 'next() should be called when redis is null')
+  })
+
+  it('uses AUTH_RATE_LIMIT_MAX and AUTH_RATE_LIMIT_WINDOW env vars as defaults', async () => {
+    const original = { ...process.env }
+    process.env.AUTH_RATE_LIMIT_MAX = '3'
+    process.env.AUTH_RATE_LIMIT_WINDOW = '120'
+
+    try {
+      const redis = makeMockRedis()
+      const limiter = createRateLimiter(redis, { keyPrefix: 'env' })
+      const ip = '5.5.5.5'
+
+      // Exhaust 3 requests
+      for (let i = 0; i < 3; i++) {
+        await limiter({ ip }, { setHeader: () => {}, status: () => ({ json: () => {} }), json: () => {} }, () => {})
+      }
+
+      // 4th request should be blocked
+      const { req, res } = makeMockReqRes(ip)
+      await limiter(req, res, () => {})
+      assert.equal(res.statusCode, 429, '4th request should be blocked with max=3 from env')
+    } finally {
+      process.env.AUTH_RATE_LIMIT_MAX = original.AUTH_RATE_LIMIT_MAX ?? ''
+      process.env.AUTH_RATE_LIMIT_WINDOW = original.AUTH_RATE_LIMIT_WINDOW ?? ''
+      if (!original.AUTH_RATE_LIMIT_MAX) delete process.env.AUTH_RATE_LIMIT_MAX
+      if (!original.AUTH_RATE_LIMIT_WINDOW) delete process.env.AUTH_RATE_LIMIT_WINDOW
+    }
+  })
+})


### PR DESCRIPTION
Applies a Redis-backed fixed-window rate limiter to all three auth endpoints: `POST /api/auth/register`, `GET /api/auth/verify-email`, and `POST /api/auth/login`.

## Changes
- `server/middleware/rateLimiter.js` — `createRateLimiter` factory using Redis INCR/EXPIRE
- `server/server.js` — wires rate limiter onto all three auth endpoints; configurable via options
- `server/app.js` — connects Redis client from REDIS_URL on startup
- Unit tests (mock Redis) and integration tests (real Redis, skipped when REDIS_URL unset)

Exceeding the limit returns 429 with `Retry-After`, `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers. Configurable via `AUTH_RATE_LIMIT_MAX` and `AUTH_RATE_LIMIT_WINDOW` env vars (defaults: 10 req / 15 min).

Closes #4

Generated with [Claude Code](https://claude.ai/code)) • [`claude/issue-4-20260330-2301`](https://github.com/dantonel/spades/tree/claude/issue-4-20260330-2301