### PR TITLE
feat: resend verification email flow #80

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ All routes are under `/api/`. Responses always use `{ ... }` JSON. Auth routes u
 |---|---|---|
 | `POST` | `/api/auth/register` | Register with email, username, password. Sends a verification email. |
 | `GET` | `/api/auth/verify-email?token=<uuid>` | Verify email address using the token from the registration email. |
+| `POST` | `/api/auth/resend-verification` | Resend the verification email to an unverified account. Always returns 200 regardless of whether the email exists (prevents enumeration). |
 
 #### `POST /api/auth/register`
 
@@ -138,13 +139,29 @@ All routes are under `/api/`. Responses always use `{ ... }` JSON. Auth routes u
 | `200` | Email verified. Account is now active. |
 | `400` | Missing, invalid, expired, or already-used token |
 
+#### `POST /api/auth/resend-verification`
+
+**Body**
+```json
+{ "email": "alice@example.com" }
+```
+
+**Responses**
+
+| Status | Meaning |
+|---|---|
+| `200` | Request accepted. If the email is registered and unverified, a new link has been sent. |
+| `500` | Internal server error |
+
+> Note: A `200` is returned even when the email is not found or the account is already verified. This prevents account enumeration.
+
 ## Web UI
 
 The web client is served as static files from `client/web/` by the Express server. Open `http://localhost:3000` in a browser after starting the server.
 
 Current screens:
-- **Sign In** (`#/login`) — email + password login
-- **Create Account** (`#/register`) — registration with email, username, and password; shows a verification prompt on success
+- **Sign In** (`#/login`) — email + password login; shows a "Resend verification email" button when login fails with an unverified email error
+- **Create Account** (`#/register`) — registration with email, username, and password; shows a verification prompt on success with a "Resend verification email" button
 
 On successful login the session is stored in `sessionStorage` (`sessionId`, `playerId`, `username`) and the player is routed to `#/lobby` (lobby screen, coming in a later slice).
 

--- a/client/web/index.html
+++ b/client/web/index.html
@@ -131,6 +131,48 @@
       .auth-message strong {
         color: #e8e8e8;
       }
+
+      .btn-secondary {
+        width: 100%;
+        padding: 0.625rem;
+        background: transparent;
+        color: #66bb6a;
+        border: 1px solid #66bb6a;
+        border-radius: 4px;
+        font-size: 0.875rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: background 0.15s, color 0.15s;
+        margin-bottom: 0.75rem;
+      }
+
+      .btn-secondary:hover:not(:disabled) {
+        background: #66bb6a;
+        color: #1a1a1a;
+      }
+
+      .btn-secondary:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+
+      .btn-link {
+        background: none;
+        border: none;
+        color: #66bb6a;
+        cursor: pointer;
+        font-size: inherit;
+        padding: 0;
+        text-decoration: underline;
+      }
+
+      .btn-link:hover {
+        color: #81c784;
+      }
+
+      .auth-resend {
+        margin-bottom: 0.75rem;
+      }
     </style>
   </head>
   <body>

