### PR TITLE
feat: registration and login screens (Web UI) #issue-80

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,32 @@ All routes are under `/api/`. Responses always use `{ ... }` JSON. Auth routes u
 | `200` | Email verified. Account is now active. |
 | `400` | Missing, invalid, expired, or already-used token |
 
+## Web UI
+
+The web client is served as static files from `client/web/` by the Express server. Open `http://localhost:3000` in a browser after starting the server.
+
+Current screens:
+- **Sign In** (`#/login`) — email + password login
+- **Create Account** (`#/register`) — registration with email, username, and password; shows a verification prompt on success
+
+On successful login the session is stored in `sessionStorage` (`sessionId`, `playerId`, `username`) and the player is routed to `#/lobby` (lobby screen, coming in a later slice).
+
 ## Project Structure
 
 ```
+client/
+  web/
+    index.html        — SPA entry point (served at /)
+    src/
+      main.js         — App entry; registers routes and starts the router
+      router.js       — Hash-based SPA router
+      validation.js   — Pure form-validation helpers (shared with unit tests)
+      api.js          — Fetch wrappers for auth API endpoints
+      screens/
+        login.js      — Sign-in screen
+        register.js   — Registration screen
 server/
-  app.js          — Express entry point
+  app.js          — Express entry point (also serves client/web as static)
   server.js       — All API route handlers
   db.js           — Shared PostgreSQL pool
   auth/
@@ -157,6 +178,7 @@ db/
 test/
   unit/
     auth/           — Pure logic tests (no DB required)
+    web/            — Web client unit tests (validation, API client)
   integration/
     auth/           — API route tests (requires DATABASE_URL)
     social/         — Profile API route tests (requires DATABASE_URL)

--- a/client/web/index.html
+++ b/client/web/index.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Spades Online</title>
+    <style>
+      *, *::before, *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+        background: #1a3a1a;
+        color: #e8e8e8;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+      }
+
+      #app {
+        width: 100%;
+        max-width: 420px;
+        padding: 1rem;
+      }
+
+      .auth-card {
+        background: #1e1e1e;
+        border: 1px solid #2e2e2e;
+        border-radius: 8px;
+        padding: 2rem;
+      }
+
+      .auth-title {
+        font-size: 1.5rem;
+        font-weight: 600;
+        margin-bottom: 1.5rem;
+        color: #fff;
+      }
+
+      .form-group {
+        margin-bottom: 1rem;
+      }
+
+      label {
+        display: block;
+        font-size: 0.875rem;
+        font-weight: 500;
+        margin-bottom: 0.25rem;
+        color: #b0b0b0;
+      }
+
+      input[type="email"],
+      input[type="text"],
+      input[type="password"] {
+        width: 100%;
+        padding: 0.625rem 0.75rem;
+        background: #2a2a2a;
+        border: 1px solid #3a3a3a;
+        border-radius: 4px;
+        color: #e8e8e8;
+        font-size: 1rem;
+        outline: none;
+        transition: border-color 0.15s;
+      }
+
+      input:focus {
+        border-color: #4caf50;
+      }
+
+      input::placeholder {
+        color: #555;
+      }
+
+      .form-error {
+        min-height: 1.25rem;
+        font-size: 0.875rem;
+        color: #e57373;
+        margin-bottom: 0.75rem;
+        margin-top: 0.25rem;
+      }
+
+      .btn-primary {
+        width: 100%;
+        padding: 0.75rem;
+        background: #2e7d32;
+        color: #fff;
+        border: none;
+        border-radius: 4px;
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.15s;
+      }
+
+      .btn-primary:hover:not(:disabled) {
+        background: #388e3c;
+      }
+
+      .btn-primary:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+
+      .auth-link {
+        margin-top: 1.25rem;
+        font-size: 0.875rem;
+        color: #888;
+        text-align: center;
+      }
+
+      .auth-link a {
+        color: #66bb6a;
+        text-decoration: none;
+      }
+
+      .auth-link a:hover {
+        text-decoration: underline;
+      }
+
+      .auth-message {
+        color: #b0b0b0;
+        line-height: 1.6;
+        margin-bottom: 1rem;
+      }
+
+      .auth-message strong {
+        color: #e8e8e8;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="src/main.js"></script>
+  </body>
+</html>

--- a/client/web/src/api.js
+++ b/client/web/src/api.js
@@ -1,0 +1,48 @@
+/**
+ * API client — thin wrappers around fetch for auth endpoints.
+ *
+ * Each function accepts an optional `fetchFn` parameter so that unit tests
+ * can inject a mock without patching the global.
+ */
+
+/**
+ * Register a new player account.
+ * @param {{ email: string, username: string, password: string }} data
+ * @param {typeof fetch} [fetchFn]
+ * @returns {Promise<{ playerId: string, message: string }>}
+ */
+export async function registerUser({ email, username, password }, fetchFn = globalThis.fetch) {
+  const res = await fetchFn('/api/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, username, password }),
+  })
+  const body = await res.json()
+  if (!res.ok) {
+    const err = new Error(body.error || 'Registration failed.')
+    err.status = res.status
+    throw err
+  }
+  return body
+}
+
+/**
+ * Log in with email and password.
+ * @param {{ email: string, password: string }} data
+ * @param {typeof fetch} [fetchFn]
+ * @returns {Promise<{ sessionId: string, playerId: string, username: string }>}
+ */
+export async function loginUser({ email, password }, fetchFn = globalThis.fetch) {
+  const res = await fetchFn('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  })
+  const body = await res.json()
+  if (!res.ok) {
+    const err = new Error(body.error || 'Login failed.')
+    err.status = res.status
+    throw err
+  }
+  return body
+}

--- a/client/web/src/main.js
+++ b/client/web/src/main.js
@@ -1,0 +1,15 @@
+import { addRoute, init } from './router.js'
+import { renderLoginScreen } from './screens/login.js'
+import { renderRegisterScreen } from './screens/register.js'
+
+const app = document.getElementById('app')
+
+addRoute('#/login', renderLoginScreen)
+addRoute('#/register', renderRegisterScreen)
+
+// Redirect authenticated users away from auth screens
+if (sessionStorage.getItem('sessionId') && window.location.hash !== '#/lobby') {
+  window.location.hash = '#/lobby'
+}
+
+init(app)

--- a/client/web/src/router.js
+++ b/client/web/src/router.js
@@ -1,0 +1,45 @@
+/**
+ * Minimal hash-based SPA router.
+ *
+ * Usage:
+ *   addRoute('#/login', renderLoginScreen)
+ *   addRoute('#/register', renderRegisterScreen)
+ *   init(document.getElementById('app'))
+ */
+
+const routes = {}
+
+/**
+ * Register a route handler for a given hash path.
+ * @param {string} hash  e.g. '#/login'
+ * @param {(container: HTMLElement) => void} renderFn
+ */
+export function addRoute(hash, renderFn) {
+  routes[hash] = renderFn
+}
+
+/**
+ * Navigate to a hash path.
+ * @param {string} hash  e.g. '#/lobby'
+ */
+export function navigate(hash) {
+  window.location.hash = hash
+}
+
+/**
+ * Start the router, rendering the current route into `container`.
+ * Re-renders on every hashchange.
+ * @param {HTMLElement} container
+ */
+export function init(container) {
+  function render() {
+    const hash = window.location.hash || '#/login'
+    const fn = routes[hash] ?? routes['#/login']
+    if (fn) {
+      container.innerHTML = ''
+      fn(container)
+    }
+  }
+  window.addEventListener('hashchange', render)
+  render()
+}

--- a/client/web/src/screens/login.js
+++ b/client/web/src/screens/login.js
@@ -1,0 +1,78 @@
+import { validateLoginForm } from '../validation.js'
+import { loginUser } from '../api.js'
+import { navigate } from '../router.js'
+
+/**
+ * Render the login screen into `container`.
+ * On success, stores session data in sessionStorage and navigates to #/lobby.
+ * @param {HTMLElement} container
+ */
+export function renderLoginScreen(container) {
+  container.innerHTML = `
+    <div class="auth-card">
+      <h1 class="auth-title">Sign In</h1>
+      <form id="login-form" novalidate>
+        <div class="form-group">
+          <label for="login-email">Email</label>
+          <input
+            type="email"
+            id="login-email"
+            name="email"
+            autocomplete="email"
+            placeholder="you@example.com"
+          />
+        </div>
+        <div class="form-group">
+          <label for="login-password">Password</label>
+          <input
+            type="password"
+            id="login-password"
+            name="password"
+            autocomplete="current-password"
+            placeholder="Your password"
+          />
+        </div>
+        <div class="form-error" id="login-error" role="alert" aria-live="polite"></div>
+        <button type="submit" id="login-btn" class="btn-primary">Sign In</button>
+      </form>
+      <p class="auth-link">Don't have an account? <a href="#/register">Create one</a></p>
+    </div>
+  `
+
+  const form = container.querySelector('#login-form')
+  const errorEl = container.querySelector('#login-error')
+  const btn = container.querySelector('#login-btn')
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault()
+    errorEl.textContent = ''
+
+    const email = form.querySelector('#login-email').value.trim()
+    const password = form.querySelector('#login-password').value
+
+    const validationError = validateLoginForm({ email, password })
+    if (validationError) {
+      errorEl.textContent = validationError
+      return
+    }
+
+    btn.disabled = true
+    btn.textContent = 'Signing in\u2026'
+
+    try {
+      const { sessionId, playerId, username } = await loginUser({ email, password })
+      sessionStorage.setItem('sessionId', sessionId)
+      sessionStorage.setItem('playerId', playerId)
+      sessionStorage.setItem('username', username)
+      console.log('Login successful:', { playerId, username })
+      navigate('#/lobby')
+    } catch (err) {
+      let message = err.message
+      if (err.status === 401) message = 'Invalid email or password.'
+      if (err.status === 403) message = 'Please verify your email address before signing in.'
+      errorEl.textContent = message
+      btn.disabled = false
+      btn.textContent = 'Sign In'
+    }
+  })
+}

--- a/client/web/src/screens/register.js
+++ b/client/web/src/screens/register.js
@@ -1,0 +1,98 @@
+import { validateRegisterForm } from '../validation.js'
+import { registerUser } from '../api.js'
+
+/**
+ * Render the registration screen into `container`.
+ * On success, replaces the form with a "check your email" confirmation.
+ * @param {HTMLElement} container
+ */
+export function renderRegisterScreen(container) {
+  container.innerHTML = `
+    <div class="auth-card">
+      <h1 class="auth-title">Create Account</h1>
+      <form id="register-form" novalidate>
+        <div class="form-group">
+          <label for="reg-email">Email</label>
+          <input
+            type="email"
+            id="reg-email"
+            name="email"
+            autocomplete="email"
+            placeholder="you@example.com"
+          />
+        </div>
+        <div class="form-group">
+          <label for="reg-username">Username</label>
+          <input
+            type="text"
+            id="reg-username"
+            name="username"
+            autocomplete="username"
+            placeholder="Choose a username"
+          />
+        </div>
+        <div class="form-group">
+          <label for="reg-password">Password</label>
+          <input
+            type="password"
+            id="reg-password"
+            name="password"
+            autocomplete="new-password"
+            placeholder="At least 8 characters"
+          />
+        </div>
+        <div class="form-error" id="register-error" role="alert" aria-live="polite"></div>
+        <button type="submit" id="register-btn" class="btn-primary">Create Account</button>
+      </form>
+      <p class="auth-link">Already have an account? <a href="#/login">Sign in</a></p>
+    </div>
+  `
+
+  const form = container.querySelector('#register-form')
+  const errorEl = container.querySelector('#register-error')
+  const btn = container.querySelector('#register-btn')
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault()
+    errorEl.textContent = ''
+
+    const email = form.querySelector('#reg-email').value.trim()
+    const username = form.querySelector('#reg-username').value.trim()
+    const password = form.querySelector('#reg-password').value
+
+    const validationError = validateRegisterForm({ email, username, password })
+    if (validationError) {
+      errorEl.textContent = validationError
+      return
+    }
+
+    btn.disabled = true
+    btn.textContent = 'Creating account\u2026'
+
+    try {
+      await registerUser({ email, username, password })
+      container.innerHTML = `
+        <div class="auth-card">
+          <h1 class="auth-title">Check your email</h1>
+          <p class="auth-message">
+            We've sent a verification link to <strong>${escapeHtml(email)}</strong>.
+            Click the link in that email to activate your account, then sign in.
+          </p>
+          <p class="auth-link"><a href="#/login">Back to sign in</a></p>
+        </div>
+      `
+    } catch (err) {
+      errorEl.textContent = err.message
+      btn.disabled = false
+      btn.textContent = 'Create Account'
+    }
+  })
+}
+
+function escapeHtml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}

--- a/client/web/src/validation.js
+++ b/client/web/src/validation.js
@@ -1,0 +1,37 @@
+/**
+ * Pure form-validation helpers — no DOM dependencies.
+ * Used by both the browser screens and the Node unit test suite.
+ */
+
+/**
+ * Validates registration form input.
+ * @param {{ email: string, username: string, password: string }} fields
+ * @returns {string|null} Error message, or null if valid.
+ */
+export function validateRegisterForm({ email, username, password }) {
+  if (!email || typeof email !== 'string' || !email.includes('@')) {
+    return 'A valid email address is required.'
+  }
+  if (!username || typeof username !== 'string' || username.trim().length < 2) {
+    return 'Username must be at least 2 characters.'
+  }
+  if (!password || typeof password !== 'string' || password.length < 8) {
+    return 'Password must be at least 8 characters.'
+  }
+  return null
+}
+
+/**
+ * Validates login form input.
+ * @param {{ email: string, password: string }} fields
+ * @returns {string|null} Error message, or null if valid.
+ */
+export function validateLoginForm({ email, password }) {
+  if (!email || typeof email !== 'string' || !email.includes('@')) {
+    return 'A valid email address is required.'
+  }
+  if (!password || typeof password !== 'string' || !password.length) {
+    return 'Password is required.'
+  }
+  return null
+}

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -41,7 +41,7 @@
 
 ### Web UI (minimal — enough to play)
 
-- [ ] `P0` Registration and login screens
+- [x] `P0` Registration and login screens
 - [ ] `P0` Create table screen: name only (no visibility/join policy yet)
 - [ ] `P0` Join table screen: list of open tables, click to join and choose a seat
 - [ ] `P0` Game screen: display hand, bid input, card play, current trick, scoreboard

--- a/server/app.js
+++ b/server/app.js
@@ -1,6 +1,10 @@
 import express from 'express'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
 import { handler } from './server.js'
 import { getRedis } from './redis.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 const app = express()
 const PORT = process.env.PORT || 3000
@@ -23,6 +27,9 @@ app.use((req, res, next) => {
 
 const redis = process.env.REDIS_URL ? await getRedis() : null
 handler(app, { redis })
+
+// Serve the web client as static files
+app.use(express.static(join(__dirname, '..', 'client', 'web')))
 
 app.listen(PORT, () => {
   console.log(`Spades Online server listening on port ${PORT}`)

--- a/test/unit/web/api.test.js
+++ b/test/unit/web/api.test.js
@@ -1,0 +1,121 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { registerUser, loginUser } from '../../../client/web/src/api.js'
+
+/**
+ * Build a minimal mock fetch that returns the given status and JSON body.
+ */
+function mockFetch(status, body) {
+  return async (_url, _opts) => ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  })
+}
+
+describe('registerUser', () => {
+  it('resolves with the response body on 201', async () => {
+    const result = await registerUser(
+      { email: 'a@b.com', username: 'alice', password: 'password123' },
+      mockFetch(201, { playerId: 'uuid-123', message: 'Registration successful.' }),
+    )
+    assert.equal(result.playerId, 'uuid-123')
+  })
+
+  it('throws with status 409 on duplicate email/username', async () => {
+    await assert.rejects(
+      () =>
+        registerUser(
+          { email: 'a@b.com', username: 'alice', password: 'password123' },
+          mockFetch(409, { error: 'Email already in use.' }),
+        ),
+      (err) => {
+        assert.equal(err.status, 409)
+        assert.match(err.message, /Email already in use/)
+        return true
+      },
+    )
+  })
+
+  it('throws with status 400 on validation error', async () => {
+    await assert.rejects(
+      () =>
+        registerUser(
+          { email: 'a@b.com', username: 'alice', password: 'short' },
+          mockFetch(400, { error: 'Password must be at least 8 characters.' }),
+        ),
+      (err) => {
+        assert.equal(err.status, 400)
+        return true
+      },
+    )
+  })
+
+  it('throws a generic message when response body has no error field', async () => {
+    await assert.rejects(
+      () =>
+        registerUser(
+          { email: 'a@b.com', username: 'alice', password: 'password123' },
+          mockFetch(500, {}),
+        ),
+      (err) => {
+        assert.ok(err.message)
+        return true
+      },
+    )
+  })
+})
+
+describe('loginUser', () => {
+  it('resolves with sessionId, playerId, and username on 200', async () => {
+    const result = await loginUser(
+      { email: 'a@b.com', password: 'password123' },
+      mockFetch(200, { sessionId: 'sess-1', playerId: 'uuid-1', username: 'alice' }),
+    )
+    assert.equal(result.sessionId, 'sess-1')
+    assert.equal(result.playerId, 'uuid-1')
+    assert.equal(result.username, 'alice')
+  })
+
+  it('throws with status 401 on invalid credentials', async () => {
+    await assert.rejects(
+      () =>
+        loginUser(
+          { email: 'a@b.com', password: 'wrongpass' },
+          mockFetch(401, { error: 'Invalid credentials.' }),
+        ),
+      (err) => {
+        assert.equal(err.status, 401)
+        return true
+      },
+    )
+  })
+
+  it('throws with status 403 on unverified email', async () => {
+    await assert.rejects(
+      () =>
+        loginUser(
+          { email: 'a@b.com', password: 'password123' },
+          mockFetch(403, { error: 'Email not verified.' }),
+        ),
+      (err) => {
+        assert.equal(err.status, 403)
+        return true
+      },
+    )
+  })
+
+  it('throws with status 400 when fields are missing', async () => {
+    await assert.rejects(
+      () =>
+        loginUser(
+          { email: 'a@b.com', password: '' },
+          mockFetch(400, { error: 'Password is required.' }),
+        ),
+      (err) => {
+        assert.equal(err.status, 400)
+        return true
+      },
+    )
+  })
+})

--- a/test/unit/web/validation.test.js
+++ b/test/unit/web/validation.test.js
@@ -1,0 +1,71 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  validateRegisterForm,
+  validateLoginForm,
+} from '../../../client/web/src/validation.js'
+
+describe('validateRegisterForm', () => {
+  it('returns null for valid inputs', () => {
+    assert.equal(
+      validateRegisterForm({ email: 'alice@example.com', username: 'alice', password: 'password123' }),
+      null,
+    )
+  })
+
+  it('returns an error when email is missing', () => {
+    assert.ok(validateRegisterForm({ email: '', username: 'alice', password: 'password123' }))
+  })
+
+  it('returns an error when email has no @', () => {
+    assert.ok(validateRegisterForm({ email: 'notanemail', username: 'alice', password: 'password123' }))
+  })
+
+  it('returns an error when username is missing', () => {
+    assert.ok(validateRegisterForm({ email: 'alice@example.com', username: '', password: 'password123' }))
+  })
+
+  it('returns an error when username is too short (1 char)', () => {
+    assert.ok(validateRegisterForm({ email: 'alice@example.com', username: 'a', password: 'password123' }))
+  })
+
+  it('returns null when username is exactly 2 chars', () => {
+    assert.equal(
+      validateRegisterForm({ email: 'alice@example.com', username: 'al', password: 'password123' }),
+      null,
+    )
+  })
+
+  it('returns an error when password is missing', () => {
+    assert.ok(validateRegisterForm({ email: 'alice@example.com', username: 'alice', password: '' }))
+  })
+
+  it('returns an error when password is fewer than 8 characters', () => {
+    assert.ok(validateRegisterForm({ email: 'alice@example.com', username: 'alice', password: 'short' }))
+  })
+
+  it('returns null when password is exactly 8 characters', () => {
+    assert.equal(
+      validateRegisterForm({ email: 'alice@example.com', username: 'alice', password: '12345678' }),
+      null,
+    )
+  })
+})
+
+describe('validateLoginForm', () => {
+  it('returns null for valid inputs', () => {
+    assert.equal(validateLoginForm({ email: 'alice@example.com', password: 'password123' }), null)
+  })
+
+  it('returns an error when email is missing', () => {
+    assert.ok(validateLoginForm({ email: '', password: 'password123' }))
+  })
+
+  it('returns an error when email has no @', () => {
+    assert.ok(validateLoginForm({ email: 'notanemail', password: 'password123' }))
+  })
+
+  it('returns an error when password is missing', () => {
+    assert.ok(validateLoginForm({ email: 'alice@example.com', password: '' }))
+  })
+})


### PR DESCRIPTION
Implements the P0 Web UI task from Slice 1: registration and login screens.

Adds a no-build-step SPA web client served by Express at `/`. Screens: Sign In (#/login) and Create Account (#/register). Session stored in sessionStorage on login. Unit tests written first (TDD) for validation and API client modules.

Closes #80

Generated with [Claude Code](https://claude.ai/code)