### PR TITLE
feat: redirect verify-email to proper SPA screens #80

### DIFF
--- a/client/web/src/main.js
+++ b/client/web/src/main.js
@@ -1,11 +1,15 @@
 import { addRoute, init } from './router.js'
 import { renderLoginScreen } from './screens/login.js'
 import { renderRegisterScreen } from './screens/register.js'
+import { renderVerifyEmailSuccess, renderVerifyEmailError, renderVerifyEmailExpired } from './screens/verifyEmail.js'
 
 const app = document.getElementById('app')
 
 addRoute('#/login', renderLoginScreen)
 addRoute('#/register', renderRegisterScreen)
+addRoute('#/verify-email-success', renderVerifyEmailSuccess)
+addRoute('#/verify-email-error', renderVerifyEmailError)
+addRoute('#/verify-email-expired', renderVerifyEmailExpired)
 
 // Redirect authenticated users away from auth screens
 if (sessionStorage.getItem('sessionId') && window.location.hash !== '#/lobby') {

--- a/client/web/src/screens/verifyEmail.js
+++ b/client/web/src/screens/verifyEmail.js
@@ -1,0 +1,37 @@
+import { navigate } from '../router.js'
+
+export function renderVerifyEmailSuccess(container) {
+  const card = document.createElement('div')
+  card.className = 'auth-card'
+  card.innerHTML = `
+    <h1 class="auth-title">Email Verified</h1>
+    <p class="auth-message">Your email address has been verified. You can now sign in to Spades Online.</p>
+    <button class="btn-primary" id="go-login">Sign In</button>
+  `
+  container.appendChild(card)
+  card.querySelector('#go-login').addEventListener('click', () => navigate('#/login'))
+}
+
+export function renderVerifyEmailError(container) {
+  const card = document.createElement('div')
+  card.className = 'auth-card'
+  card.innerHTML = `
+    <h1 class="auth-title">Verification Failed</h1>
+    <p class="auth-message">This verification link is invalid or has already been used. Please request a new one from the sign-in page.</p>
+    <button class="btn-primary" id="go-login">Sign In</button>
+  `
+  container.appendChild(card)
+  card.querySelector('#go-login').addEventListener('click', () => navigate('#/login'))
+}
+
+export function renderVerifyEmailExpired(container) {
+  const card = document.createElement('div')
+  card.className = 'auth-card'
+  card.innerHTML = `
+    <h1 class="auth-title">Link Expired</h1>
+    <p class="auth-message">This verification link has expired. Please request a new one from the sign-in page.</p>
+    <button class="btn-primary" id="go-login">Sign In</button>
+  `
+  container.appendChild(card)
+  card.querySelector('#go-login').addEventListener('click', () => navigate('#/login'))
+}

--- a/server/server.js
+++ b/server/server.js
@@ -77,13 +77,14 @@ export function handler(app, { mailer, redis, rateLimitConfig } = {}) {
     try {
       const db = getDb()
       await verifyEmailToken(db, token)
-      sendJSON(res, 200, { message: 'Email verified successfully. You may now log in.' })
+      return res.redirect('/#/verify-email-success')
     } catch (err) {
-      if (err.code === 'VALIDATION_ERROR') return sendJSON(res, 400, { error: err.message })
-      if (err.code === 'INVALID_TOKEN') return sendJSON(res, 400, { error: err.message })
-      if (err.code === 'EXPIRED_TOKEN') return sendJSON(res, 400, { error: err.message })
+      if (err.code === 'EXPIRED_TOKEN') return res.redirect('/#/verify-email-expired')
+      if (err.code === 'VALIDATION_ERROR' || err.code === 'INVALID_TOKEN') {
+        return res.redirect('/#/verify-email-error')
+      }
       console.error('Email verification error:', { error: err.message })
-      sendJSON(res, 500, { error: 'Internal server error' })
+      return res.redirect('/#/verify-email-error')
     }
   })
 

--- a/test/integration/auth/registration.test.js
+++ b/test/integration/auth/registration.test.js
@@ -202,7 +202,7 @@ describe('GET /api/auth/verify-email', { skip }, () => {
     await closeDb()
   })
 
-  it('returns 200 and marks account verified with a valid token', async () => {
+  it('redirects to /#/verify-email-success and marks account verified with a valid token', async () => {
     // Register a player to get a real token
     server.sentEmails.length = 0
     await fetch(`${server.baseUrl}/api/auth/register`, {
@@ -216,8 +216,9 @@ describe('GET /api/auth/verify-email', { skip }, () => {
     })
     const { token } = server.sentEmails[0]
 
-    const res = await fetch(`${server.baseUrl}/api/auth/verify-email?token=${token}`)
-    assert.equal(res.status, 200)
+    const res = await fetch(`${server.baseUrl}/api/auth/verify-email?token=${token}`, { redirect: 'manual' })
+    assert.equal(res.status, 302)
+    assert.ok(res.headers.get('location').includes('/verify-email-success'))
 
     const result = await db.query(
       `SELECT is_verified FROM players WHERE email = $1`,
@@ -226,19 +227,22 @@ describe('GET /api/auth/verify-email', { skip }, () => {
     assert.equal(result.rows[0].is_verified, true)
   })
 
-  it('returns 400 for an invalid token', async () => {
+  it('redirects to /#/verify-email-error for an invalid token', async () => {
     const res = await fetch(
       `${server.baseUrl}/api/auth/verify-email?token=00000000-0000-4000-8000-000000000000`,
+      { redirect: 'manual' },
     )
-    assert.equal(res.status, 400)
+    assert.equal(res.status, 302)
+    assert.ok(res.headers.get('location').includes('/verify-email-error'))
   })
 
-  it('returns 400 when no token is provided', async () => {
-    const res = await fetch(`${server.baseUrl}/api/auth/verify-email`)
-    assert.equal(res.status, 400)
+  it('redirects to /#/verify-email-error when no token is provided', async () => {
+    const res = await fetch(`${server.baseUrl}/api/auth/verify-email`, { redirect: 'manual' })
+    assert.equal(res.status, 302)
+    assert.ok(res.headers.get('location').includes('/verify-email-error'))
   })
 
-  it('returns 400 when the same token is used twice (single use)', async () => {
+  it('redirects to /#/verify-email-error when the same token is used twice (single use)', async () => {
     server.sentEmails.length = 0
     await fetch(`${server.baseUrl}/api/auth/register`, {
       method: 'POST',
@@ -251,8 +255,9 @@ describe('GET /api/auth/verify-email', { skip }, () => {
     })
     const { token } = server.sentEmails[0]
 
-    await fetch(`${server.baseUrl}/api/auth/verify-email?token=${token}`)
-    const res = await fetch(`${server.baseUrl}/api/auth/verify-email?token=${token}`)
-    assert.equal(res.status, 400)
+    await fetch(`${server.baseUrl}/api/auth/verify-email?token=${token}`, { redirect: 'manual' })
+    const res = await fetch(`${server.baseUrl}/api/auth/verify-email?token=${token}`, { redirect: 'manual' })
+    assert.equal(res.status, 302)
+    assert.ok(res.headers.get('location').includes('/verify-email-error'))
   })
 })


### PR DESCRIPTION
The GET /api/auth/verify-email endpoint was returning raw JSON after a successful verification, leaving users on a bare page.

It now redirects to the SPA:
- Valid token → `#/verify-email-success` (styled card with Sign In button)
- Invalid/already-used token → `#/verify-email-error`
- Expired token → `#/verify-email-expired`

Related to #80

Generated with [Claude Code](https://claude.ai/code)