--- a/client/web/src/api.js
+++ b/client/web/src/api.js
@@ -27,6 +27,29 @@ export async function registerUser({ email, username, password }, fetchFn = glob
 }
 
 /**
+ * Request a new verification email for an unverified account.
+ * Always returns successfully — the server does not reveal whether the email
+ * exists or is already verified.
+ * @param {{ email: string }} data
+ * @param {typeof fetch} [fetchFn]
+ * @returns {Promise<{ message: string }>}
+ */
+export async function resendVerification({ email }, fetchFn = globalThis.fetch) {
+  const res = await fetchFn('/api/auth/resend-verification', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email }),
+  })
+  const body = await res.json()
+  if (!res.ok) {
+    const err = new Error(body.error || 'Failed to resend verification email.')
+    err.status = res.status
+    throw err
+  }
+  return body
+}
+
+/**
  * Log in with email and password.
  * @param {{ email: string, password: string }} data
  * @param {typeof fetch} [fetchFn]

--- a/client/web/src/screens/login.js
+++ b/client/web/src/screens/login.js
@@ -1,5 +1,5 @@
 import { validateLoginForm } from '../validation.js'
-import { loginUser } from '../api.js'
+import { loginUser, resendVerification } from '../api.js'
 import { navigate } from '../router.js'
 
 /**
@@ -33,6 +33,9 @@ export function renderLoginScreen(container) {
           />
         </div>
         <div class="form-error" id="login-error" role="alert" aria-live="polite"></div>
+        <div id="login-resend-section" style="display:none;" class="auth-resend">
+          <button type="button" id="resend-btn" class="btn-secondary">Resend verification email</button>
+        </div>
         <button type="submit" id="login-btn" class="btn-primary">Sign In</button>
       </form>
       <p class="auth-link">Don't have an account? <a href="#/register">Create one</a></p>
@@ -42,10 +45,13 @@ export function renderLoginScreen(container) {
   const form = container.querySelector('#login-form')
   const errorEl = container.querySelector('#login-error')
   const btn = container.querySelector('#login-btn')
+  const resendSection = container.querySelector('#login-resend-section')
+  const resendBtn = container.querySelector('#resend-btn')
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault()
     errorEl.textContent = ''
+    resendSection.style.display = 'none'
 
     const email = form.querySelector('#login-email').value.trim()
     const password = form.querySelector('#login-password').value
@@ -69,10 +75,27 @@ export function renderLoginScreen(container) {
     } catch (err) {
       let message = err.message
       if (err.status === 401) message = 'Invalid email or password.'
-      if (err.status === 403) message = 'Please verify your email address before signing in.'
+      if (err.status === 403) {
+        message = 'Please verify your email address before signing in.'
+        resendSection.style.display = 'block'
+      }
       errorEl.textContent = message
       btn.disabled = false
       btn.textContent = 'Sign In'
+    }
+  })
+
+  resendBtn.addEventListener('click', async () => {
+    const email = form.querySelector('#login-email').value.trim()
+    resendBtn.disabled = true
+    resendBtn.textContent = 'Sending\u2026'
+    errorEl.textContent = ''
+
+    try {
+      await resendVerification({ email })
+      resendSection.innerHTML = '<p class="auth-message">Verification email sent — check your inbox.</p>'
+    } catch (_err) {
+      resendSection.innerHTML = '<p class="auth-message">Could not send email. Please try again later.</p>'
     }
   })
 }

--- a/client/web/src/screens/register.js
+++ b/client/web/src/screens/register.js
@@ -1,5 +1,5 @@
 import { validateRegisterForm } from '../validation.js'
-import { registerUser } from '../api.js'
+import { registerUser, resendVerification } from '../api.js'
 
 /**
  * Render the registration screen into `container`.
@@ -71,16 +71,31 @@ export function renderRegisterScreen(container) {
 
     try {
       await registerUser({ email, username, password })
+      const safeEmail = escapeHtml(email)
       container.innerHTML = `
         <div class="auth-card">
           <h1 class="auth-title">Check your email</h1>
           <p class="auth-message">
-            We've sent a verification link to <strong>${escapeHtml(email)}</strong>.
+            We've sent a verification link to <strong>${safeEmail}</strong>.
             Click the link in that email to activate your account, then sign in.
+          </p>
+          <p class="auth-message" id="resend-status">
+            Didn't receive it?
+            <button type="button" id="resend-btn" class="btn-link">Resend verification email</button>
           </p>
           <p class="auth-link"><a href="#/login">Back to sign in</a></p>
         </div>
       `
+      container.querySelector('#resend-btn').addEventListener('click', async () => {
+        const resendStatus = container.querySelector('#resend-status')
+        resendStatus.textContent = 'Sending\u2026'
+        try {
+          await resendVerification({ email })
+          resendStatus.textContent = 'Verification email resent — check your inbox.'
+        } catch (_err) {
+          resendStatus.textContent = 'Could not send email. Please try again later.'
+        }
+      })
     } catch (err) {
       errorEl.textContent = err.message
       btn.disabled = false

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -10,6 +10,7 @@
 ## ✅ Completed
 
 - [x] `P0` Implement email/password registration with required email verification
+- [x] `P0` Resend verification email flow: `POST /api/auth/resend-verification` + UI prompt on login 403 and registration success screen
 - [x] `P0` Implement login and session management
 - [x] `P0` Apply rate limiting on all authentication endpoints
 - [x] `P1` Build player profile page (username, avatar, career win/loss record, recent 20 games, cosmetics)

--- a/server/auth/registration.js
+++ b/server/auth/registration.js
@@ -117,6 +117,45 @@ export async function verifyEmailToken(db, token) {
 }
 
 /**
+ * Resend the verification email for an unverified account.
+ *
+ * Silently succeeds when the email is not found or already verified to
+ * prevent account enumeration. Deletes any existing token and issues a
+ * fresh one before sending.
+ *
+ * @param {object} db - pg Pool (or compatible query interface)
+ * @param {string} email
+ * @param {(email: string, token: string) => Promise<void>} sendVerificationEmail
+ */
+export async function resendVerificationEmail(db, email, sendVerificationEmail) {
+  const normalizedEmail = email.toLowerCase().trim()
+
+  const result = await db.query(
+    `SELECT id, is_verified FROM players WHERE email = $1`,
+    [normalizedEmail],
+  )
+
+  if (result.rows.length === 0 || result.rows[0].is_verified) {
+    return
+  }
+
+  const playerId = result.rows[0].id
+
+  await db.query(`DELETE FROM email_verification_tokens WHERE player_id = $1`, [playerId])
+
+  const token = generateVerificationToken()
+  const expiresAt = new Date(Date.now() + VERIFICATION_TOKEN_TTL_HOURS * 60 * 60 * 1000)
+
+  await db.query(
+    `INSERT INTO email_verification_tokens (token, player_id, expires_at)
+     VALUES ($1, $2, $3)`,
+    [token, playerId, expiresAt],
+  )
+
+  await sendVerificationEmail(normalizedEmail, token)
+}
+
+/**
  * Check whether a player has verified their email.
  *
  * @param {object} db

--- a/server/server.js
+++ b/server/server.js
@@ -1,4 +1,4 @@
-import { registerPlayer, verifyEmailToken } from './auth/registration.js'
+import { registerPlayer, verifyEmailToken, resendVerificationEmail } from './auth/registration.js'
 import { sendVerificationEmail as defaultMailer } from './auth/email.js'
 import { getPlayerProfile, isValidUuid } from './social/profile.js'
 import { loginPlayer } from './auth/login.js'
@@ -83,6 +83,21 @@ export function handler(app, { mailer, redis, rateLimitConfig } = {}) {
       if (err.code === 'INVALID_TOKEN') return sendJSON(res, 400, { error: err.message })
       if (err.code === 'EXPIRED_TOKEN') return sendJSON(res, 400, { error: err.message })
       console.error('Email verification error:', { error: err.message })
+      sendJSON(res, 500, { error: 'Internal server error' })
+    }
+  })
+
+  // POST /api/auth/resend-verification
+  app.post('/api/auth/resend-verification', authRateLimiter, async (req, res) => {
+    const { email } = req.body ?? {}
+    try {
+      const db = getDb()
+      await resendVerificationEmail(db, email || '', emailer)
+      sendJSON(res, 200, {
+        message: 'If this email is registered and unverified, a new verification link has been sent.',
+      })
+    } catch (err) {
+      console.error('Resend verification error:', { error: err.message })
       sendJSON(res, 500, { error: 'Internal server error' })
     }
   })

--- a/test/unit/auth/registration.test.js
+++ b/test/unit/auth/registration.test.js
@@ -6,6 +6,7 @@ import {
   generateVerificationToken,
   registerPlayer,
   verifyEmailToken,
+  resendVerificationEmail,
 } from '../../../server/auth/registration.js'
 
 describe('hashPassword', () => {
@@ -112,6 +113,65 @@ describe('registerPlayer — input validation', () => {
       async (email) => { capturedEmail = email },
     )
     assert.equal(capturedEmail, 'alice@example.com')
+  })
+})
+
+describe('resendVerificationEmail', () => {
+  it('succeeds silently when email is not found (prevents enumeration)', async () => {
+    const db = {
+      query: async (sql) => {
+        if (sql.includes('SELECT')) return { rows: [] }
+        return { rows: [] }
+      },
+    }
+    const emails = []
+    await resendVerificationEmail(db, 'ghost@example.com', async (email) => emails.push(email))
+    assert.equal(emails.length, 0)
+  })
+
+  it('succeeds silently when player is already verified (prevents enumeration)', async () => {
+    const db = {
+      query: async (sql) => {
+        if (sql.includes('SELECT')) return { rows: [{ id: 'player-1', is_verified: true }] }
+        return { rows: [] }
+      },
+    }
+    const emails = []
+    await resendVerificationEmail(db, 'alice@example.com', async (email) => emails.push(email))
+    assert.equal(emails.length, 0)
+  })
+
+  it('deletes old tokens and sends a new one for unverified player', async () => {
+    const queries = []
+    const db = {
+      query: async (sql, params) => {
+        queries.push({ sql, params })
+        if (sql.includes('SELECT')) return { rows: [{ id: 'player-1', is_verified: false }] }
+        return { rows: [] }
+      },
+    }
+    const emails = []
+    await resendVerificationEmail(db, 'alice@example.com', async (email) => emails.push(email))
+
+    const deleteQuery = queries.find((q) => q.sql.includes('DELETE'))
+    assert.ok(deleteQuery, 'should delete old tokens')
+    assert.equal(emails.length, 1)
+    assert.equal(emails[0], 'alice@example.com')
+  })
+
+  it('normalises email to lowercase before lookup', async () => {
+    const lookups = []
+    const db = {
+      query: async (sql, params) => {
+        if (sql.includes('SELECT')) {
+          lookups.push(params[0])
+          return { rows: [] }
+        }
+        return { rows: [] }
+      },
+    }
+    await resendVerificationEmail(db, 'Alice@EXAMPLE.COM', async () => {})
+    assert.equal(lookups[0], 'alice@example.com')
   })
 })
 

--- a/test/unit/web/api.test.js
+++ b/test/unit/web/api.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { registerUser, loginUser } from '../../../client/web/src/api.js'
+import { registerUser, loginUser, resendVerification } from '../../../client/web/src/api.js'
 
 /**
  * Build a minimal mock fetch that returns the given status and JSON body.
@@ -60,6 +60,26 @@ describe('registerUser', () => {
         ),
       (err) => {
         assert.ok(err.message)
+        return true
+      },
+    )
+  })
+})
+
+describe('resendVerification', () => {
+  it('resolves on 200', async () => {
+    const result = await resendVerification(
+      { email: 'a@b.com' },
+      mockFetch(200, { message: 'If this email is registered and unverified, a new link has been sent.' }),
+    )
+    assert.ok(result.message)
+  })
+
+  it('throws on network/server error', async () => {
+    await assert.rejects(
+      () => resendVerification({ email: 'a@b.com' }, mockFetch(500, { error: 'Internal server error' })),
+      (err) => {
+        assert.equal(err.status, 500)
         return true
       },
     )


### PR DESCRIPTION
Adds a resend verification email flow for users who never received their registration email.

**Backend:** New `resendVerificationEmail` function and `POST /api/auth/resend-verification` endpoint (rate limited, always returns 200 to prevent enumeration).

**UI:** Login screen surfaces a resend button on 403 unverified-email errors; registration success screen includes an inline resend link.

Tests written first (TDD).

Related to #80

Generated with [Claude Code](https://claude.ai/code)