### PR TITLE
feat: Implement full Spades game loop (deal, bid, play tricks, score, repeat)

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -22,22 +22,22 @@
 
 ### Backend
 
-- [ ] `P0` Implement full Spades game loop: deal, bid, play tricks, score, repeat
-- [ ] `P0` Implement dealer rotation: North deals first hand, button rotates clockwise each hand
-- [ ] `P0` Implement partnership bidding: first bidder bids individually, second bidder sets team total (first bidder's number is advisory only)
-- [ ] `P0` Implement Nil bid (+50 / -50)
-- [ ] `P0` Implement Blind Nil bid (+100 / -100): eligibility check (≥100 pts behind), one-per-team limit, card exchange after all bids but before opening lead
-- [ ] `P0` Implement team bid of 0: legal, not treated as Nil; every trick taken is a bag
-- [ ] `P0` Enforce no Spade lead on first trick rule
-- [ ] `P0` Implement Spades-breaking logic
-- [ ] `P0` Implement bag tracking: +1 per overtrick; -100 pts per 10 bags; nil bidder tricks count toward partner's bid and are bags if partner exceeds their bid; double-nil — every trick either player takes is a bag and breaks that individual's nil
-- [ ] `P0` Implement win condition: first to 250 pts wins; if both reach 250 in same round, higher score wins; exact tie plays another hand
-- [ ] `P0` Implement loss condition: -250 or lower is immediate loss; if both teams qualify, higher score wins; exact tie plays another hand
-- [ ] `P0` Server-side game state validation: legal move enforcement, no out-of-turn plays, no cards not in hand
-- [ ] `P0` Ensure no opponent card info is sent to client before it is played
-- [ ] `P0` Basic table creation: create a table, seat 4 players (North/South vs East/West), start game when full
-- [ ] `P0` Gate game start until all 4 human seats are filled
-- [ ] `P0` Always sort hand by suit and rank (not configurable)
+- [x] `P0` Implement full Spades game loop: deal, bid, play tricks, score, repeat
+- [x] `P0` Implement dealer rotation: North deals first hand, button rotates clockwise each hand
+- [x] `P0` Implement partnership bidding: first bidder bids individually, second bidder sets team total (first bidder's number is advisory only)
+- [x] `P0` Implement Nil bid (+50 / -50)
+- [x] `P0` Implement Blind Nil bid (+100 / -100): eligibility check (≥100 pts behind), one-per-team limit, card exchange after all bids but before opening lead
+- [x] `P0` Implement team bid of 0: legal, not treated as Nil; every trick taken is a bag
+- [x] `P0` Enforce no Spade lead on first trick rule
+- [x] `P0` Implement Spades-breaking logic
+- [x] `P0` Implement bag tracking: +1 per overtrick; -100 pts per 10 bags; nil bidder tricks count toward partner's bid and are bags if partner exceeds their bid; double-nil — every trick either player takes is a bag and breaks that individual's nil
+- [x] `P0` Implement win condition: first to 250 pts wins; if both reach 250 in same round, higher score wins; exact tie plays another hand
+- [x] `P0` Implement loss condition: -250 or lower is immediate loss; if both teams qualify, higher score wins; exact tie plays another hand
+- [x] `P0` Server-side game state validation: legal move enforcement, no out-of-turn plays, no cards not in hand
+- [x] `P0` Ensure no opponent card info is sent to client before it is played
+- [x] `P0` Basic table creation: create a table, seat 4 players (North/South vs East/West), start game when full
+- [x] `P0` Gate game start until all 4 human seats are filled
+- [x] `P0` Always sort hand by suit and rank (not configurable)
 
 ### Web UI (minimal — enough to play)
 

--- a/server/anticheat/validate.js
+++ b/server/anticheat/validate.js
@@ -1,0 +1,61 @@
+import { isCardLegal } from '../game/trick.js'
+import { cardEquals } from '../game/deck.js'
+
+/**
+ * Validate that a player is allowed to play the given card.
+ *
+ * Checks (in order):
+ * 1. Game must be in 'playing' phase.
+ * 2. It must be the player's turn.
+ * 3. The card must exist in the player's hand.
+ * 4. The card must be a legal play under current game rules.
+ *
+ * Throws a structured error on any violation.
+ *
+ * @param {object} gameState - Full server game state
+ * @param {string} seat - Seat of the player attempting to play
+ * @param {{ suit: string, rank: string }} card - The card being played
+ */
+export function validateCardPlay(gameState, seat, card) {
+  if (gameState.phase !== 'playing') {
+    throw Object.assign(new Error('Game is not in playing phase'), { code: 'INVALID_ACTION' })
+  }
+  if (gameState.currentPlayerSeat !== seat) {
+    throw Object.assign(new Error('It is not your turn'), { code: 'NOT_YOUR_TURN' })
+  }
+
+  const hand = gameState.hands[seat]
+  if (!hand || !hand.some((c) => cardEquals(c, card))) {
+    throw Object.assign(new Error('Card is not in your hand'), { code: 'CARD_NOT_IN_HAND' })
+  }
+
+  if (!isCardLegal(card, hand, gameState.currentTrick, gameState.spadesbroken, gameState.isFirstTrick)) {
+    throw Object.assign(new Error('That card is not a legal play'), { code: 'ILLEGAL_PLAY' })
+  }
+}
+
+/**
+ * Validate that a player is allowed to place a bid.
+ *
+ * @param {object} gameState
+ * @param {string} seat
+ */
+export function validateBidTurn(gameState, seat) {
+  if (gameState.phase !== 'bidding') {
+    throw Object.assign(new Error('Game is not in bidding phase'), { code: 'INVALID_ACTION' })
+  }
+  if (gameState.currentBidderSeat !== seat) {
+    throw Object.assign(new Error('It is not your turn to bid'), { code: 'NOT_YOUR_TURN' })
+  }
+}
+
+/**
+ * Derive the seat for a player at a given table from the table's seats map.
+ *
+ * @param {{ north: string|null, east: string|null, south: string|null, west: string|null }} seats
+ * @param {string} playerId
+ * @returns {string|null} Seat name or null if player is not seated
+ */
+export function getSeatForPlayer(seats, playerId) {
+  return Object.entries(seats).find(([, pid]) => pid === playerId)?.[0] ?? null
+}

--- a/server/game/bid.js
+++ b/server/game/bid.js
@@ -1,0 +1,124 @@
+/** Clockwise seat order. */
+const CLOCKWISE = ['north', 'east', 'south', 'west']
+
+/** Team membership for each seat. */
+export const TEAM_FOR_SEAT = {
+  north: 'ns',
+  east: 'ew',
+  south: 'ns',
+  west: 'ew',
+}
+
+/** Partner seat for each seat. */
+export function getPartnerSeat(seat) {
+  const partners = { north: 'south', south: 'north', east: 'west', west: 'east' }
+  return partners[seat]
+}
+
+/**
+ * Return the 4-seat bidding order (clockwise from player left of dealer).
+ * @param {'north'|'east'|'south'|'west'} dealerSeat
+ * @returns {string[]}
+ */
+export function getBiddingOrder(dealerSeat) {
+  const idx = CLOCKWISE.indexOf(dealerSeat)
+  return [
+    CLOCKWISE[(idx + 1) % 4],
+    CLOCKWISE[(idx + 2) % 4],
+    CLOCKWISE[(idx + 3) % 4],
+    CLOCKWISE[(idx + 4) % 4],
+  ]
+}
+
+/**
+ * Return the two seats for a team in the order they appear in the bidding sequence.
+ * @param {'ns'|'ew'} team
+ * @param {string[]} biddingOrder
+ * @returns {[string, string]} [firstBidder, secondBidder]
+ */
+function getTeamBiddingOrder(team, biddingOrder) {
+  return biddingOrder.filter((s) => TEAM_FOR_SEAT[s] === team)
+}
+
+/**
+ * Whether a player is the second bidder for their team in this hand.
+ * @param {string} seat
+ * @param {string[]} biddingOrder
+ * @returns {boolean}
+ */
+export function isSecondTeamBidder(seat, biddingOrder) {
+  const team = TEAM_FOR_SEAT[seat]
+  const members = getTeamBiddingOrder(team, biddingOrder)
+  return members[1] === seat
+}
+
+/**
+ * Whether a player is eligible to bid Blind Nil.
+ * Requires their team to be at least 100 points behind the opposing team.
+ * @param {{ ns: number, ew: number }} scores
+ * @param {string} seat
+ * @returns {boolean}
+ */
+export function isEligibleForBlindNil(scores, seat) {
+  const team = TEAM_FOR_SEAT[seat]
+  const opposing = team === 'ns' ? 'ew' : 'ns'
+  return scores[opposing] - scores[team] >= 100
+}
+
+/**
+ * Whether a teammate has already bid Blind Nil this hand (only one per team is allowed).
+ * @param {{ north: *, east: *, south: *, west: * }} bids - current bids (null means not yet bid)
+ * @param {string} seat - the seat checking eligibility
+ * @returns {boolean}
+ */
+export function teamHasBlindNil(bids, seat) {
+  const team = TEAM_FOR_SEAT[seat]
+  return Object.entries(bids).some(
+    ([s, b]) => TEAM_FOR_SEAT[s] === team && b === 'blind_nil',
+  )
+}
+
+/**
+ * Validate whether a bid value is legal (0–13, 'nil', or 'blind_nil').
+ * @param {*} bid
+ * @returns {boolean}
+ */
+export function isValidBidValue(bid) {
+  if (bid === 'nil' || bid === 'blind_nil') return true
+  return Number.isInteger(bid) && bid >= 0 && bid <= 13
+}
+
+/**
+ * Compute the effective team bids after all 4 players have bid.
+ *
+ * Rules:
+ * - If second bidder bids a number → that number is the team bid.
+ * - If second bidder bids nil/blind_nil → first bidder's bid (if a number) is the team bid.
+ * - If both bid nil/blind_nil (double nil) → team bid is null (no team target).
+ *
+ * @param {{ north: *, east: *, south: *, west: * }} bids
+ * @param {string[]} biddingOrder
+ * @returns {{ ns: number|null, ew: number|null }}
+ */
+export function computeTeamBids(bids, biddingOrder) {
+  const result = { ns: null, ew: null }
+  for (const team of ['ns', 'ew']) {
+    const [firstSeat, secondSeat] = getTeamBiddingOrder(team, biddingOrder)
+    const firstBid = bids[firstSeat]
+    const secondBid = bids[secondSeat]
+    const firstIsNil = firstBid === 'nil' || firstBid === 'blind_nil'
+    const secondIsNil = secondBid === 'nil' || secondBid === 'blind_nil'
+
+    if (firstIsNil && secondIsNil) {
+      // Double nil — no team bid target
+      result[team] = null
+    } else if (secondIsNil) {
+      // Second bid nil → first bidder's number is the team target
+      result[team] = firstIsNil ? null : firstBid
+    } else {
+      // Second bid a number → that overrides whatever first bid
+      result[team] = secondBid
+    }
+  }
+  return result
+}

--- a/server/game/deck.js
+++ b/server/game/deck.js
@@ -1,0 +1,74 @@
+export const SUITS = ['clubs', 'diamonds', 'hearts', 'spades']
+export const RANKS = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A']
+
+const SUIT_ORDER = Object.fromEntries(SUITS.map((s, i) => [s, i]))
+const RANK_ORDER = Object.fromEntries(RANKS.map((r, i) => [r, i]))
+
+/** Create an unshuffled 52-card deck. */
+export function createDeck() {
+  const deck = []
+  for (const suit of SUITS) {
+    for (const rank of RANKS) {
+      deck.push({ suit, rank })
+    }
+  }
+  return deck
+}
+
+/** Fisher-Yates shuffle — returns a new array, does not mutate the input. */
+export function shuffle(deck) {
+  const d = [...deck]
+  for (let i = d.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[d[i], d[j]] = [d[j], d[i]]
+  }
+  return d
+}
+
+/**
+ * Deal 52 cards into 4 hands of 13 in clockwise seat order: north, east, south, west.
+ * @param {Array} deck - A shuffled 52-card deck
+ * @returns {{ north: Card[], east: Card[], south: Card[], west: Card[] }}
+ */
+export function deal(deck) {
+  const seats = ['north', 'east', 'south', 'west']
+  const hands = { north: [], east: [], south: [], west: [] }
+  for (let i = 0; i < 52; i++) {
+    hands[seats[i % 4]].push(deck[i])
+  }
+  return hands
+}
+
+/**
+ * Return the numeric sort value for a rank (higher = stronger).
+ * @param {string} rank
+ * @returns {number}
+ */
+export function rankValue(rank) {
+  return RANK_ORDER[rank]
+}
+
+/**
+ * Sort a hand by suit (clubs < diamonds < hearts < spades) then rank (2 < … < A).
+ * Returns a new array — does not mutate the input.
+ * @param {Card[]} hand
+ * @returns {Card[]}
+ */
+export function sortHand(hand) {
+  return [...hand].sort((a, b) => {
+    if (SUIT_ORDER[a.suit] !== SUIT_ORDER[b.suit]) {
+      return SUIT_ORDER[a.suit] - SUIT_ORDER[b.suit]
+    }
+    return RANK_ORDER[a.rank] - RANK_ORDER[b.rank]
+  })
+}
+
+/**
+ * Check whether two cards represent the same card.
+ * @param {{ suit: string, rank: string }} a
+ * @param {{ suit: string, rank: string }} b
+ * @returns {boolean}
+ */
+export function cardEquals(a, b) {
+  return a.suit === b.suit && a.rank === b.rank
+}

--- a/server/game/score.js
+++ b/server/game/score.js
@@ -1,0 +1,136 @@
+import { TEAM_FOR_SEAT } from './bid.js'
+
+const TEAMS = ['ns', 'ew']
+
+function getTeamSeats(team) {
+  return Object.keys(TEAM_FOR_SEAT).filter((s) => TEAM_FOR_SEAT[s] === team)
+}
+
+function getTeamTotalTricks(team, tricksWon) {
+  return getTeamSeats(team).reduce((sum, seat) => sum + tricksWon[seat], 0)
+}
+
+function getNilBidders(team, bids) {
+  return getTeamSeats(team).filter((s) => bids[s] === 'nil' || bids[s] === 'blind_nil')
+}
+
+/**
+ * Score a completed hand.
+ *
+ * Returns score delta and new bags earned this hand. Bag penalty deduction is
+ * handled separately in applyBagPenalties so the caller can apply both in one
+ * step with full visibility.
+ *
+ * @param {{ bids, teamBids, tricksWon }} hand
+ * @returns {{ scoreDelta: {ns,ew}, newBags: {ns,ew} }}
+ */
+export function scoreHand({ bids, teamBids, tricksWon }) {
+  const scoreDelta = { ns: 0, ew: 0 }
+  const newBags = { ns: 0, ew: 0 }
+
+  for (const team of TEAMS) {
+    const nilBidders = getNilBidders(team, bids)
+    const isDoubleNil = nilBidders.length === 2
+
+    // --- Score each individual nil / blind nil bid ---
+    for (const seat of nilBidders) {
+      const bid = bids[seat]
+      const points = bid === 'blind_nil' ? 100 : 50
+      if (tricksWon[seat] === 0) {
+        scoreDelta[team] += points // Nil/blind nil made
+      } else {
+        scoreDelta[team] -= points // Nil/blind nil failed
+      }
+      if (isDoubleNil) {
+        // Every trick a player takes in a double-nil situation is a bag
+        newBags[team] += tricksWon[seat]
+      }
+    }
+
+    if (isDoubleNil) continue // No team bid scoring in double nil
+
+    // --- Score the team bid ---
+    const teamBid = teamBids[team]
+    if (teamBid === null) continue // Defensive — shouldn't happen outside double nil
+
+    const totalTricks = getTeamTotalTricks(team, tricksWon)
+
+    if (teamBid === 0) {
+      // Team bid of 0: every trick is a bag, no positive/negative from made/missed scoring
+      newBags[team] += totalTricks
+    } else if (totalTricks >= teamBid) {
+      scoreDelta[team] += teamBid * 10
+      newBags[team] += totalTricks - teamBid
+    } else {
+      scoreDelta[team] -= teamBid * 10
+    }
+  }
+
+  return { scoreDelta, newBags }
+}
+
+/**
+ * Apply bag penalties to scores.
+ *
+ * Every 10 accumulated bags deducts 100 points and resets that group of 10.
+ *
+ * @param {{ ns: number, ew: number }} scores - Current cumulative scores
+ * @param {{ ns: number, ew: number }} bags - Current cumulative bag counts (before this hand)
+ * @param {{ ns: number, ew: number }} newBags - Bags earned this hand
+ * @returns {{ scores: {ns,ew}, bags: {ns,ew} }}
+ */
+export function applyBagPenalties(scores, bags, newBags) {
+  const updatedScores = { ...scores }
+  const updatedBags = { ...bags }
+
+  for (const team of TEAMS) {
+    const total = updatedBags[team] + newBags[team]
+    const penalties = Math.floor(total / 10)
+    updatedBags[team] = total % 10
+    updatedScores[team] -= penalties * 100
+  }
+
+  return { scores: updatedScores, bags: updatedBags }
+}
+
+/**
+ * Check whether the current scores trigger a win or loss condition.
+ *
+ * Win: first to 250+ wins; both at 250+ → higher score wins; exact tie → null (play another).
+ * Loss: -250 or lower is an immediate loss; same tie-break rules apply.
+ *
+ * @param {{ ns: number, ew: number }} scores
+ * @returns {{ winner: string, loser: string } | null}
+ */
+export function checkWinLoss(scores) {
+  const nsWins = scores.ns >= 250
+  const ewWins = scores.ew >= 250
+  const nsLoses = scores.ns <= -250
+  const ewLoses = scores.ew <= -250
+
+  // Win condition: one or both teams have reached 250
+  if (nsWins || ewWins) {
+    if (nsWins && ewWins) {
+      // Tie at exactly 250 — play another hand
+      if (scores.ns === scores.ew) return null
+      const winner = scores.ns > scores.ew ? 'ns' : 'ew'
+      return { winner, loser: winner === 'ns' ? 'ew' : 'ns' }
+    }
+    const winner = nsWins ? 'ns' : 'ew'
+    return { winner, loser: winner === 'ns' ? 'ew' : 'ns' }
+  }
+
+  // Loss condition: one or both teams have hit -250 or below
+  if (nsLoses || ewLoses) {
+    if (nsLoses && ewLoses) {
+      // Both lost — higher score wins
+      if (scores.ns === scores.ew) return null
+      const winner = scores.ns > scores.ew ? 'ns' : 'ew'
+      return { winner, loser: winner === 'ns' ? 'ew' : 'ns' }
+    }
+    const loser = nsLoses ? 'ns' : 'ew'
+    return { winner: loser === 'ns' ? 'ew' : 'ns', loser }
+  }
+
+  return null
+}

--- a/server/game/state.js
+++ b/server/game/state.js
@@ -1,0 +1,449 @@
+import { v4 as uuidv4 } from 'uuid'
+import { createDeck, shuffle, deal, sortHand, cardEquals } from './deck.js'
+import {
+  getBiddingOrder,
+  isEligibleForBlindNil,
+  teamHasBlindNil,
+  isValidBidValue,
+  computeTeamBids,
+  getPartnerSeat,
+} from './bid.js'
+import { getLegalPlays, determineTrickWinner, isCardLegal } from './trick.js'
+import { scoreHand, applyBagPenalties, checkWinLoss } from './score.js'
+
+/** Seats in clockwise order starting from north. */
+export const CLOCKWISE_SEATS = ['north', 'east', 'south', 'west']
+
+/**
+ * Get the next seat clockwise.
+ * @param {string} seat
+ * @returns {string}
+ */
+function nextSeat(seat) {
+  return CLOCKWISE_SEATS[(CLOCKWISE_SEATS.indexOf(seat) + 1) % 4]
+}
+
+/**
+ * Deal and initialise the per-hand state.
+ * @param {string} dealerSeat
+ * @returns {object} Partial hand state
+ */
+function dealHand(dealerSeat) {
+  const deck = shuffle(createDeck())
+  const rawHands = deal(deck)
+  const hands = {}
+  for (const seat of CLOCKWISE_SEATS) {
+    hands[seat] = sortHand(rawHands[seat])
+  }
+  const biddingOrder = getBiddingOrder(dealerSeat)
+  return {
+    hands,
+    bids: { north: null, east: null, south: null, west: null },
+    teamBids: { ns: null, ew: null },
+    biddingOrder,
+    currentBidderSeat: biddingOrder[0],
+    blindNilExchange: null,
+    currentTrick: [],
+    completedTricks: [],
+    tricksWon: { north: 0, east: 0, south: 0, west: 0 },
+    currentPlayerSeat: null, // set when play phase starts
+    leadSeat: null, // player left of dealer opens play
+    spadesbroken: false,
+    isFirstTrick: true,
+  }
+}
+
+/**
+ * Create a new game state.
+ *
+ * @param {string} tableId
+ * @param {{ north: string, east: string, south: string, west: string }} players - Map of seat → playerId
+ * @returns {object} Initial game state
+ */
+export function createGame(tableId, players) {
+  const gameId = uuidv4()
+  const dealerSeat = 'north' // North deals the first hand
+  const handState = dealHand(dealerSeat)
+
+  return {
+    gameId,
+    tableId,
+    handNumber: 1,
+    dealerSeat,
+    players,
+    scores: { ns: 0, ew: 0 },
+    bags: { ns: 0, ew: 0 },
+    phase: 'bidding',
+    gameOver: false,
+    winner: null,
+    ...handState,
+  }
+}
+
+/**
+ * Validate and apply a bid from the current bidder.
+ *
+ * @param {object} state
+ * @param {string} seat
+ * @param {number|'nil'|'blind_nil'} bid
+ * @returns {object} New state
+ * @throws {Error} If the bid is invalid
+ */
+export function placeBid(state, seat, bid) {
+  if (state.phase !== 'bidding') {
+    throw Object.assign(new Error('Game is not in bidding phase'), { code: 'INVALID_ACTION' })
+  }
+  if (seat !== state.currentBidderSeat) {
+    throw Object.assign(new Error('Not your turn to bid'), { code: 'NOT_YOUR_TURN' })
+  }
+  if (!isValidBidValue(bid)) {
+    throw Object.assign(new Error(`Invalid bid value: ${bid}`), { code: 'INVALID_BID' })
+  }
+
+  // Blind nil eligibility checks
+  if (bid === 'blind_nil') {
+    if (!isEligibleForBlindNil(state.scores, seat)) {
+      throw Object.assign(
+        new Error('Not eligible for Blind Nil — team must be at least 100 points behind'),
+        { code: 'NOT_ELIGIBLE' },
+      )
+    }
+    if (teamHasBlindNil(state.bids, seat)) {
+      throw Object.assign(
+        new Error('A teammate has already bid Blind Nil this hand'),
+        { code: 'ALREADY_BID_BLIND_NIL' },
+      )
+    }
+  }
+
+  const newBids = { ...state.bids, [seat]: bid }
+  const allBid = Object.values(newBids).every((b) => b !== null)
+
+  if (!allBid) {
+    // Advance to next bidder
+    const currentIdx = state.biddingOrder.indexOf(seat)
+    const nextBidderSeat = state.biddingOrder[currentIdx + 1]
+    return { ...state, bids: newBids, currentBidderSeat: nextBidderSeat }
+  }
+
+  // All 4 have bid — compute team bids and transition phase
+  const teamBids = computeTeamBids(newBids, state.biddingOrder)
+
+  // Check if blind nil exchange is needed
+  const blindNilSeats = CLOCKWISE_SEATS.filter((s) => newBids[s] === 'blind_nil')
+  if (blindNilSeats.length > 0) {
+    // Blind nil player sends cards first
+    const firstBlindNil = blindNilSeats[0]
+    return {
+      ...state,
+      bids: newBids,
+      teamBids,
+      currentBidderSeat: null,
+      phase: 'blind_nil_exchange',
+      blindNilExchange: {
+        pending: [...blindNilSeats],
+        currentBlindNilSeat: firstBlindNil,
+        step: 'blind_to_partner',
+        cardsFromBlind: null,
+      },
+    }
+  }
+
+  // No blind nil — move straight to playing
+  return startPlayPhase({ ...state, bids: newBids, teamBids, currentBidderSeat: null })
+}
+
+/**
+ * Transition state to the playing phase.
+ * Sets currentPlayerSeat and leadSeat to the player left of the dealer.
+ */
+function startPlayPhase(state) {
+  const leadSeat = nextSeat(state.dealerSeat)
+  return {
+    ...state,
+    phase: 'playing',
+    currentPlayerSeat: leadSeat,
+    leadSeat,
+  }
+}
+
+/**
+ * Handle a blind nil card exchange.
+ *
+ * Step 1: blind nil player sends 2 cards to partner.
+ * Step 2: partner sends 2 cards back to blind nil player.
+ *
+ * @param {object} state
+ * @param {string} seat - Seat submitting the exchange
+ * @param {Array<{suit: string, rank: string}>} cards - Exactly 2 cards
+ * @returns {object} New state
+ */
+export function submitBlindNilExchange(state, seat, cards) {
+  if (state.phase !== 'blind_nil_exchange') {
+    throw Object.assign(new Error('Game is not in blind nil exchange phase'), { code: 'INVALID_ACTION' })
+  }
+  if (!Array.isArray(cards) || cards.length !== 2) {
+    throw Object.assign(new Error('Must submit exactly 2 cards'), { code: 'INVALID_EXCHANGE' })
+  }
+
+  const { blindNilExchange } = state
+  const { currentBlindNilSeat, step } = blindNilExchange
+  const partnerSeat = getPartnerSeat(currentBlindNilSeat)
+
+  if (step === 'blind_to_partner') {
+    if (seat !== currentBlindNilSeat) {
+      throw Object.assign(
+        new Error('Blind Nil player must send cards first'),
+        { code: 'INVALID_EXCHANGE' },
+      )
+    }
+    // Verify cards are in blind nil player's hand
+    const hand = state.hands[seat]
+    for (const card of cards) {
+      if (!hand.some((c) => cardEquals(c, card))) {
+        throw Object.assign(
+          new Error('Card not in hand'),
+          { code: 'CARD_NOT_IN_HAND' },
+        )
+      }
+    }
+    // Remove cards from blind nil player's hand
+    const newHand = hand.filter((c) => !cards.some((card) => cardEquals(c, card)))
+
+    return {
+      ...state,
+      hands: { ...state.hands, [seat]: sortHand(newHand) },
+      blindNilExchange: {
+        ...blindNilExchange,
+        step: 'partner_to_blind',
+        cardsFromBlind: cards,
+      },
+    }
+  }
+
+  // step === 'partner_to_blind'
+  if (seat !== partnerSeat) {
+    throw Object.assign(
+      new Error('Partner must send cards back to Blind Nil player'),
+      { code: 'INVALID_EXCHANGE' },
+    )
+  }
+  const partnerHand = state.hands[seat]
+  for (const card of cards) {
+    if (!partnerHand.some((c) => cardEquals(c, card))) {
+      throw Object.assign(new Error('Card not in hand'), { code: 'CARD_NOT_IN_HAND' })
+    }
+  }
+
+  // Complete the exchange
+  const cardsFromBlind = blindNilExchange.cardsFromBlind
+  const newPartnerHand = partnerHand.filter((c) => !cards.some((card) => cardEquals(c, card)))
+  const newBlindHand = state.hands[currentBlindNilSeat]
+
+  // Give partner the blind nil player's cards; give blind nil player the partner's cards
+  const finalPartnerHand = sortHand([...newPartnerHand, ...cardsFromBlind])
+  const finalBlindHand = sortHand([...newBlindHand, ...cards])
+
+  const newHands = {
+    ...state.hands,
+    [currentBlindNilSeat]: finalBlindHand,
+    [partnerSeat]: finalPartnerHand,
+  }
+
+  // Check if there are more blind nil players to process
+  const remainingPending = blindNilExchange.pending.filter((s) => s !== currentBlindNilSeat)
+
+  if (remainingPending.length > 0) {
+    const nextBlindNil = remainingPending[0]
+    return {
+      ...state,
+      hands: newHands,
+      blindNilExchange: {
+        pending: remainingPending,
+        currentBlindNilSeat: nextBlindNil,
+        step: 'blind_to_partner',
+        cardsFromBlind: null,
+      },
+    }
+  }
+
+  // All exchanges done — start play
+  return startPlayPhase({
+    ...state,
+    hands: newHands,
+    blindNilExchange: null,
+  })
+}
+
+/**
+ * Play a card from a player's hand.
+ *
+ * @param {object} state
+ * @param {string} seat - Seat playing the card
+ * @param {{ suit: string, rank: string }} card
+ * @returns {object} New state
+ */
+export function playCard(state, seat, card) {
+  if (state.phase !== 'playing') {
+    throw Object.assign(new Error('Game is not in playing phase'), { code: 'INVALID_ACTION' })
+  }
+  if (seat !== state.currentPlayerSeat) {
+    throw Object.assign(new Error('Not your turn to play'), { code: 'NOT_YOUR_TURN' })
+  }
+
+  const hand = state.hands[seat]
+  if (!hand.some((c) => cardEquals(c, card))) {
+    throw Object.assign(new Error('Card not in hand — invalid card'), { code: 'CARD_NOT_IN_HAND' })
+  }
+  if (!isCardLegal(card, hand, state.currentTrick, state.spadesbroken, state.isFirstTrick)) {
+    throw Object.assign(new Error('Illegal play'), { code: 'ILLEGAL_PLAY' })
+  }
+
+  // Remove card from hand
+  const newHand = hand.filter((c) => !cardEquals(c, card))
+  const newTrick = [...state.currentTrick, { seat, card }]
+
+  // Track spades breaking
+  let { spadesbroken } = state
+  if (card.suit === 'spades' && !spadesbroken) {
+    spadesbroken = true
+    console.log('Spades broken:', { tableId: state.tableId, seat, card })
+  }
+
+  if (newTrick.length < 4) {
+    // Trick not yet complete — advance to next player
+    return {
+      ...state,
+      hands: { ...state.hands, [seat]: newHand },
+      currentTrick: newTrick,
+      currentPlayerSeat: nextSeat(seat),
+      spadesbroken,
+    }
+  }
+
+  // Trick complete — determine winner
+  const trickWinner = determineTrickWinner(newTrick)
+  const newTricksWon = {
+    ...state.tricksWon,
+    [trickWinner]: state.tricksWon[trickWinner] + 1,
+  }
+  const completedTricks = [
+    ...state.completedTricks,
+    { winner: trickWinner, plays: newTrick },
+  ]
+
+  console.log('Trick complete:', {
+    tableId: state.tableId,
+    trickNumber: completedTricks.length,
+    winner: trickWinner,
+  })
+
+  const newHands = { ...state.hands, [seat]: newHand }
+
+  if (completedTricks.length < 13) {
+    // More tricks to play
+    return {
+      ...state,
+      hands: newHands,
+      currentTrick: [],
+      completedTricks,
+      tricksWon: newTricksWon,
+      currentPlayerSeat: trickWinner,
+      leadSeat: trickWinner,
+      spadesbroken,
+      isFirstTrick: false,
+    }
+  }
+
+  // All 13 tricks played — score the hand
+  return scoreCompletedHand({
+    ...state,
+    hands: newHands,
+    currentTrick: [],
+    completedTricks,
+    tricksWon: newTricksWon,
+    currentPlayerSeat: null,
+    spadesbroken,
+    isFirstTrick: false,
+  })
+}
+
+/**
+ * Score a completed hand and transition to the next hand or end the game.
+ */
+function scoreCompletedHand(state) {
+  const { scoreDelta, newBags } = scoreHand({
+    bids: state.bids,
+    teamBids: state.teamBids,
+    tricksWon: state.tricksWon,
+  })
+
+  const rawScores = {
+    ns: state.scores.ns + scoreDelta.ns,
+    ew: state.scores.ew + scoreDelta.ew,
+  }
+
+  const { scores, bags } = applyBagPenalties(rawScores, state.bags, newBags)
+
+  console.log('Hand scored:', {
+    tableId: state.tableId,
+    handNumber: state.handNumber,
+    scoreDelta,
+    newBags,
+    scores,
+    bags,
+  })
+
+  const winLoss = checkWinLoss(scores)
+  if (winLoss) {
+    console.log('Game over:', { tableId: state.tableId, winner: winLoss.winner })
+    return {
+      ...state,
+      scores,
+      bags,
+      phase: 'game_over',
+      gameOver: true,
+      winner: winLoss.winner,
+    }
+  }
+
+  // Start the next hand
+  const nextDealer = nextSeat(state.dealerSeat)
+  const nextHandState = dealHand(nextDealer)
+
+  console.log('Starting next hand:', {
+    tableId: state.tableId,
+    handNumber: state.handNumber + 1,
+    dealer: nextDealer,
+  })
+
+  return {
+    ...state,
+    ...nextHandState,
+    handNumber: state.handNumber + 1,
+    dealerSeat: nextDealer,
+    scores,
+    bags,
+    phase: 'bidding',
+    gameOver: false,
+    winner: null,
+  }
+}
+
+/**
+ * Return a player-specific view of the game state that does not expose other
+ * players' hands. This is what gets sent to the client.
+ *
+ * @param {object} state - Full server game state
+ * @param {string} seat - The requesting player's seat
+ * @returns {object} Filtered state safe to send to the client
+ */
+export function getPlayerView(state, seat) {
+  const { hands, ...rest } = state
+  return {
+    ...rest,
+    myHand: hands[seat],
+    // Include played cards from the current trick (visible to all)
+    // Do NOT include other players' unplayed hands
+  }
+}

--- a/server/game/trick.js
+++ b/server/game/trick.js
@@ -1,0 +1,94 @@
+import { rankValue, cardEquals } from './deck.js'
+
+/**
+ * Return the subset of cards in hand that the player may legally play.
+ *
+ * @param {Card[]} hand - The player's current hand
+ * @param {Array<{seat: string, card: Card}>} currentTrick - Cards already played this trick
+ * @param {boolean} spadesbroken - Whether spades have been broken this hand
+ * @param {boolean} isFirstTrick - Whether this is the very first trick of the hand
+ * @returns {Card[]}
+ */
+export function getLegalPlays(hand, currentTrick, spadesbroken, isFirstTrick) {
+  const isLeading = currentTrick.length === 0
+
+  if (isLeading) {
+    if (isFirstTrick) {
+      // Cannot lead spades on the first trick of a hand
+      const nonSpades = hand.filter((c) => c.suit !== 'spades')
+      return nonSpades.length > 0 ? nonSpades : hand
+    }
+    if (!spadesbroken) {
+      // Cannot lead spades until they are broken
+      const nonSpades = hand.filter((c) => c.suit !== 'spades')
+      return nonSpades.length > 0 ? nonSpades : hand
+    }
+    // Spades are broken (or not leading) — any card is legal
+    return hand
+  }
+
+  // Following a trick — must follow the led suit if possible
+  const ledSuit = currentTrick[0].card.suit
+  const canFollow = hand.filter((c) => c.suit === ledSuit)
+  if (canFollow.length > 0) {
+    return canFollow
+  }
+
+  // Cannot follow suit — on the first trick, may not play spades if alternatives exist
+  if (isFirstTrick) {
+    const nonSpades = hand.filter((c) => c.suit !== 'spades')
+    if (nonSpades.length > 0) return nonSpades
+  }
+
+  // No suit-follow requirement and not restricted — any card is legal
+  return hand
+}
+
+/**
+ * Determine which seat wins a completed 4-card trick.
+ *
+ * @param {Array<{seat: string, card: Card}>} trick - Exactly 4 plays in order
+ * @returns {string} The winning seat
+ */
+export function determineTrickWinner(trick) {
+  const ledSuit = trick[0].card.suit
+  let winner = trick[0]
+  for (let i = 1; i < trick.length; i++) {
+    if (beats(trick[i].card, winner.card, ledSuit)) {
+      winner = trick[i]
+    }
+  }
+  return winner.seat
+}
+
+/**
+ * Return true if card `a` beats card `b` given the led suit.
+ * Spades trump all other suits; within the same suit, higher rank wins.
+ */
+function beats(a, b, ledSuit) {
+  if (a.suit === 'spades' && b.suit !== 'spades') return true
+  if (b.suit === 'spades' && a.suit !== 'spades') return false
+  // Both spades or both non-spades
+  if (a.suit === b.suit) return rankValue(a.rank) > rankValue(b.rank)
+  // Different non-spade suits: only the led suit card can win
+  if (a.suit === ledSuit) return true
+  // b is led suit (or neither is led suit, in which case b was leading)
+  return false
+}
+
+/**
+ * Check whether playing `card` is legal given the current game state.
+ *
+ * @param {Card} card
+ * @param {Card[]} hand
+ * @param {Array<{seat: string, card: Card}>} currentTrick
+ * @param {boolean} spadesbroken
+ * @param {boolean} isFirstTrick
+ * @returns {boolean}
+ */
+export function isCardLegal(card, hand, currentTrick, spadesbroken, isFirstTrick) {
+  const inHand = hand.some((c) => cardEquals(c, card))
+  if (!inHand) return false
+  const legal = getLegalPlays(hand, currentTrick, spadesbroken, isFirstTrick)
+  return legal.some((c) => cardEquals(c, card))
+}

--- a/server/lobby/table.js
+++ b/server/lobby/table.js
@@ -1,0 +1,162 @@
+import { v4 as uuidv4 } from 'uuid'
+
+const TABLE_TTL_SECONDS = 3600 // 1 hour of inactivity
+
+/**
+ * @typedef {Object} TableState
+ * @property {string} tableId
+ * @property {string} hostPlayerId
+ * @property {{ north: string|null, east: string|null, south: string|null, west: string|null }} seats
+ * @property {'waiting'|'playing'} status
+ * @property {string|null} gameId
+ * @property {string} createdAt
+ */
+
+/**
+ * Create a new table in Redis and return its ID.
+ *
+ * @param {import('redis').RedisClientType} redis
+ * @param {{ hostPlayerId: string }} opts
+ * @returns {Promise<TableState>}
+ */
+export async function createTable(redis, { hostPlayerId }) {
+  const tableId = uuidv4()
+  const table = {
+    tableId,
+    hostPlayerId,
+    seats: { north: null, east: null, south: null, west: null },
+    status: 'waiting',
+    gameId: null,
+    createdAt: new Date().toISOString(),
+  }
+
+  const key = `table:${tableId}`
+  await redis.set(key, JSON.stringify(table), { EX: TABLE_TTL_SECONDS })
+
+  // Add to the lobby index
+  await redis.hSet('lobby:tables', tableId, JSON.stringify({ tableId, hostPlayerId, status: 'waiting' }))
+
+  console.log('Table created:', { tableId, hostPlayerId })
+  return table
+}
+
+/**
+ * Retrieve a table from Redis.
+ *
+ * @param {import('redis').RedisClientType} redis
+ * @param {string} tableId
+ * @returns {Promise<TableState|null>}
+ */
+export async function getTable(redis, tableId) {
+  const raw = await redis.get(`table:${tableId}`)
+  return raw ? JSON.parse(raw) : null
+}
+
+/**
+ * Persist an updated table state to Redis and reset its TTL.
+ *
+ * @param {import('redis').RedisClientType} redis
+ * @param {TableState} table
+ */
+export async function saveTable(redis, table) {
+  const key = `table:${table.tableId}`
+  await redis.set(key, JSON.stringify(table), { EX: TABLE_TTL_SECONDS })
+}
+
+/**
+ * Seat a player at an empty seat.
+ *
+ * @param {import('redis').RedisClientType} redis
+ * @param {string} tableId
+ * @param {string} playerId
+ * @param {'north'|'east'|'south'|'west'} seat
+ * @returns {Promise<TableState>}
+ * @throws {Error} If the table is not found, game already started, seat is taken, or player already seated
+ */
+export async function sitAtTable(redis, tableId, playerId, seat) {
+  const validSeats = ['north', 'east', 'south', 'west']
+  if (!validSeats.includes(seat)) {
+    throw Object.assign(new Error(`Invalid seat: ${seat}`), { code: 'INVALID_SEAT' })
+  }
+
+  const table = await getTable(redis, tableId)
+  if (!table) {
+    throw Object.assign(new Error('Table not found'), { code: 'NOT_FOUND' })
+  }
+  if (table.status === 'playing') {
+    throw Object.assign(new Error('Game already in progress'), { code: 'GAME_IN_PROGRESS' })
+  }
+  if (table.seats[seat] !== null) {
+    throw Object.assign(new Error('Seat is already taken'), { code: 'SEAT_TAKEN' })
+  }
+  // Check player isn't already seated
+  const alreadySeated = Object.values(table.seats).includes(playerId)
+  if (alreadySeated) {
+    throw Object.assign(new Error('Player is already seated at this table'), { code: 'ALREADY_SEATED' })
+  }
+
+  const updated = {
+    ...table,
+    seats: { ...table.seats, [seat]: playerId },
+  }
+  await saveTable(redis, updated)
+  console.log('Player seated:', { tableId, playerId, seat })
+  return updated
+}
+
+/**
+ * Return true if all 4 seats are occupied.
+ * @param {TableState} table
+ * @returns {boolean}
+ */
+export function isTableFull(table) {
+  return Object.values(table.seats).every((p) => p !== null)
+}
+
+/**
+ * Mark the table as in-game and record the gameId.
+ *
+ * @param {import('redis').RedisClientType} redis
+ * @param {string} tableId
+ * @param {string} gameId
+ * @returns {Promise<TableState>}
+ */
+export async function markTablePlaying(redis, tableId, gameId) {
+  const table = await getTable(redis, tableId)
+  if (!table) throw Object.assign(new Error('Table not found'), { code: 'NOT_FOUND' })
+
+  const updated = { ...table, status: 'playing', gameId }
+  await saveTable(redis, updated)
+
+  // Update lobby index
+  await redis.hSet('lobby:tables', tableId, JSON.stringify({
+    tableId,
+    hostPlayerId: table.hostPlayerId,
+    status: 'playing',
+  }))
+
+  return updated
+}
+
+/**
+ * Retrieve the current game state for a table from Redis.
+ *
+ * @param {import('redis').RedisClientType} redis
+ * @param {string} tableId
+ * @returns {Promise<object|null>}
+ */
+export async function getGameState(redis, tableId) {
+  const raw = await redis.get(`game:${tableId}`)
+  return raw ? JSON.parse(raw) : null
+}
+
+/**
+ * Persist game state to Redis.
+ *
+ * @param {import('redis').RedisClientType} redis
+ * @param {string} tableId
+ * @param {object} gameState
+ */
+export async function saveGameState(redis, tableId, gameState) {
+  await redis.set(`game:${tableId}`, JSON.stringify(gameState), { EX: TABLE_TTL_SECONDS })
+}

--- a/server/server.js
+++ b/server/server.js
@@ -2,10 +2,21 @@ import { registerPlayer, verifyEmailToken } from './auth/registration.js'
 import { sendVerificationEmail as defaultMailer } from './auth/email.js'
 import { getPlayerProfile, isValidUuid } from './social/profile.js'
 import { loginPlayer } from './auth/login.js'
-import { createSession, deleteSession } from './auth/session.js'
+import { createSession, deleteSession, validateAuthHeaders } from './auth/session.js'
 import { getDb } from './db.js'
 import { getRedis } from './redis.js'
 import { createRateLimiter } from './middleware/rateLimiter.js'
+import {
+  createTable,
+  getTable,
+  sitAtTable,
+  isTableFull,
+  markTablePlaying,
+  getGameState,
+  saveGameState,
+} from './lobby/table.js'
+import { createGame, placeBid, playCard, submitBlindNilExchange, getPlayerView } from './game/state.js'
+import { getSeatForPlayer } from './anticheat/validate.js'
 
 function sendJSON(res, statusCode, data) {
   res.status(statusCode).json(data)
@@ -107,6 +118,171 @@ export function handler(app, { mailer, redis, rateLimitConfig } = {}) {
       sendJSON(res, 200, { message: 'Logged out successfully.' })
     } catch (err) {
       console.error('Logout error:', { error: err.message })
+      sendJSON(res, 500, { error: 'Internal server error' })
+    }
+  })
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Table & Game Routes (all require authentication)
+  // ──────────────────────────────────────────────────────────────────────────
+
+  // POST /api/tables — create a new table
+  app.post('/api/tables', async (req, res) => {
+    try {
+      const redisClient = await getRedis()
+      const session = await validateAuthHeaders(redisClient, req)
+      const table = await createTable(redisClient, { hostPlayerId: session.playerId })
+      sendJSON(res, 201, { tableId: table.tableId })
+    } catch (err) {
+      if (err.code === 'UNAUTHORIZED') return sendJSON(res, 401, { error: err.message })
+      console.error('Create table error:', { error: err.message })
+      sendJSON(res, 500, { error: 'Internal server error' })
+    }
+  })
+
+  // POST /api/tables/:tableId/sit — sit at a seat
+  app.post('/api/tables/:tableId/sit', async (req, res) => {
+    const { tableId } = req.params
+    const { seat } = req.body ?? {}
+    try {
+      const redisClient = await getRedis()
+      const session = await validateAuthHeaders(redisClient, req)
+      const table = await sitAtTable(redisClient, tableId, session.playerId, seat)
+
+      // If table is now full, start the game
+      if (isTableFull(table)) {
+        const players = table.seats // { north, east, south, west } → playerIds
+        const gameState = createGame(tableId, players)
+        await saveGameState(redisClient, tableId, gameState)
+        await markTablePlaying(redisClient, tableId, gameState.gameId)
+        console.log('Game started:', { tableId, gameId: gameState.gameId })
+      }
+
+      sendJSON(res, 200, { tableId, seat })
+    } catch (err) {
+      if (err.code === 'UNAUTHORIZED') return sendJSON(res, 401, { error: err.message })
+      if (err.code === 'NOT_FOUND') return sendJSON(res, 404, { error: err.message })
+      if (err.code === 'GAME_IN_PROGRESS') return sendJSON(res, 409, { error: err.message })
+      if (err.code === 'SEAT_TAKEN') return sendJSON(res, 409, { error: err.message })
+      if (err.code === 'ALREADY_SEATED') return sendJSON(res, 409, { error: err.message })
+      if (err.code === 'INVALID_SEAT') return sendJSON(res, 400, { error: err.message })
+      console.error('Sit at table error:', { tableId, error: err.message })
+      sendJSON(res, 500, { error: 'Internal server error' })
+    }
+  })
+
+  // GET /api/tables/:tableId/state — get game state (filtered for this player)
+  app.get('/api/tables/:tableId/state', async (req, res) => {
+    const { tableId } = req.params
+    try {
+      const redisClient = await getRedis()
+      const session = await validateAuthHeaders(redisClient, req)
+      const table = await getTable(redisClient, tableId)
+      if (!table) return sendJSON(res, 404, { error: 'Table not found' })
+
+      const seat = getSeatForPlayer(table.seats, session.playerId)
+      if (!seat) return sendJSON(res, 403, { error: 'You are not seated at this table' })
+
+      const gameState = await getGameState(redisClient, tableId)
+      if (!gameState) return sendJSON(res, 200, { status: 'waiting', seats: table.seats })
+
+      sendJSON(res, 200, getPlayerView(gameState, seat))
+    } catch (err) {
+      if (err.code === 'UNAUTHORIZED') return sendJSON(res, 401, { error: err.message })
+      console.error('Get game state error:', { tableId, error: err.message })
+      sendJSON(res, 500, { error: 'Internal server error' })
+    }
+  })
+
+  // POST /api/tables/:tableId/bid — place a bid
+  app.post('/api/tables/:tableId/bid', async (req, res) => {
+    const { tableId } = req.params
+    const { bid } = req.body ?? {}
+    try {
+      const redisClient = await getRedis()
+      const session = await validateAuthHeaders(redisClient, req)
+      const table = await getTable(redisClient, tableId)
+      if (!table) return sendJSON(res, 404, { error: 'Table not found' })
+
+      const seat = getSeatForPlayer(table.seats, session.playerId)
+      if (!seat) return sendJSON(res, 403, { error: 'You are not seated at this table' })
+
+      const gameState = await getGameState(redisClient, tableId)
+      if (!gameState) return sendJSON(res, 409, { error: 'Game has not started' })
+
+      const newState = placeBid(gameState, seat, bid)
+      await saveGameState(redisClient, tableId, newState)
+      sendJSON(res, 200, getPlayerView(newState, seat))
+    } catch (err) {
+      if (err.code === 'UNAUTHORIZED') return sendJSON(res, 401, { error: err.message })
+      if (err.code === 'NOT_FOUND') return sendJSON(res, 404, { error: err.message })
+      if (err.code === 'INVALID_ACTION') return sendJSON(res, 409, { error: err.message })
+      if (err.code === 'NOT_YOUR_TURN') return sendJSON(res, 409, { error: err.message })
+      if (err.code === 'INVALID_BID') return sendJSON(res, 400, { error: err.message })
+      if (err.code === 'NOT_ELIGIBLE') return sendJSON(res, 400, { error: err.message })
+      if (err.code === 'ALREADY_BID_BLIND_NIL') return sendJSON(res, 400, { error: err.message })
+      console.error('Bid error:', { tableId, error: err.message })
+      sendJSON(res, 500, { error: 'Internal server error' })
+    }
+  })
+
+  // POST /api/tables/:tableId/blind-nil-exchange — submit cards for blind nil exchange
+  app.post('/api/tables/:tableId/blind-nil-exchange', async (req, res) => {
+    const { tableId } = req.params
+    const { cards } = req.body ?? {}
+    try {
+      const redisClient = await getRedis()
+      const session = await validateAuthHeaders(redisClient, req)
+      const table = await getTable(redisClient, tableId)
+      if (!table) return sendJSON(res, 404, { error: 'Table not found' })
+
+      const seat = getSeatForPlayer(table.seats, session.playerId)
+      if (!seat) return sendJSON(res, 403, { error: 'You are not seated at this table' })
+
+      const gameState = await getGameState(redisClient, tableId)
+      if (!gameState) return sendJSON(res, 409, { error: 'Game has not started' })
+
+      const newState = submitBlindNilExchange(gameState, seat, cards)
+      await saveGameState(redisClient, tableId, newState)
+      sendJSON(res, 200, getPlayerView(newState, seat))
+    } catch (err) {
+      if (err.code === 'UNAUTHORIZED') return sendJSON(res, 401, { error: err.message })
+      if (err.code === 'NOT_FOUND') return sendJSON(res, 404, { error: err.message })
+      if (err.code === 'INVALID_ACTION') return sendJSON(res, 409, { error: err.message })
+      if (err.code === 'INVALID_EXCHANGE') return sendJSON(res, 400, { error: err.message })
+      if (err.code === 'CARD_NOT_IN_HAND') return sendJSON(res, 400, { error: err.message })
+      console.error('Blind nil exchange error:', { tableId, error: err.message })
+      sendJSON(res, 500, { error: 'Internal server error' })
+    }
+  })
+
+  // POST /api/tables/:tableId/play — play a card
+  app.post('/api/tables/:tableId/play', async (req, res) => {
+    const { tableId } = req.params
+    const { card } = req.body ?? {}
+    try {
+      const redisClient = await getRedis()
+      const session = await validateAuthHeaders(redisClient, req)
+      const table = await getTable(redisClient, tableId)
+      if (!table) return sendJSON(res, 404, { error: 'Table not found' })
+
+      const seat = getSeatForPlayer(table.seats, session.playerId)
+      if (!seat) return sendJSON(res, 403, { error: 'You are not seated at this table' })
+
+      const gameState = await getGameState(redisClient, tableId)
+      if (!gameState) return sendJSON(res, 409, { error: 'Game has not started' })
+
+      const newState = playCard(gameState, seat, card)
+      await saveGameState(redisClient, tableId, newState)
+      sendJSON(res, 200, getPlayerView(newState, seat))
+    } catch (err) {
+      if (err.code === 'UNAUTHORIZED') return sendJSON(res, 401, { error: err.message })
+      if (err.code === 'NOT_FOUND') return sendJSON(res, 404, { error: err.message })
+      if (err.code === 'INVALID_ACTION') return sendJSON(res, 409, { error: err.message })
+      if (err.code === 'NOT_YOUR_TURN') return sendJSON(res, 409, { error: err.message })
+      if (err.code === 'CARD_NOT_IN_HAND') return sendJSON(res, 400, { error: err.message })
+      if (err.code === 'ILLEGAL_PLAY') return sendJSON(res, 400, { error: err.message })
+      console.error('Play card error:', { tableId, error: err.message })
       sendJSON(res, 500, { error: 'Internal server error' })
     }
   })

--- a/test/integration/game/table.test.js
+++ b/test/integration/game/table.test.js
@@ -1,0 +1,306 @@
+/**
+ * Integration tests for table creation and seat management.
+ * Requires a real Redis instance (REDIS_URL).
+ * Tests are skipped when REDIS_URL is not set.
+ */
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import express from 'express'
+import bcrypt from 'bcryptjs'
+import { handler } from '../../../server/server.js'
+import { getDb, closeDb } from '../../../server/db.js'
+import { getRedis, closeRedis } from '../../../server/redis.js'
+
+const skip =
+  !process.env.DATABASE_URL || !process.env.REDIS_URL
+    ? 'DATABASE_URL and REDIS_URL must both be set'
+    : false
+
+async function startTestServer() {
+  const app = express()
+  app.use(express.json())
+  handler(app)
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address()
+      resolve({
+        baseUrl: `http://127.0.0.1:${port}`,
+        close: () => new Promise((res) => server.close(res)),
+      })
+    })
+  })
+}
+
+async function ensurePlayersTable(db) {
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS players (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      email VARCHAR(255) UNIQUE NOT NULL,
+      username VARCHAR(50) UNIQUE NOT NULL,
+      password_hash VARCHAR(255) NOT NULL,
+      is_verified BOOLEAN NOT NULL DEFAULT FALSE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `)
+  await db.query(`DELETE FROM players WHERE email LIKE '%@gtest.spades.invalid'`)
+}
+
+async function insertVerifiedPlayer(db, { email, username, password }) {
+  const hash = await bcrypt.hash(password, 4)
+  const result = await db.query(
+    `INSERT INTO players (email, username, password_hash, is_verified)
+     VALUES ($1, $2, $3, TRUE) RETURNING id`,
+    [email, username, hash],
+  )
+  return result.rows[0].id
+}
+
+async function loginPlayer(baseUrl, email, password) {
+  const res = await fetch(`${baseUrl}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  })
+  return res.json()
+}
+
+describe('POST /api/tables', { skip }, () => {
+  let server, db, redis
+
+  before(async () => {
+    db = getDb()
+    redis = await getRedis()
+    await ensurePlayersTable(db)
+    await insertVerifiedPlayer(db, {
+      email: 'host@gtest.spades.invalid',
+      username: 'gtest_host',
+      password: 'password123',
+    })
+    server = await startTestServer()
+  })
+
+  after(async () => {
+    await server.close()
+    await closeDb()
+    await closeRedis()
+  })
+
+  it('creates a table and returns tableId for authenticated player', async () => {
+    const { sessionId, playerId } = await loginPlayer(
+      server.baseUrl,
+      'host@gtest.spades.invalid',
+      'password123',
+    )
+    const res = await fetch(`${server.baseUrl}/api/tables`, {
+      method: 'POST',
+      headers: { 'x-session-id': sessionId, 'x-player-id': playerId },
+    })
+    assert.equal(res.status, 201)
+    const body = await res.json()
+    assert.ok(body.tableId, 'should return a tableId')
+  })
+
+  it('returns 401 without auth headers', async () => {
+    const res = await fetch(`${server.baseUrl}/api/tables`, { method: 'POST' })
+    assert.equal(res.status, 401)
+  })
+})
+
+describe('POST /api/tables/:tableId/sit', { skip }, () => {
+  let server, db, redis
+  const players = []
+
+  before(async () => {
+    db = getDb()
+    redis = await getRedis()
+    await ensurePlayersTable(db)
+    for (let i = 1; i <= 4; i++) {
+      await insertVerifiedPlayer(db, {
+        email: `sitplayer${i}@gtest.spades.invalid`,
+        username: `gtest_sit${i}`,
+        password: 'password123',
+      })
+    }
+    server = await startTestServer()
+    // Login all 4 players
+    for (let i = 1; i <= 4; i++) {
+      const data = await loginPlayer(
+        server.baseUrl,
+        `sitplayer${i}@gtest.spades.invalid`,
+        'password123',
+      )
+      players.push(data)
+    }
+  })
+
+  after(async () => {
+    await server.close()
+    await closeDb()
+    await closeRedis()
+  })
+
+  it('4 players can sit and game starts automatically', async () => {
+    // Host creates table
+    const { sessionId, playerId } = players[0]
+    const createRes = await fetch(`${server.baseUrl}/api/tables`, {
+      method: 'POST',
+      headers: { 'x-session-id': sessionId, 'x-player-id': playerId },
+    })
+    const { tableId } = await createRes.json()
+
+    const seats = ['north', 'east', 'south', 'west']
+    for (let i = 0; i < 4; i++) {
+      const p = players[i]
+      const sitRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/sit`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-session-id': p.sessionId,
+          'x-player-id': p.playerId,
+        },
+        body: JSON.stringify({ seat: seats[i] }),
+      })
+      assert.equal(sitRes.status, 200, `player ${i + 1} sit failed`)
+    }
+
+    // Check game state is now available
+    const stateRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
+      headers: { 'x-session-id': players[0].sessionId, 'x-player-id': players[0].playerId },
+    })
+    assert.equal(stateRes.status, 200)
+    const state = await stateRes.json()
+    assert.equal(state.phase, 'bidding', 'game should be in bidding phase after all players sit')
+    assert.equal(state.myHand.length, 13, 'player should have 13 cards')
+  })
+
+  it('returns 409 when seat is already taken', async () => {
+    const { sessionId, playerId } = players[0]
+    const createRes = await fetch(`${server.baseUrl}/api/tables`, {
+      method: 'POST',
+      headers: { 'x-session-id': sessionId, 'x-player-id': playerId },
+    })
+    const { tableId } = await createRes.json()
+
+    // Sit player 0 at north
+    await fetch(`${server.baseUrl}/api/tables/${tableId}/sit`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': players[0].sessionId,
+        'x-player-id': players[0].playerId,
+      },
+      body: JSON.stringify({ seat: 'north' }),
+    })
+
+    // Try to sit player 1 at north too
+    const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/sit`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': players[1].sessionId,
+        'x-player-id': players[1].playerId,
+      },
+      body: JSON.stringify({ seat: 'north' }),
+    })
+    assert.equal(res.status, 409)
+  })
+})
+
+describe('POST /api/tables/:tableId/bid', { skip }, () => {
+  let server, db, redis
+  const players = []
+  let tableId
+
+  before(async () => {
+    db = getDb()
+    redis = await getRedis()
+    await ensurePlayersTable(db)
+    for (let i = 1; i <= 4; i++) {
+      await insertVerifiedPlayer(db, {
+        email: `bidplayer${i}@gtest.spades.invalid`,
+        username: `gtest_bid${i}`,
+        password: 'password123',
+      })
+    }
+    server = await startTestServer()
+    for (let i = 1; i <= 4; i++) {
+      const data = await loginPlayer(
+        server.baseUrl,
+        `bidplayer${i}@gtest.spades.invalid`,
+        'password123',
+      )
+      players.push(data)
+    }
+
+    // Set up a table with 4 players
+    const createRes = await fetch(`${server.baseUrl}/api/tables`, {
+      method: 'POST',
+      headers: { 'x-session-id': players[0].sessionId, 'x-player-id': players[0].playerId },
+    })
+    const body = await createRes.json()
+    tableId = body.tableId
+
+    const seats = ['north', 'east', 'south', 'west']
+    for (let i = 0; i < 4; i++) {
+      await fetch(`${server.baseUrl}/api/tables/${tableId}/sit`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-session-id': players[i].sessionId,
+          'x-player-id': players[i].playerId,
+        },
+        body: JSON.stringify({ seat: seats[i] }),
+      })
+    }
+  })
+
+  after(async () => {
+    await server.close()
+    await closeDb()
+    await closeRedis()
+  })
+
+  it('east player bids first (left of north dealer)', async () => {
+    // players[1] is east (second player seated)
+    const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/bid`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': players[1].sessionId,
+        'x-player-id': players[1].playerId,
+      },
+      body: JSON.stringify({ bid: 3 }),
+    })
+    assert.equal(res.status, 200)
+    const state = await res.json()
+    assert.equal(state.bids.east, 3)
+    assert.equal(state.currentBidderSeat, 'south')
+  })
+
+  it('returns 409 when wrong player tries to bid', async () => {
+    // players[0] is north — but it should be south's turn now
+    const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/bid`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': players[0].sessionId,
+        'x-player-id': players[0].playerId,
+      },
+      body: JSON.stringify({ bid: 4 }),
+    })
+    assert.equal(res.status, 409)
+  })
+
+  it('returns 400 for an invalid bid value', async () => {
+    const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/bid`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': players[2].sessionId,
+        'x-player-id': players[2].playerId,
+      },
+      body: JSON.stringify({ bid: 14 }),
+    })
+    assert.equal(res.status, 400)
+  })
+})

--- a/test/unit/game/bid.test.js
+++ b/test/unit/game/bid.test.js
@@ -1,0 +1,180 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  getBiddingOrder,
+  isEligibleForBlindNil,
+  teamHasBlindNil,
+  isValidBidValue,
+  getPartnerSeat,
+  computeTeamBids,
+  TEAM_FOR_SEAT,
+} from '../../../server/game/bid.js'
+
+describe('getBiddingOrder', () => {
+  it('starts with player left of dealer (clockwise)', () => {
+    // North deals → east goes first
+    const order = getBiddingOrder('north')
+    assert.deepEqual(order, ['east', 'south', 'west', 'north'])
+  })
+
+  it('rotates correctly for east dealer', () => {
+    const order = getBiddingOrder('east')
+    assert.deepEqual(order, ['south', 'west', 'north', 'east'])
+  })
+
+  it('rotates correctly for south dealer', () => {
+    const order = getBiddingOrder('south')
+    assert.deepEqual(order, ['west', 'north', 'east', 'south'])
+  })
+
+  it('rotates correctly for west dealer', () => {
+    const order = getBiddingOrder('west')
+    assert.deepEqual(order, ['north', 'east', 'south', 'west'])
+  })
+})
+
+describe('TEAM_FOR_SEAT', () => {
+  it('north and south are on ns team', () => {
+    assert.equal(TEAM_FOR_SEAT.north, 'ns')
+    assert.equal(TEAM_FOR_SEAT.south, 'ns')
+  })
+
+  it('east and west are on ew team', () => {
+    assert.equal(TEAM_FOR_SEAT.east, 'ew')
+    assert.equal(TEAM_FOR_SEAT.west, 'ew')
+  })
+})
+
+describe('getPartnerSeat', () => {
+  it('north partner is south', () => {
+    assert.equal(getPartnerSeat('north'), 'south')
+  })
+
+  it('south partner is north', () => {
+    assert.equal(getPartnerSeat('south'), 'north')
+  })
+
+  it('east partner is west', () => {
+    assert.equal(getPartnerSeat('east'), 'west')
+  })
+
+  it('west partner is east', () => {
+    assert.equal(getPartnerSeat('west'), 'east')
+  })
+})
+
+describe('isEligibleForBlindNil', () => {
+  it('eligible when team is 100+ points behind', () => {
+    assert.ok(isEligibleForBlindNil({ ns: 0, ew: 100 }, 'north'))
+  })
+
+  it('eligible when exactly 100 behind', () => {
+    assert.ok(isEligibleForBlindNil({ ns: 50, ew: 150 }, 'north'))
+  })
+
+  it('not eligible when less than 100 behind', () => {
+    assert.ok(!isEligibleForBlindNil({ ns: 50, ew: 149 }, 'north'))
+  })
+
+  it('not eligible when ahead', () => {
+    assert.ok(!isEligibleForBlindNil({ ns: 200, ew: 100 }, 'north'))
+  })
+
+  it('works for ew team players', () => {
+    assert.ok(isEligibleForBlindNil({ ns: 200, ew: 50 }, 'east'))
+  })
+})
+
+describe('teamHasBlindNil', () => {
+  it('returns true if partner bid blind nil', () => {
+    const bids = { north: 'blind_nil', east: null, south: null, west: null }
+    assert.ok(teamHasBlindNil(bids, 'south'))
+  })
+
+  it('returns false if no one on team bid blind nil', () => {
+    const bids = { north: 4, east: null, south: null, west: null }
+    assert.ok(!teamHasBlindNil(bids, 'north'))
+  })
+
+  it('returns true for the blind nil bidder themselves', () => {
+    const bids = { north: 'blind_nil', east: null, south: null, west: null }
+    assert.ok(teamHasBlindNil(bids, 'north'))
+  })
+})
+
+describe('isValidBidValue', () => {
+  it('accepts integers 0–13', () => {
+    for (let i = 0; i <= 13; i++) {
+      assert.ok(isValidBidValue(i), `${i} should be valid`)
+    }
+  })
+
+  it('rejects negative numbers', () => {
+    assert.ok(!isValidBidValue(-1))
+  })
+
+  it('rejects 14 and above', () => {
+    assert.ok(!isValidBidValue(14))
+  })
+
+  it('accepts "nil"', () => {
+    assert.ok(isValidBidValue('nil'))
+  })
+
+  it('accepts "blind_nil"', () => {
+    assert.ok(isValidBidValue('blind_nil'))
+  })
+
+  it('rejects strings other than nil/blind_nil', () => {
+    assert.ok(!isValidBidValue('five'))
+  })
+
+  it('rejects non-integer numbers', () => {
+    assert.ok(!isValidBidValue(3.5))
+  })
+})
+
+describe('computeTeamBids', () => {
+  it('second bidder number overrides first bidder number', () => {
+    // North deals → bidding: east, south, west, north
+    // EW: east bids first (4), west bids second (7) → EW team bid = 7
+    // NS: south bids first (3), north bids second (5) → NS team bid = 5
+    const bids = { north: 5, east: 4, south: 3, west: 7 }
+    const biddingOrder = getBiddingOrder('north')
+    const teamBids = computeTeamBids(bids, biddingOrder)
+    assert.equal(teamBids.ew, 7)
+    assert.equal(teamBids.ns, 5)
+  })
+
+  it('first bidder number is kept when second bidder bids nil', () => {
+    // EW: east bids 4 first, west bids nil → EW team bid = 4 (east's individual number)
+    const bids = { north: 5, east: 4, south: 3, west: 'nil' }
+    const biddingOrder = getBiddingOrder('north')
+    const teamBids = computeTeamBids(bids, biddingOrder)
+    assert.equal(teamBids.ew, 4)
+  })
+
+  it('returns null team bid for double nil team', () => {
+    // NS: both bid nil
+    const bids = { north: 'nil', east: 4, south: 'nil', west: 7 }
+    const biddingOrder = getBiddingOrder('north')
+    const teamBids = computeTeamBids(bids, biddingOrder)
+    assert.equal(teamBids.ns, null)
+    assert.equal(teamBids.ew, 7)
+  })
+
+  it('handles first bidder nil with second bidder number', () => {
+    // EW: east bids nil first, west bids 5 → EW team bid = 5 (west bids the team total, east's nil stands individually)
+    const bids = { north: 5, east: 'nil', south: 3, west: 5 }
+    const biddingOrder = getBiddingOrder('north')
+    const teamBids = computeTeamBids(bids, biddingOrder)
+    assert.equal(teamBids.ew, 5)
+  })
+
+  it('team bid of 0 is preserved', () => {
+    const bids = { north: 0, east: 4, south: 0, west: 7 }
+    const biddingOrder = getBiddingOrder('north')
+    const teamBids = computeTeamBids(bids, biddingOrder)
+    assert.equal(teamBids.ns, 0)
+  })
+})

--- a/test/unit/game/deck.test.js
+++ b/test/unit/game/deck.test.js
@@ -1,0 +1,168 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  createDeck,
+  shuffle,
+  deal,
+  sortHand,
+  rankValue,
+  cardEquals,
+  SUITS,
+  RANKS,
+} from '../../../server/game/deck.js'
+
+describe('createDeck', () => {
+  it('returns 52 cards', () => {
+    const deck = createDeck()
+    assert.equal(deck.length, 52)
+  })
+
+  it('has 13 cards per suit', () => {
+    const deck = createDeck()
+    for (const suit of SUITS) {
+      const count = deck.filter((c) => c.suit === suit).length
+      assert.equal(count, 13, `expected 13 ${suit} cards`)
+    }
+  })
+
+  it('has 4 of each rank', () => {
+    const deck = createDeck()
+    for (const rank of RANKS) {
+      const count = deck.filter((c) => c.rank === rank).length
+      assert.equal(count, 4, `expected 4 cards of rank ${rank}`)
+    }
+  })
+
+  it('has no duplicate cards', () => {
+    const deck = createDeck()
+    const unique = new Set(deck.map((c) => `${c.suit}:${c.rank}`))
+    assert.equal(unique.size, 52)
+  })
+})
+
+describe('shuffle', () => {
+  it('returns a deck with 52 cards', () => {
+    const deck = createDeck()
+    const shuffled = shuffle(deck)
+    assert.equal(shuffled.length, 52)
+  })
+
+  it('does not mutate the original deck', () => {
+    const deck = createDeck()
+    const original = deck.map((c) => ({ ...c }))
+    shuffle(deck)
+    assert.deepEqual(deck, original)
+  })
+
+  it('contains the same cards as the original', () => {
+    const deck = createDeck()
+    const shuffled = shuffle(deck)
+    const toKey = (c) => `${c.suit}:${c.rank}`
+    const orig = new Set(deck.map(toKey))
+    const shuf = new Set(shuffled.map(toKey))
+    assert.equal(orig.size, shuf.size)
+    for (const k of orig) assert.ok(shuf.has(k), `missing card ${k}`)
+  })
+})
+
+describe('deal', () => {
+  it('returns 4 hands of 13 cards each', () => {
+    const deck = shuffle(createDeck())
+    const hands = deal(deck)
+    for (const seat of ['north', 'east', 'south', 'west']) {
+      assert.equal(hands[seat].length, 13, `${seat} should have 13 cards`)
+    }
+  })
+
+  it('distributes all 52 cards without duplication', () => {
+    const deck = shuffle(createDeck())
+    const hands = deal(deck)
+    const allCards = [
+      ...hands.north,
+      ...hands.east,
+      ...hands.south,
+      ...hands.west,
+    ]
+    assert.equal(allCards.length, 52)
+    const unique = new Set(allCards.map((c) => `${c.suit}:${c.rank}`))
+    assert.equal(unique.size, 52)
+  })
+})
+
+describe('sortHand', () => {
+  it('sorts clubs before diamonds before hearts before spades', () => {
+    const hand = [
+      { suit: 'spades', rank: '2' },
+      { suit: 'hearts', rank: '3' },
+      { suit: 'clubs', rank: '4' },
+      { suit: 'diamonds', rank: '5' },
+    ]
+    const sorted = sortHand(hand)
+    assert.equal(sorted[0].suit, 'clubs')
+    assert.equal(sorted[1].suit, 'diamonds')
+    assert.equal(sorted[2].suit, 'hearts')
+    assert.equal(sorted[3].suit, 'spades')
+  })
+
+  it('sorts by rank ascending within the same suit', () => {
+    const hand = [
+      { suit: 'clubs', rank: 'A' },
+      { suit: 'clubs', rank: '2' },
+      { suit: 'clubs', rank: 'K' },
+      { suit: 'clubs', rank: '10' },
+    ]
+    const sorted = sortHand(hand)
+    assert.deepEqual(
+      sorted.map((c) => c.rank),
+      ['2', '10', 'K', 'A'],
+    )
+  })
+
+  it('does not mutate the original hand', () => {
+    const hand = [
+      { suit: 'spades', rank: 'A' },
+      { suit: 'clubs', rank: '2' },
+    ]
+    const original = hand.map((c) => ({ ...c }))
+    sortHand(hand)
+    assert.deepEqual(hand, original)
+  })
+})
+
+describe('rankValue', () => {
+  it('returns a higher value for A than K', () => {
+    assert.ok(rankValue('A') > rankValue('K'))
+  })
+
+  it('returns a higher value for K than Q', () => {
+    assert.ok(rankValue('K') > rankValue('Q'))
+  })
+
+  it('returns a higher value for 10 than 9', () => {
+    assert.ok(rankValue('10') > rankValue('9'))
+  })
+
+  it('returns a higher value for J than 10', () => {
+    assert.ok(rankValue('J') > rankValue('10'))
+  })
+
+  it('returns the lowest value for 2', () => {
+    for (const r of RANKS.filter((r) => r !== '2')) {
+      assert.ok(rankValue('2') < rankValue(r), `2 should be less than ${r}`)
+    }
+  })
+})
+
+describe('cardEquals', () => {
+  it('returns true for the same card', () => {
+    assert.ok(cardEquals({ suit: 'spades', rank: 'A' }, { suit: 'spades', rank: 'A' }))
+  })
+
+  it('returns false when suit differs', () => {
+    assert.ok(!cardEquals({ suit: 'spades', rank: 'A' }, { suit: 'hearts', rank: 'A' }))
+  })
+
+  it('returns false when rank differs', () => {
+    assert.ok(!cardEquals({ suit: 'spades', rank: 'A' }, { suit: 'spades', rank: 'K' }))
+  })
+})

--- a/test/unit/game/score.test.js
+++ b/test/unit/game/score.test.js
@@ -1,0 +1,225 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { scoreHand, checkWinLoss, applyBagPenalties } from '../../../server/game/score.js'
+
+describe('scoreHand — basic team bid', () => {
+  it('awards bid × 10 when team makes their bid exactly', () => {
+    const { scoreDelta, newBags } = scoreHand({
+      bids: { north: 3, east: 4, south: 4, west: 3 },
+      teamBids: { ns: 7, ew: 7 },
+      tricksWon: { north: 3, east: 4, south: 4, west: 3 },
+    })
+    assert.equal(scoreDelta.ns, 70)
+    assert.equal(scoreDelta.ew, 70)
+    assert.equal(newBags.ns, 0)
+    assert.equal(newBags.ew, 0)
+  })
+
+  it('awards overtricks as bags (+1 per overtrick, not +10)', () => {
+    const { scoreDelta, newBags } = scoreHand({
+      bids: { north: 3, east: 4, south: 4, west: 3 },
+      teamBids: { ns: 7, ew: 7 },
+      tricksWon: { north: 4, east: 5, south: 4, west: 3 },
+    })
+    // NS: 8 tricks vs bid 7 → +70 + 1 bag
+    assert.equal(scoreDelta.ns, 70)
+    assert.equal(newBags.ns, 1)
+    // EW: 8 tricks vs bid 7 → +70 + 1 bag
+    assert.equal(scoreDelta.ew, 70)
+    assert.equal(newBags.ew, 1)
+  })
+
+  it('deducts bid × 10 when team misses their bid', () => {
+    const { scoreDelta, newBags } = scoreHand({
+      bids: { north: 4, east: 4, south: 4, west: 3 },
+      teamBids: { ns: 8, ew: 7 },
+      tricksWon: { north: 3, east: 3, south: 3, west: 4 },
+    })
+    // NS: 6 tricks vs bid 8 → -80
+    assert.equal(scoreDelta.ns, -80)
+    assert.equal(newBags.ns, 0)
+    // EW: 7 tricks vs bid 7 → +70
+    assert.equal(scoreDelta.ew, 70)
+    assert.equal(newBags.ew, 0)
+  })
+})
+
+describe('scoreHand — nil bid', () => {
+  it('awards +50 for a successful nil', () => {
+    const { scoreDelta } = scoreHand({
+      bids: { north: 'nil', east: 4, south: 5, west: 3 },
+      teamBids: { ns: 5, ew: 7 },
+      tricksWon: { north: 0, east: 4, south: 5, west: 3 },
+    })
+    // North made nil: +50. NS also made team bid of 5: +50
+    assert.equal(scoreDelta.ns, 50 + 50)
+  })
+
+  it('deducts -50 for a failed nil', () => {
+    const { scoreDelta, newBags } = scoreHand({
+      bids: { north: 'nil', east: 4, south: 5, west: 3 },
+      teamBids: { ns: 5, ew: 7 },
+      tricksWon: { north: 2, east: 4, south: 3, west: 3 },
+    })
+    // North failed nil: -50
+    // NS team: north(2) + south(3) = 5 tricks vs bid 5 → +50, 0 bags
+    assert.equal(scoreDelta.ns, -50 + 50)
+    assert.equal(newBags.ns, 0)
+  })
+
+  it('nil bidder tricks that push team over bid create bags', () => {
+    const { scoreDelta, newBags } = scoreHand({
+      bids: { north: 'nil', east: 4, south: 5, west: 3 },
+      teamBids: { ns: 5, ew: 7 },
+      // North fails nil with 3 tricks; south has 5; team total = 8, bid = 5 → 3 bags
+      tricksWon: { north: 3, east: 4, south: 5, west: 3 },
+    })
+    // North failed nil: -50
+    // NS: 8 tricks vs bid 5 → +50 + 3 bags
+    assert.equal(scoreDelta.ns, -50 + 50)
+    assert.equal(newBags.ns, 3)
+  })
+})
+
+describe('scoreHand — blind nil bid', () => {
+  it('awards +100 for a successful blind nil', () => {
+    const { scoreDelta } = scoreHand({
+      bids: { north: 'blind_nil', east: 4, south: 5, west: 3 },
+      teamBids: { ns: 5, ew: 7 },
+      tricksWon: { north: 0, east: 4, south: 5, west: 3 },
+    })
+    assert.ok(scoreDelta.ns >= 100 + 50) // +100 blind nil + +50 team
+  })
+
+  it('deducts -100 for a failed blind nil', () => {
+    const { scoreDelta } = scoreHand({
+      bids: { north: 'blind_nil', east: 4, south: 5, west: 3 },
+      teamBids: { ns: 5, ew: 7 },
+      tricksWon: { north: 1, east: 4, south: 4, west: 3 },
+    })
+    // North failed blind nil: -100
+    // NS: 5 tricks vs bid 5 → +50
+    assert.equal(scoreDelta.ns, -100 + 50)
+  })
+})
+
+describe('scoreHand — double nil', () => {
+  it('awards +50 to each successful individual nil in a double nil', () => {
+    const { scoreDelta, newBags } = scoreHand({
+      bids: { north: 'nil', east: 4, south: 'nil', west: 3 },
+      teamBids: { ns: null, ew: 7 },
+      tricksWon: { north: 0, east: 4, south: 0, west: 3 },
+    })
+    // Both made nil: +50 + +50 = +100 for NS
+    assert.equal(scoreDelta.ns, 100)
+    assert.equal(newBags.ns, 0)
+  })
+
+  it('every trick in double nil is a bag and breaks individual nil', () => {
+    const { scoreDelta, newBags } = scoreHand({
+      bids: { north: 'nil', east: 4, south: 'nil', west: 3 },
+      teamBids: { ns: null, ew: 7 },
+      tricksWon: { north: 2, east: 4, south: 0, west: 3 },
+    })
+    // North failed nil (-50); south made nil (+50); north's 2 tricks = 2 bags
+    assert.equal(scoreDelta.ns, -50 + 50)
+    assert.equal(newBags.ns, 2)
+  })
+})
+
+describe('scoreHand — team bid of 0', () => {
+  it('every trick is a bag when team bids 0', () => {
+    const { scoreDelta, newBags } = scoreHand({
+      bids: { north: 0, east: 4, south: 0, west: 3 },
+      teamBids: { ns: 0, ew: 7 },
+      tricksWon: { north: 2, east: 4, south: 1, west: 3 },
+    })
+    // NS team bid 0: every trick is a bag, no positive/negative score
+    assert.equal(scoreDelta.ns, 0)
+    assert.equal(newBags.ns, 3) // 2 + 1
+  })
+})
+
+describe('applyBagPenalties', () => {
+  it('deducts 100 points per 10 bags accumulated', () => {
+    const { scores, bags } = applyBagPenalties(
+      { ns: 150, ew: 100 },
+      { ns: 9, ew: 5 },
+      { ns: 3, ew: 2 },
+    )
+    // NS: 9 + 3 = 12 bags → 1 penalty (−100), 2 bags remaining
+    assert.equal(scores.ns, 50) // 150 - 100
+    assert.equal(bags.ns, 2)
+    // EW: 5 + 2 = 7 bags → no penalty
+    assert.equal(scores.ew, 100)
+    assert.equal(bags.ew, 7)
+  })
+
+  it('deducts 200 when accumulating 20+ bags', () => {
+    const { scores, bags } = applyBagPenalties(
+      { ns: 300, ew: 100 },
+      { ns: 15, ew: 0 },
+      { ns: 8, ew: 0 },
+    )
+    // NS: 15 + 8 = 23 bags → 2 penalties (−200), 3 bags remaining
+    assert.equal(scores.ns, 100) // 300 - 200
+    assert.equal(bags.ns, 3)
+  })
+
+  it('does not deduct when fewer than 10 bags total', () => {
+    const { scores, bags } = applyBagPenalties(
+      { ns: 100, ew: 100 },
+      { ns: 4, ew: 4 },
+      { ns: 3, ew: 3 },
+    )
+    assert.equal(scores.ns, 100)
+    assert.equal(bags.ns, 7)
+    assert.equal(scores.ew, 100)
+    assert.equal(bags.ew, 7)
+  })
+})
+
+describe('checkWinLoss', () => {
+  it('returns win for team that reaches 250', () => {
+    const result = checkWinLoss({ ns: 250, ew: 100 })
+    assert.equal(result.winner, 'ns')
+    assert.equal(result.loser, 'ew')
+  })
+
+  it('returns win for higher-scoring team when both reach 250', () => {
+    const result = checkWinLoss({ ns: 260, ew: 255 })
+    assert.equal(result.winner, 'ns')
+  })
+
+  it('returns null when tied at exactly 250 (play another hand)', () => {
+    const result = checkWinLoss({ ns: 250, ew: 250 })
+    assert.equal(result, null)
+  })
+
+  it('returns loss for team that reaches -250', () => {
+    const result = checkWinLoss({ ns: -250, ew: 100 })
+    assert.equal(result.loser, 'ns')
+    assert.equal(result.winner, 'ew')
+  })
+
+  it('higher score wins when both reach -250', () => {
+    const result = checkWinLoss({ ns: -260, ew: -255 })
+    assert.equal(result.winner, 'ew') // ew has higher score
+  })
+
+  it('returns null when tied at exactly -250 (play another hand)', () => {
+    const result = checkWinLoss({ ns: -250, ew: -250 })
+    assert.equal(result, null)
+  })
+
+  it('returns null when neither threshold is reached', () => {
+    const result = checkWinLoss({ ns: 100, ew: 150 })
+    assert.equal(result, null)
+  })
+
+  it('win condition takes priority over loss when one team hits 250 and other hits -250', () => {
+    // Both conditions — winner is the team above 250
+    const result = checkWinLoss({ ns: 250, ew: -250 })
+    assert.equal(result.winner, 'ns')
+  })
+})

--- a/test/unit/game/state.test.js
+++ b/test/unit/game/state.test.js
@@ -1,0 +1,235 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  createGame,
+  placeBid,
+  playCard,
+  submitBlindNilExchange,
+  getPlayerView,
+  CLOCKWISE_SEATS,
+} from '../../../server/game/state.js'
+
+// Helper: play through all bids to get to 'playing' phase
+function bidAll(state, bids) {
+  for (const [seat, bid] of bids) {
+    state = placeBid(state, seat, bid)
+  }
+  return state
+}
+
+// Helper: play out an entire hand using provided play sequences
+// plays: [[seat, card], ...] for all 52 plays
+function playTricks(state, plays) {
+  for (const [seat, card] of plays) {
+    state = playCard(state, seat, card)
+  }
+  return state
+}
+
+const PLAYER_IDS = {
+  north: 'player-north',
+  east: 'player-east',
+  south: 'player-south',
+  west: 'player-west',
+}
+
+describe('createGame', () => {
+  it('creates a game in bidding phase', () => {
+    const state = createGame('table-1', PLAYER_IDS)
+    assert.equal(state.phase, 'bidding')
+  })
+
+  it('deals 13 cards to each player', () => {
+    const state = createGame('table-1', PLAYER_IDS)
+    for (const seat of CLOCKWISE_SEATS) {
+      assert.equal(state.hands[seat].length, 13)
+    }
+  })
+
+  it('hands are sorted by suit then rank', () => {
+    const state = createGame('table-1', PLAYER_IDS)
+    for (const seat of CLOCKWISE_SEATS) {
+      const hand = state.hands[seat]
+      for (let i = 1; i < hand.length; i++) {
+        const prev = hand[i - 1]
+        const curr = hand[i]
+        const suitOrder = ['clubs', 'diamonds', 'hearts', 'spades']
+        const rankOrder = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A']
+        if (prev.suit === curr.suit) {
+          assert.ok(
+            rankOrder.indexOf(prev.rank) <= rankOrder.indexOf(curr.rank),
+            `hand not sorted by rank for ${seat}`,
+          )
+        } else {
+          assert.ok(
+            suitOrder.indexOf(prev.suit) <= suitOrder.indexOf(curr.suit),
+            `hand not sorted by suit for ${seat}`,
+          )
+        }
+      }
+    }
+  })
+
+  it('north is the dealer on the first hand', () => {
+    const state = createGame('table-1', PLAYER_IDS)
+    assert.equal(state.dealerSeat, 'north')
+  })
+
+  it('first bidder is east (left of north dealer)', () => {
+    const state = createGame('table-1', PLAYER_IDS)
+    assert.equal(state.currentBidderSeat, 'east')
+  })
+
+  it('initialises scores and bags to zero', () => {
+    const state = createGame('table-1', PLAYER_IDS)
+    assert.deepEqual(state.scores, { ns: 0, ew: 0 })
+    assert.deepEqual(state.bags, { ns: 0, ew: 0 })
+  })
+})
+
+describe('placeBid', () => {
+  it('throws if not in bidding phase', () => {
+    const state = createGame('table-1', PLAYER_IDS)
+    // Manually set phase
+    const badState = { ...state, phase: 'playing' }
+    assert.throws(() => placeBid(badState, 'east', 3), /not in bidding phase/i)
+  })
+
+  it('throws if wrong player bids', () => {
+    const state = createGame('table-1', PLAYER_IDS)
+    assert.throws(() => placeBid(state, 'north', 3), /not your turn/i)
+  })
+
+  it('records the bid and advances to next bidder', () => {
+    let state = createGame('table-1', PLAYER_IDS)
+    state = placeBid(state, 'east', 3)
+    assert.equal(state.bids.east, 3)
+    assert.equal(state.currentBidderSeat, 'south')
+  })
+
+  it('transitions to playing phase after all 4 bids', () => {
+    let state = createGame('table-1', PLAYER_IDS)
+    state = bidAll(state, [
+      ['east', 3],
+      ['south', 4],
+      ['west', 3],
+      ['north', 7],
+    ])
+    assert.equal(state.phase, 'playing')
+  })
+
+  it('transitions to blind_nil_exchange when a player bids blind nil', () => {
+    // Make NS far behind so blind nil is eligible
+    let state = createGame('table-1', PLAYER_IDS)
+    state = { ...state, scores: { ns: 0, ew: 100 } }
+    state = placeBid(state, 'east', 3) // east bids (ew first)
+    state = placeBid(state, 'south', 'blind_nil') // south bids blind nil (ns first)
+    state = placeBid(state, 'west', 3) // west bids (ew second)
+    state = placeBid(state, 'north', 5) // north bids (ns second)
+    assert.equal(state.phase, 'blind_nil_exchange')
+  })
+
+  it('rejects invalid bid value', () => {
+    const state = createGame('table-1', PLAYER_IDS)
+    assert.throws(() => placeBid(state, 'east', 14), /invalid bid/i)
+  })
+
+  it('rejects blind nil when team is not 100+ behind', () => {
+    const state = createGame('table-1', PLAYER_IDS)
+    assert.throws(() => placeBid(state, 'east', 'blind_nil'), /not eligible/i)
+  })
+
+  it('rejects second blind nil for same team', () => {
+    let state = createGame('table-1', PLAYER_IDS)
+    // NS must be 100+ behind EW for NS players to bid blind nil
+    state = { ...state, scores: { ns: 0, ew: 100 } }
+    // Bidding order: east, south, west, north (north is dealer)
+    state = placeBid(state, 'east', 3) // east bids
+    state = placeBid(state, 'south', 'blind_nil') // south (NS first bidder) bids blind nil
+    state = placeBid(state, 'west', 3) // west bids
+    // North (NS second bidder) tries to also bid blind nil — should be rejected
+    assert.throws(() => placeBid(state, 'north', 'blind_nil'), /already bid blind nil/i)
+  })
+})
+
+describe('playCard', () => {
+  function getToPlayingPhase() {
+    let state = createGame('table-1', PLAYER_IDS)
+    state = bidAll(state, [
+      ['east', 3],
+      ['south', 4],
+      ['west', 3],
+      ['north', 7],
+    ])
+    return state
+  }
+
+  it('throws if not in playing phase', () => {
+    const state = createGame('table-1', PLAYER_IDS)
+    const card = state.hands.east[0]
+    assert.throws(() => playCard(state, 'east', card), /not in playing phase/i)
+  })
+
+  it('throws if wrong player plays', () => {
+    let state = getToPlayingPhase()
+    const wrongCard = state.hands.north[0]
+    // East leads the first trick after north deals
+    assert.throws(() => playCard(state, 'north', wrongCard), /not your turn/i)
+  })
+
+  it('throws if card not in hand', () => {
+    let state = getToPlayingPhase()
+    assert.throws(
+      () => playCard(state, 'east', { suit: 'spades', rank: '2' }),
+      /not in hand|invalid card/i,
+    )
+  })
+
+  it('removes played card from hand', () => {
+    let state = getToPlayingPhase()
+    const card = state.hands.east[0]
+    state = playCard(state, 'east', card)
+    assert.equal(state.hands.east.length, 12)
+    assert.ok(!state.hands.east.some((c) => c.suit === card.suit && c.rank === card.rank))
+  })
+
+  it('spades are broken when first spade is played', () => {
+    let state = getToPlayingPhase()
+    assert.equal(state.spadesbroken, false)
+
+    // Find a player who can legally play a spade (i.e., has no other option when following)
+    // Simpler: inject a known hand state for testing
+    // Force a situation where east has only spades
+    state = {
+      ...state,
+      hands: {
+        ...state.hands,
+        east: [{ suit: 'spades', rank: 'A' }],
+      },
+    }
+    state = playCard(state, 'east', { suit: 'spades', rank: 'A' })
+    assert.equal(state.spadesbroken, true)
+  })
+})
+
+describe('getPlayerView', () => {
+  it('includes only the requesting player\'s hand', () => {
+    const state = createGame('table-1', PLAYER_IDS)
+    const view = getPlayerView(state, 'north')
+    assert.ok(view.myHand)
+    assert.equal(view.myHand.length, 13)
+    assert.ok(!view.hands, 'should not expose all hands')
+  })
+
+  it('does not expose other players\' hands', () => {
+    const state = createGame('table-1', PLAYER_IDS)
+    const view = getPlayerView(state, 'north')
+    assert.ok(!view.hands || !view.hands.east, 'should not expose other players hands')
+  })
+})
+
+describe('CLOCKWISE_SEATS', () => {
+  it('lists seats in clockwise order starting from north', () => {
+    assert.deepEqual(CLOCKWISE_SEATS, ['north', 'east', 'south', 'west'])
+  })
+})

--- a/test/unit/game/trick.test.js
+++ b/test/unit/game/trick.test.js
@@ -1,0 +1,181 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { getLegalPlays, determineTrickWinner, isCardLegal } from '../../../server/game/trick.js'
+
+describe('getLegalPlays — leading a trick', () => {
+  it('allows any non-spade on the first trick of a hand', () => {
+    const hand = [
+      { suit: 'clubs', rank: 'A' },
+      { suit: 'spades', rank: 'K' },
+      { suit: 'hearts', rank: '7' },
+    ]
+    const legal = getLegalPlays(hand, [], false, true)
+    assert.equal(legal.length, 2)
+    assert.ok(legal.every((c) => c.suit !== 'spades'))
+  })
+
+  it('on the first trick, if a player has ONLY spades they must play spades', () => {
+    const hand = [
+      { suit: 'spades', rank: 'A' },
+      { suit: 'spades', rank: '2' },
+    ]
+    const legal = getLegalPlays(hand, [], false, true)
+    assert.equal(legal.length, 2)
+    assert.ok(legal.every((c) => c.suit === 'spades'))
+  })
+
+  it('cannot lead spades before spades are broken (and has non-spades)', () => {
+    const hand = [
+      { suit: 'clubs', rank: 'A' },
+      { suit: 'spades', rank: 'K' },
+    ]
+    const legal = getLegalPlays(hand, [], false, false) // spades not broken, not first trick
+    assert.equal(legal.length, 1)
+    assert.equal(legal[0].suit, 'clubs')
+  })
+
+  it('can lead spades once spades are broken', () => {
+    const hand = [
+      { suit: 'clubs', rank: 'A' },
+      { suit: 'spades', rank: 'K' },
+    ]
+    const legal = getLegalPlays(hand, [], true, false) // spades broken
+    assert.equal(legal.length, 2)
+  })
+
+  it('can lead any card when spades not broken but player has only spades', () => {
+    const hand = [{ suit: 'spades', rank: 'A' }]
+    const legal = getLegalPlays(hand, [], false, false)
+    assert.equal(legal.length, 1)
+    assert.equal(legal[0].suit, 'spades')
+  })
+})
+
+describe('getLegalPlays — following a trick', () => {
+  it('must follow suit if possible', () => {
+    const hand = [
+      { suit: 'clubs', rank: 'A' },
+      { suit: 'clubs', rank: '5' },
+      { suit: 'spades', rank: 'K' },
+    ]
+    const trick = [{ seat: 'north', card: { suit: 'clubs', rank: '2' } }]
+    const legal = getLegalPlays(hand, trick, false, false)
+    assert.equal(legal.length, 2)
+    assert.ok(legal.every((c) => c.suit === 'clubs'))
+  })
+
+  it('may play any card when unable to follow suit', () => {
+    const hand = [
+      { suit: 'spades', rank: 'A' },
+      { suit: 'hearts', rank: '5' },
+    ]
+    const trick = [{ seat: 'north', card: { suit: 'clubs', rank: '2' } }]
+    const legal = getLegalPlays(hand, trick, false, false)
+    assert.equal(legal.length, 2)
+  })
+
+  it('on the first trick, cannot play spades when unable to follow suit if non-spades exist', () => {
+    const hand = [
+      { suit: 'hearts', rank: '5' },
+      { suit: 'spades', rank: 'A' },
+    ]
+    const trick = [{ seat: 'north', card: { suit: 'clubs', rank: '2' } }]
+    const legal = getLegalPlays(hand, trick, false, true)
+    // Can't follow clubs, but on first trick can't play spades if other options exist
+    assert.equal(legal.length, 1)
+    assert.equal(legal[0].suit, 'hearts')
+  })
+
+  it('on the first trick, must play spades if only spades available when unable to follow suit', () => {
+    const hand = [{ suit: 'spades', rank: 'A' }]
+    const trick = [{ seat: 'north', card: { suit: 'clubs', rank: '2' } }]
+    const legal = getLegalPlays(hand, trick, false, true)
+    assert.equal(legal.length, 1)
+    assert.equal(legal[0].suit, 'spades')
+  })
+})
+
+describe('determineTrickWinner', () => {
+  it('highest card of led suit wins when no spades played', () => {
+    const trick = [
+      { seat: 'north', card: { suit: 'clubs', rank: 'A' } },
+      { seat: 'east', card: { suit: 'clubs', rank: '3' } },
+      { seat: 'south', card: { suit: 'hearts', rank: 'K' } }, // different suit — irrelevant
+      { seat: 'west', card: { suit: 'clubs', rank: 'Q' } },
+    ]
+    assert.equal(determineTrickWinner(trick), 'north')
+  })
+
+  it('spade beats highest non-spade of led suit', () => {
+    const trick = [
+      { seat: 'north', card: { suit: 'clubs', rank: 'A' } },
+      { seat: 'east', card: { suit: 'spades', rank: '2' } },
+      { seat: 'south', card: { suit: 'clubs', rank: 'K' } },
+      { seat: 'west', card: { suit: 'clubs', rank: 'Q' } },
+    ]
+    assert.equal(determineTrickWinner(trick), 'east')
+  })
+
+  it('highest spade wins when multiple spades played', () => {
+    const trick = [
+      { seat: 'north', card: { suit: 'clubs', rank: 'A' } },
+      { seat: 'east', card: { suit: 'spades', rank: '5' } },
+      { seat: 'south', card: { suit: 'spades', rank: 'K' } },
+      { seat: 'west', card: { suit: 'spades', rank: '2' } },
+    ]
+    assert.equal(determineTrickWinner(trick), 'south')
+  })
+
+  it('off-suit cards (not spades, not led suit) never win', () => {
+    const trick = [
+      { seat: 'north', card: { suit: 'clubs', rank: '2' } },
+      { seat: 'east', card: { suit: 'hearts', rank: 'A' } }, // off-suit, irrelevant
+      { seat: 'south', card: { suit: 'diamonds', rank: 'A' } }, // off-suit, irrelevant
+      { seat: 'west', card: { suit: 'clubs', rank: '3' } },
+    ]
+    assert.equal(determineTrickWinner(trick), 'west')
+  })
+
+  it('first spade played wins if it is the only spade', () => {
+    const trick = [
+      { seat: 'north', card: { suit: 'hearts', rank: 'A' } },
+      { seat: 'east', card: { suit: 'spades', rank: '2' } },
+      { seat: 'south', card: { suit: 'hearts', rank: 'K' } },
+      { seat: 'west', card: { suit: 'hearts', rank: 'Q' } },
+    ]
+    assert.equal(determineTrickWinner(trick), 'east')
+  })
+})
+
+describe('isCardLegal', () => {
+  it('returns false if card not in hand', () => {
+    const hand = [{ suit: 'clubs', rank: 'A' }]
+    assert.ok(
+      !isCardLegal({ suit: 'spades', rank: 'K' }, hand, [], false, false),
+    )
+  })
+
+  it('returns true if card is a legal play', () => {
+    const hand = [{ suit: 'clubs', rank: 'A' }]
+    const trick = [{ seat: 'north', card: { suit: 'clubs', rank: '2' } }]
+    assert.ok(isCardLegal({ suit: 'clubs', rank: 'A' }, hand, trick, false, false))
+  })
+
+  it('returns false if play violates suit-following rule', () => {
+    const hand = [
+      { suit: 'clubs', rank: 'A' },
+      { suit: 'spades', rank: 'K' },
+    ]
+    const trick = [{ seat: 'north', card: { suit: 'clubs', rank: '2' } }]
+    // Must follow clubs, playing spades is illegal
+    assert.ok(!isCardLegal({ suit: 'spades', rank: 'K' }, hand, trick, false, false))
+  })
+
+  it('returns false if leading spades on first trick when non-spades available', () => {
+    const hand = [
+      { suit: 'clubs', rank: 'A' },
+      { suit: 'spades', rank: 'K' },
+    ]
+    assert.ok(!isCardLegal({ suit: 'spades', rank: 'K' }, hand, [], false, true))
+  })
+})


### PR DESCRIPTION
Implements the full Spades game loop for Slice 1 of the v1.0 roadmap.

## Changes

- `server/game/deck.js` — card representation, shuffle, deal, sort
- `server/game/bid.js` — partnership bidding, blind nil eligibility, team bid computation
- `server/game/trick.js` — legal play validation, spades-breaking, trick winner
- `server/game/score.js` — full scoring with bags, nil, blind nil, win/loss conditions
- `server/game/state.js` — game state machine (deal → bid → play → score → repeat)
- `server/lobby/table.js` — table creation, seat management, game auto-start
- `server/anticheat/validate.js` — server-side move validation
- API routes wired in `server/server.js`
- Unit and integration tests
- `docs/TASKS.md` updated

Closes #64

Generated with [Claude Code](https://claude.ai/code)