### PR TITLE
fix: use north's dealt card to reliably test 'card not in hand'

### DIFF
--- a/test/unit/game/state.test.js
+++ b/test/unit/game/state.test.js
@@ -179,8 +179,14 @@ describe('playCard', () => {
 
   it('throws if card not in hand', () => {
     let state = getToPlayingPhase()
+    // Use a card from north's hand — since all 52 cards are dealt to exactly one
+    // player, any card in north's hand is guaranteed not to be in east's hand.
+    // Hardcoding a specific card (e.g. 2♠) is unreliable because the shuffle is
+    // random and east holds the 2♠ ~25% of the time, causing this test to fail
+    // intermittently with "Illegal play" instead of "not in hand".
+    const cardNotInEastsHand = state.hands.north[0]
     assert.throws(
-      () => playCard(state, 'east', { suit: 'spades', rank: '2' }),
+      () => playCard(state, 'east', cardNotInEastsHand),
       /not in hand|invalid card/i,
     )
   })


### PR DESCRIPTION
The "throws if card not in hand" test in `test/unit/game/state.test.js` hardcoded the 2♠ as the card expected to be absent from east's hand. Since the deck is shuffled randomly, east holds it ~25% of the time, causing the test to throw "Illegal play" instead of "not in hand" and fail intermittently.

Fix: reference `state.hands.north[0]` instead — a card in north's hand is guaranteed not to be in east's hand regardless of shuffle order.

Closes #64

Generated with [Claude Code](https://claude.ai/code)