### PR TITLE
feat: forgot password flow with reset screens #80

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ All routes are under `/api/`. Responses always use `{ ... }` JSON. Auth routes u
 | `POST` | `/api/auth/register` | Register with email, username, password. Sends a verification email. |
 | `GET` | `/api/auth/verify-email?token=<uuid>` | Verify email address using the token from the registration email. |
 | `POST` | `/api/auth/resend-verification` | Resend the verification email to an unverified account. Always returns 200 regardless of whether the email exists (prevents enumeration). |
+| `POST` | `/api/auth/forgot-password` | Request a password reset email. Always returns 200 (prevents enumeration). |
+| `POST` | `/api/auth/reset-password` | Reset password using a valid reset token from the email. |
 
 #### `POST /api/auth/register`
 
@@ -155,13 +157,46 @@ All routes are under `/api/`. Responses always use `{ ... }` JSON. Auth routes u
 
 > Note: A `200` is returned even when the email is not found or the account is already verified. This prevents account enumeration.
 
+#### `POST /api/auth/forgot-password`
+
+**Body**
+```json
+{ "email": "alice@example.com" }
+```
+
+**Responses**
+
+| Status | Meaning |
+|---|---|
+| `200` | Request accepted. If the email is registered, a reset link has been sent. |
+| `500` | Internal server error |
+
+> Note: Always returns `200` regardless of whether the email exists (prevents enumeration). The reset link expires in 1 hour.
+
+#### `POST /api/auth/reset-password`
+
+**Body**
+```json
+{ "token": "<reset-token-from-email>", "newPassword": "newpassword123" }
+```
+
+**Responses**
+
+| Status | Meaning |
+|---|---|
+| `200` | Password updated. Player can now sign in with the new password. |
+| `400` | Missing/invalid token, expired token, or password too short |
+| `500` | Internal server error |
+
 ## Web UI
 
 The web client is served as static files from `client/web/` by the Express server. Open `http://localhost:3000` in a browser after starting the server.
 
 Current screens:
-- **Sign In** (`#/login`) — email + password login; shows a "Resend verification email" button when login fails with an unverified email error
+- **Sign In** (`#/login`) — email + password login; shows a "Resend verification email" button when login fails with an unverified email error; includes a "Forgot your password?" link
 - **Create Account** (`#/register`) — registration with email, username, and password; shows a verification prompt on success with a "Resend verification email" button
+- **Forgot Password** (`#/forgot-password`) — email input form; shows a "check your email" confirmation on submit (always, to prevent enumeration)
+- **Reset Password** (`#/reset-password?token=<uuid>`) — new password form; shows success screen on completion or an error screen for invalid/expired links
 
 On successful login the session is stored in `sessionStorage` (`sessionId`, `playerId`, `username`) and the player is routed to `#/lobby` (lobby screen, coming in a later slice).
 
@@ -177,21 +212,25 @@ client/
       validation.js   — Pure form-validation helpers (shared with unit tests)
       api.js          — Fetch wrappers for auth API endpoints
       screens/
-        login.js      — Sign-in screen
-        register.js   — Registration screen
+        login.js          — Sign-in screen
+        register.js       — Registration screen
+        forgotPassword.js — Forgot password request screen
+        resetPassword.js  — Reset password form and landing screens
 server/
   app.js          — Express entry point (also serves client/web as static)
   server.js       — All API route handlers
   db.js           — Shared PostgreSQL pool
   auth/
-    registration.js — Registration and email-verification logic
-    email.js        — Verification email builder and sender
+    registration.js  — Registration and email-verification logic
+    passwordReset.js — Forgot/reset password logic
+    email.js         — Email builders and senders (verification + password reset)
   social/
     profile.js      — Player profile data access
 db/
   migrations/
     001_create_players.sql
     002_create_profile_and_games.sql
+    003_create_password_reset_tokens.sql
 test/
   unit/
     auth/           — Pure logic tests (no DB required)

--- a/client/web/src/api.js
+++ b/client/web/src/api.js
@@ -50,6 +50,49 @@ export async function resendVerification({ email }, fetchFn = globalThis.fetch) 
 }
 
 /**
+ * Request a password reset email for the given address.
+ * Always resolves — the server does not reveal whether the email exists.
+ * @param {{ email: string }} data
+ * @param {typeof fetch} [fetchFn]
+ * @returns {Promise<{ message: string }>}
+ */
+export async function forgotPassword({ email }, fetchFn = globalThis.fetch) {
+  const res = await fetchFn('/api/auth/forgot-password', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email }),
+  })
+  const body = await res.json()
+  if (!res.ok) {
+    const err = new Error(body.error || 'Failed to send reset email.')
+    err.status = res.status
+    throw err
+  }
+  return body
+}
+
+/**
+ * Reset a player's password using a valid reset token.
+ * @param {{ token: string, newPassword: string }} data
+ * @param {typeof fetch} [fetchFn]
+ * @returns {Promise<{ message: string }>}
+ */
+export async function resetPassword({ token, newPassword }, fetchFn = globalThis.fetch) {
+  const res = await fetchFn('/api/auth/reset-password', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token, newPassword }),
+  })
+  const body = await res.json()
+  if (!res.ok) {
+    const err = new Error(body.error || 'Failed to reset password.')
+    err.status = res.status
+    throw err
+  }
+  return body
+}
+
+/**
  * Log in with email and password.
  * @param {{ email: string, password: string }} data
  * @param {typeof fetch} [fetchFn]

--- a/client/web/src/main.js
+++ b/client/web/src/main.js
@@ -2,6 +2,8 @@ import { addRoute, init } from './router.js'
 import { renderLoginScreen } from './screens/login.js'
 import { renderRegisterScreen } from './screens/register.js'
 import { renderVerifyEmailSuccess, renderVerifyEmailError, renderVerifyEmailExpired } from './screens/verifyEmail.js'
+import { renderForgotPasswordScreen } from './screens/forgotPassword.js'
+import { renderResetPasswordScreen } from './screens/resetPassword.js'
 
 const app = document.getElementById('app')
 
@@ -10,6 +12,8 @@ addRoute('#/register', renderRegisterScreen)
 addRoute('#/verify-email-success', renderVerifyEmailSuccess)
 addRoute('#/verify-email-error', renderVerifyEmailError)
 addRoute('#/verify-email-expired', renderVerifyEmailExpired)
+addRoute('#/forgot-password', renderForgotPasswordScreen)
+addRoute('#/reset-password', renderResetPasswordScreen)
 
 // Redirect authenticated users away from auth screens
 if (sessionStorage.getItem('sessionId') && window.location.hash !== '#/lobby') {

--- a/client/web/src/router.js
+++ b/client/web/src/router.js
@@ -34,7 +34,8 @@ export function navigate(hash) {
 export function init(container) {
   function render() {
     const hash = window.location.hash || '#/login'
-    const fn = routes[hash] ?? routes['#/login']
+    const route = hash.split('?')[0]
+    const fn = routes[route] ?? routes['#/login']
     if (fn) {
       container.innerHTML = ''
       fn(container)

--- a/client/web/src/screens/forgotPassword.js
+++ b/client/web/src/screens/forgotPassword.js
@@ -1,0 +1,75 @@
+import { forgotPassword } from '../api.js'
+import { navigate } from '../router.js'
+
+/**
+ * Render the forgot password screen into `container`.
+ * On submit, sends a reset email (or silently succeeds if email not found).
+ * @param {HTMLElement} container
+ */
+export function renderForgotPasswordScreen(container) {
+  container.innerHTML = `
+    <div class="auth-card">
+      <h1 class="auth-title">Forgot Password</h1>
+      <p class="auth-message">Enter your email address and we'll send you a link to reset your password.</p>
+      <form id="forgot-form" novalidate>
+        <div class="form-group">
+          <label for="forgot-email">Email</label>
+          <input
+            type="email"
+            id="forgot-email"
+            name="email"
+            autocomplete="email"
+            placeholder="you@example.com"
+          />
+        </div>
+        <div class="form-error" id="forgot-error" role="alert" aria-live="polite"></div>
+        <button type="submit" id="forgot-btn" class="btn-primary">Send Reset Link</button>
+      </form>
+      <p class="auth-link"><a href="#/login">Back to sign in</a></p>
+    </div>
+  `
+
+  const form = container.querySelector('#forgot-form')
+  const errorEl = container.querySelector('#forgot-error')
+  const btn = container.querySelector('#forgot-btn')
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault()
+    errorEl.textContent = ''
+
+    const email = form.querySelector('#forgot-email').value.trim()
+    if (!email) {
+      errorEl.textContent = 'Please enter your email address.'
+      return
+    }
+
+    btn.disabled = true
+    btn.textContent = 'Sending\u2026'
+
+    try {
+      await forgotPassword({ email })
+      container.innerHTML = `
+        <div class="auth-card">
+          <h1 class="auth-title">Check your email</h1>
+          <p class="auth-message">
+            If <strong>${escapeHtml(email)}</strong> is registered, you'll receive a password reset link shortly.
+            Check your spam folder if it doesn't arrive.
+          </p>
+          <p class="auth-link"><a href="#/login">Back to sign in</a></p>
+        </div>
+      `
+    } catch (_err) {
+      errorEl.textContent = 'Something went wrong. Please try again later.'
+      btn.disabled = false
+      btn.textContent = 'Send Reset Link'
+    }
+  })
+}
+
+function escapeHtml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}

--- a/client/web/src/screens/login.js
+++ b/client/web/src/screens/login.js
@@ -39,6 +39,7 @@ export function renderLoginScreen(container) {
         <button type="submit" id="login-btn" class="btn-primary">Sign In</button>
       </form>
       <p class="auth-link">Don't have an account? <a href="#/register">Create one</a></p>
+      <p class="auth-link"><a href="#/forgot-password">Forgot your password?</a></p>
     </div>
   `
 

--- a/client/web/src/screens/resetPassword.js
+++ b/client/web/src/screens/resetPassword.js
@@ -1,0 +1,133 @@
+import { resetPassword } from '../api.js'
+import { navigate } from '../router.js'
+
+/**
+ * Extract the reset token from the hash query string.
+ * e.g. window.location.hash = '#/reset-password?token=abc123' → 'abc123'
+ * @returns {string|null}
+ */
+function getTokenFromHash() {
+  const hash = window.location.hash || ''
+  const queryIndex = hash.indexOf('?')
+  if (queryIndex === -1) return null
+  const params = new URLSearchParams(hash.slice(queryIndex + 1))
+  return params.get('token')
+}
+
+/**
+ * Render the reset password screen into `container`.
+ * Reads the token from the URL hash, shows a new password form.
+ * @param {HTMLElement} container
+ */
+export function renderResetPasswordScreen(container) {
+  const token = getTokenFromHash()
+
+  if (!token) {
+    container.innerHTML = `
+      <div class="auth-card">
+        <h1 class="auth-title">Invalid Link</h1>
+        <p class="auth-message">This password reset link is invalid. Please request a new one.</p>
+        <button class="btn-primary" id="go-forgot">Request Password Reset</button>
+      </div>
+    `
+    container.querySelector('#go-forgot').addEventListener('click', () => navigate('#/forgot-password'))
+    return
+  }
+
+  container.innerHTML = `
+    <div class="auth-card">
+      <h1 class="auth-title">Reset Password</h1>
+      <form id="reset-form" novalidate>
+        <div class="form-group">
+          <label for="reset-password">New Password</label>
+          <input
+            type="password"
+            id="reset-password"
+            name="newPassword"
+            autocomplete="new-password"
+            placeholder="At least 8 characters"
+          />
+        </div>
+        <div class="form-group">
+          <label for="reset-confirm">Confirm Password</label>
+          <input
+            type="password"
+            id="reset-confirm"
+            name="confirmPassword"
+            autocomplete="new-password"
+            placeholder="Repeat your new password"
+          />
+        </div>
+        <div class="form-error" id="reset-error" role="alert" aria-live="polite"></div>
+        <button type="submit" id="reset-btn" class="btn-primary">Set New Password</button>
+      </form>
+      <p class="auth-link"><a href="#/login">Back to sign in</a></p>
+    </div>
+  `
+
+  const form = container.querySelector('#reset-form')
+  const errorEl = container.querySelector('#reset-error')
+  const btn = container.querySelector('#reset-btn')
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault()
+    errorEl.textContent = ''
+
+    const newPassword = form.querySelector('#reset-password').value
+    const confirmPassword = form.querySelector('#reset-confirm').value
+
+    if (newPassword.length < 8) {
+      errorEl.textContent = 'Password must be at least 8 characters.'
+      return
+    }
+    if (newPassword !== confirmPassword) {
+      errorEl.textContent = 'Passwords do not match.'
+      return
+    }
+
+    btn.disabled = true
+    btn.textContent = 'Saving\u2026'
+
+    try {
+      await resetPassword({ token, newPassword })
+      container.innerHTML = `
+        <div class="auth-card">
+          <h1 class="auth-title">Password Reset</h1>
+          <p class="auth-message">Your password has been reset successfully. You can now sign in with your new password.</p>
+          <button class="btn-primary" id="go-login">Sign In</button>
+        </div>
+      `
+      container.querySelector('#go-login').addEventListener('click', () => navigate('#/login'))
+    } catch (err) {
+      let message = 'Something went wrong. Please try again later.'
+      if (err.status === 400) {
+        if (err.message.includes('expired')) {
+          message = 'This reset link has expired.'
+        } else {
+          message = 'This reset link is invalid or has already been used.'
+        }
+        container.innerHTML = `
+          <div class="auth-card">
+            <h1 class="auth-title">Link No Longer Valid</h1>
+            <p class="auth-message">${escapeHtml(message)}</p>
+            <button class="btn-primary" id="go-forgot">Request a New Link</button>
+            <p class="auth-link"><a href="#/login">Back to sign in</a></p>
+          </div>
+        `
+        container.querySelector('#go-forgot').addEventListener('click', () => navigate('#/forgot-password'))
+        return
+      }
+      errorEl.textContent = message
+      btn.disabled = false
+      btn.textContent = 'Set New Password'
+    }
+  })
+}
+
+function escapeHtml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}

--- a/db/migrations/003_create_password_reset_tokens.sql
+++ b/db/migrations/003_create_password_reset_tokens.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS password_reset_tokens (
+  token TEXT PRIMARY KEY,
+  player_id UUID NOT NULL REFERENCES players(id) ON DELETE CASCADE,
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_player_id
+  ON password_reset_tokens (player_id);

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -11,6 +11,7 @@
 
 - [x] `P0` Implement email/password registration with required email verification
 - [x] `P0` Resend verification email flow: `POST /api/auth/resend-verification` + UI prompt on login 403 and registration success screen
+- [x] `P0` Forgot password flow: `POST /api/auth/forgot-password`, `POST /api/auth/reset-password`, forgot/reset password screens with proper success/error landing pages
 - [x] `P0` Implement login and session management
 - [x] `P0` Apply rate limiting on all authentication endpoints
 - [x] `P1` Build player profile page (username, avatar, career win/loss record, recent 20 games, cosmetics)

--- a/server/auth/email.js
+++ b/server/auth/email.js
@@ -58,6 +58,49 @@ function createTransport() {
 }
 
 /**
+ * Build the subject, plain-text, and HTML content for a password reset email.
+ *
+ * @param {string} token
+ * @param {string} appUrl - Public base URL of the application (no trailing slash)
+ * @returns {{ subject: string, text: string, html: string }}
+ */
+export function buildPasswordResetEmailContent(token, appUrl) {
+  const resetUrl = `${appUrl}/#/reset-password?token=${token}`
+
+  const subject = 'Reset your Spades Online password'
+
+  const text = [
+    'You requested a password reset for your Spades Online account.',
+    '',
+    'Click the link below to set a new password:',
+    '',
+    resetUrl,
+    '',
+    'This link expires in 1 hour.',
+    '',
+    'If you did not request a password reset, you can safely ignore this email.',
+  ].join('\n')
+
+  const html = `
+    <p>You requested a password reset for your <strong>Spades Online</strong> account.</p>
+    <p>Click the button below to set a new password:</p>
+    <p>
+      <a href="${resetUrl}"
+         style="display:inline-block;padding:10px 20px;background:#1a73e8;color:#fff;
+                text-decoration:none;border-radius:4px;font-weight:bold;">
+        Reset Password
+      </a>
+    </p>
+    <p>Or copy and paste this URL into your browser:</p>
+    <p>${resetUrl}</p>
+    <p>This link expires in 1 hour.</p>
+    <p><small>If you did not request a password reset, you can safely ignore this email.</small></p>
+  `.trim()
+
+  return { subject, text, html }
+}
+
+/**
  * Send a verification email to the given address.
  * Falls back to console logging when EMAIL_HOST is not configured.
  *
@@ -76,6 +119,32 @@ export async function sendVerificationEmail(toEmail, token) {
       to: toEmail,
       subject,
       verificationUrl: `${appUrl}/api/auth/verify-email?token=${token}`,
+    })
+    return
+  }
+
+  await transport.sendMail({ from: fromAddress, to: toEmail, subject, text, html })
+}
+
+/**
+ * Send a password reset email to the given address.
+ * Falls back to console logging when EMAIL_HOST is not configured.
+ *
+ * @param {string} toEmail
+ * @param {string} token
+ */
+export async function sendPasswordResetEmail(toEmail, token) {
+  const appUrl = (process.env.APP_URL || 'http://localhost:3000').replace(/\/$/, '')
+  const fromAddress = process.env.EMAIL_FROM || 'noreply@spades.online'
+  const { subject, text, html } = buildPasswordResetEmailContent(token, appUrl)
+
+  const transport = createTransport()
+
+  if (!transport) {
+    console.log('Password reset email (EMAIL_HOST not configured — logging instead):', {
+      to: toEmail,
+      subject,
+      resetUrl: `${appUrl}/#/reset-password?token=${token}`,
     })
     return
   }

--- a/server/auth/passwordReset.js
+++ b/server/auth/passwordReset.js
@@ -1,0 +1,85 @@
+import { v4 as uuidv4 } from 'uuid'
+import { hashPassword } from './registration.js'
+
+const RESET_TOKEN_TTL_HOURS = 1
+
+export function generateResetToken() {
+  return uuidv4()
+}
+
+/**
+ * Initiate a password reset for the given email address.
+ *
+ * Silently succeeds when the email is not found to prevent account enumeration.
+ * Deletes any existing reset token for the player before issuing a new one.
+ *
+ * @param {object} db - pg Pool (or compatible query interface)
+ * @param {string} email
+ * @param {(email: string, token: string) => Promise<void>} sendPasswordResetEmail
+ */
+export async function forgotPassword(db, email, sendPasswordResetEmail) {
+  const normalizedEmail = email.toLowerCase().trim()
+
+  const result = await db.query(
+    `SELECT id FROM players WHERE email = $1`,
+    [normalizedEmail],
+  )
+
+  if (result.rows.length === 0) {
+    return
+  }
+
+  const playerId = result.rows[0].id
+
+  await db.query(`DELETE FROM password_reset_tokens WHERE player_id = $1`, [playerId])
+
+  const token = generateResetToken()
+  const expiresAt = new Date(Date.now() + RESET_TOKEN_TTL_HOURS * 60 * 60 * 1000)
+
+  await db.query(
+    `INSERT INTO password_reset_tokens (token, player_id, expires_at) VALUES ($1, $2, $3)`,
+    [token, playerId, expiresAt],
+  )
+
+  await sendPasswordResetEmail(normalizedEmail, token)
+}
+
+/**
+ * Reset the password for the player associated with the given reset token.
+ *
+ * @param {object} db - pg Pool (or compatible query interface)
+ * @param {string} token
+ * @param {string} newPassword
+ * @returns {{ playerId: string }}
+ */
+export async function resetPassword(db, token, newPassword) {
+  if (!token) {
+    throw Object.assign(new Error('token is required'), { code: 'VALIDATION_ERROR' })
+  }
+  if (!newPassword || newPassword.length < 8) {
+    throw Object.assign(new Error('password must be at least 8 characters'), {
+      code: 'VALIDATION_ERROR',
+    })
+  }
+
+  const result = await db.query(
+    `SELECT player_id, expires_at FROM password_reset_tokens WHERE token = $1`,
+    [token],
+  )
+
+  if (result.rows.length === 0) {
+    throw Object.assign(new Error('invalid or already used reset token'), { code: 'INVALID_TOKEN' })
+  }
+
+  const { player_id, expires_at } = result.rows[0]
+
+  if (new Date() > new Date(expires_at)) {
+    throw Object.assign(new Error('reset token has expired'), { code: 'EXPIRED_TOKEN' })
+  }
+
+  const passwordHash = await hashPassword(newPassword)
+  await db.query(`UPDATE players SET password_hash = $1 WHERE id = $2`, [passwordHash, player_id])
+  await db.query(`DELETE FROM password_reset_tokens WHERE token = $1`, [token])
+
+  return { playerId: player_id }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,5 +1,6 @@
 import { registerPlayer, verifyEmailToken, resendVerificationEmail } from './auth/registration.js'
-import { sendVerificationEmail as defaultMailer } from './auth/email.js'
+import { forgotPassword, resetPassword } from './auth/passwordReset.js'
+import { sendVerificationEmail as defaultMailer, sendPasswordResetEmail as defaultPasswordResetMailer } from './auth/email.js'
 import { getPlayerProfile, isValidUuid } from './social/profile.js'
 import { loginPlayer } from './auth/login.js'
 import { createSession, deleteSession, validateAuthHeaders } from './auth/session.js'
@@ -28,8 +29,9 @@ function sendJSON(res, statusCode, data) {
  * @param {import('express').Application} app
  * @param {{ mailer?: (email: string, token: string) => Promise<void>, redis?: object, rateLimitConfig?: { max?: number, windowSecs?: number } }} [opts]
  */
-export function handler(app, { mailer, redis, rateLimitConfig } = {}) {
+export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConfig } = {}) {
   const emailer = mailer ?? defaultMailer
+  const passwordResetEmailer = passwordResetMailer ?? defaultPasswordResetMailer
   const authRateLimiter = createRateLimiter(redis ?? null, {
     keyPrefix: 'auth',
     ...rateLimitConfig,
@@ -121,6 +123,37 @@ export function handler(app, { mailer, redis, rateLimitConfig } = {}) {
       if (err.code === 'INVALID_CREDENTIALS') return sendJSON(res, 401, { error: err.message })
       if (err.code === 'UNVERIFIED_EMAIL') return sendJSON(res, 403, { error: err.message })
       console.error('Login error:', { error: err.message })
+      sendJSON(res, 500, { error: 'Internal server error' })
+    }
+  })
+
+  // POST /api/auth/forgot-password
+  app.post('/api/auth/forgot-password', authRateLimiter, async (req, res) => {
+    const { email } = req.body ?? {}
+    try {
+      const db = getDb()
+      await forgotPassword(db, email || '', passwordResetEmailer)
+      sendJSON(res, 200, {
+        message: 'If that email address is registered, you will receive a password reset link shortly.',
+      })
+    } catch (err) {
+      console.error('Forgot password error:', { error: err.message })
+      sendJSON(res, 500, { error: 'Internal server error' })
+    }
+  })
+
+  // POST /api/auth/reset-password
+  app.post('/api/auth/reset-password', authRateLimiter, async (req, res) => {
+    const { token, newPassword } = req.body ?? {}
+    try {
+      const db = getDb()
+      await resetPassword(db, token, newPassword)
+      sendJSON(res, 200, { message: 'Password reset successfully. You may now sign in.' })
+    } catch (err) {
+      if (err.code === 'VALIDATION_ERROR') return sendJSON(res, 400, { error: err.message })
+      if (err.code === 'INVALID_TOKEN') return sendJSON(res, 400, { error: err.message })
+      if (err.code === 'EXPIRED_TOKEN') return sendJSON(res, 400, { error: err.message })
+      console.error('Reset password error:', { error: err.message })
       sendJSON(res, 500, { error: 'Internal server error' })
     }
   })

--- a/test/unit/auth/email.test.js
+++ b/test/unit/auth/email.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { buildVerificationEmailContent } from '../../../server/auth/email.js'
+import { buildVerificationEmailContent, buildPasswordResetEmailContent } from '../../../server/auth/email.js'
 
 describe('buildVerificationEmailContent', () => {
   it('includes the full verification URL in the plain-text body', () => {
@@ -31,5 +31,37 @@ describe('buildVerificationEmailContent', () => {
   it('mentions the 24-hour expiry window', () => {
     const { text } = buildVerificationEmailContent('tok', 'https://example.com')
     assert.ok(text.includes('24 hours'), 'should tell the user the link expires in 24 hours')
+  })
+})
+
+describe('buildPasswordResetEmailContent', () => {
+  it('includes the full reset URL in the plain-text body', () => {
+    const token = 'reset-token-123'
+    const appUrl = 'https://spades.example.com'
+    const { text } = buildPasswordResetEmailContent(token, appUrl)
+    assert.ok(
+      text.includes(`${appUrl}/#/reset-password?token=${token}`),
+      'plain text should contain the reset URL',
+    )
+  })
+
+  it('includes the full reset URL in the HTML body', () => {
+    const token = 'reset-token-123'
+    const appUrl = 'https://spades.example.com'
+    const { html } = buildPasswordResetEmailContent(token, appUrl)
+    assert.ok(
+      html.includes(`${appUrl}/#/reset-password?token=${token}`),
+      'HTML body should contain the reset URL',
+    )
+  })
+
+  it('has a non-empty subject line', () => {
+    const { subject } = buildPasswordResetEmailContent('tok', 'https://example.com')
+    assert.ok(typeof subject === 'string' && subject.length > 0)
+  })
+
+  it('mentions the 1-hour expiry window', () => {
+    const { text } = buildPasswordResetEmailContent('tok', 'https://example.com')
+    assert.ok(text.includes('1 hour'), 'should tell the user the link expires in 1 hour')
   })
 })

--- a/test/unit/auth/passwordReset.test.js
+++ b/test/unit/auth/passwordReset.test.js
@@ -1,0 +1,137 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { forgotPassword, resetPassword } from '../../../server/auth/passwordReset.js'
+
+describe('forgotPassword', () => {
+  it('succeeds silently when email is not found (prevents enumeration)', async () => {
+    const db = {
+      query: async (sql) => {
+        if (sql.includes('SELECT')) return { rows: [] }
+        return { rows: [] }
+      },
+    }
+    const emails = []
+    await forgotPassword(db, 'ghost@example.com', async (email) => emails.push(email))
+    assert.equal(emails.length, 0)
+  })
+
+  it('deletes old tokens, creates a new one, and sends email for existing player', async () => {
+    const queries = []
+    const db = {
+      query: async (sql, params) => {
+        queries.push({ sql, params })
+        if (sql.includes('SELECT id FROM players')) {
+          return { rows: [{ id: 'player-1' }] }
+        }
+        return { rows: [] }
+      },
+    }
+    const emails = []
+    await forgotPassword(db, 'alice@example.com', async (email) => emails.push(email))
+
+    const deleteQuery = queries.find((q) => q.sql.includes('DELETE'))
+    assert.ok(deleteQuery, 'should delete old reset tokens')
+
+    const insertQuery = queries.find((q) => q.sql.includes('INSERT INTO password_reset_tokens'))
+    assert.ok(insertQuery, 'should insert a new reset token')
+
+    assert.equal(emails.length, 1)
+    assert.equal(emails[0], 'alice@example.com')
+  })
+
+  it('normalises email to lowercase before lookup', async () => {
+    const lookups = []
+    const db = {
+      query: async (sql, params) => {
+        if (sql.includes('SELECT')) {
+          lookups.push(params[0])
+          return { rows: [] }
+        }
+        return { rows: [] }
+      },
+    }
+    await forgotPassword(db, 'Alice@EXAMPLE.COM', async () => {})
+    assert.equal(lookups[0], 'alice@example.com')
+  })
+})
+
+describe('resetPassword', () => {
+  it('throws VALIDATION_ERROR when token is missing', async () => {
+    const db = {}
+    await assert.rejects(
+      () => resetPassword(db, undefined, 'newpassword123'),
+      (err) => {
+        assert.equal(err.code, 'VALIDATION_ERROR')
+        return true
+      },
+    )
+  })
+
+  it('throws VALIDATION_ERROR when new password is too short', async () => {
+    const db = {}
+    await assert.rejects(
+      () => resetPassword(db, 'some-token', 'short'),
+      (err) => {
+        assert.equal(err.code, 'VALIDATION_ERROR')
+        return true
+      },
+    )
+  })
+
+  it('throws INVALID_TOKEN when token is not found', async () => {
+    const db = {
+      query: async () => ({ rows: [] }),
+    }
+    await assert.rejects(
+      () => resetPassword(db, 'nonexistent-token', 'newpassword123'),
+      (err) => {
+        assert.equal(err.code, 'INVALID_TOKEN')
+        return true
+      },
+    )
+  })
+
+  it('throws EXPIRED_TOKEN when token is past its expiry', async () => {
+    const db = {
+      query: async (sql) => {
+        if (sql.includes('SELECT')) {
+          return {
+            rows: [{ player_id: 'player-1', expires_at: new Date(Date.now() - 1000) }],
+          }
+        }
+        return { rows: [] }
+      },
+    }
+    await assert.rejects(
+      () => resetPassword(db, 'expired-token', 'newpassword123'),
+      (err) => {
+        assert.equal(err.code, 'EXPIRED_TOKEN')
+        return true
+      },
+    )
+  })
+
+  it('updates the password hash and deletes the token on success', async () => {
+    const queries = []
+    const db = {
+      query: async (sql, params) => {
+        queries.push({ sql, params })
+        if (sql.includes('SELECT')) {
+          return {
+            rows: [{ player_id: 'player-1', expires_at: new Date(Date.now() + 3600 * 1000) }],
+          }
+        }
+        return { rows: [] }
+      },
+    }
+    const result = await resetPassword(db, 'valid-token', 'newpassword123')
+
+    const updateQuery = queries.find((q) => q.sql.includes('UPDATE players'))
+    assert.ok(updateQuery, 'should update the player password')
+
+    const deleteQuery = queries.find((q) => q.sql.includes('DELETE FROM password_reset_tokens'))
+    assert.ok(deleteQuery, 'should delete the used token')
+
+    assert.equal(result.playerId, 'player-1')
+  })
+})

--- a/test/unit/web/api.test.js
+++ b/test/unit/web/api.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { registerUser, loginUser, resendVerification } from '../../../client/web/src/api.js'
+import { registerUser, loginUser, resendVerification, forgotPassword, resetPassword } from '../../../client/web/src/api.js'
 
 /**
  * Build a minimal mock fetch that returns the given status and JSON body.
@@ -80,6 +80,50 @@ describe('resendVerification', () => {
       () => resendVerification({ email: 'a@b.com' }, mockFetch(500, { error: 'Internal server error' })),
       (err) => {
         assert.equal(err.status, 500)
+        return true
+      },
+    )
+  })
+})
+
+describe('forgotPassword', () => {
+  it('resolves on 200', async () => {
+    const result = await forgotPassword(
+      { email: 'a@b.com' },
+      mockFetch(200, { message: 'If that email is registered, a reset link has been sent.' }),
+    )
+    assert.ok(result.message)
+  })
+
+  it('throws on server error', async () => {
+    await assert.rejects(
+      () => forgotPassword({ email: 'a@b.com' }, mockFetch(500, { error: 'Internal server error' })),
+      (err) => {
+        assert.equal(err.status, 500)
+        return true
+      },
+    )
+  })
+})
+
+describe('resetPassword', () => {
+  it('resolves with message on 200', async () => {
+    const result = await resetPassword(
+      { token: 'valid-token', newPassword: 'newpassword123' },
+      mockFetch(200, { message: 'Password reset successfully. You may now sign in.' }),
+    )
+    assert.ok(result.message)
+  })
+
+  it('throws with status 400 on invalid or expired token', async () => {
+    await assert.rejects(
+      () =>
+        resetPassword(
+          { token: 'bad-token', newPassword: 'newpassword123' },
+          mockFetch(400, { error: 'invalid or already used reset token' }),
+        ),
+      (err) => {
+        assert.equal(err.status, 400)
         return true
       },
     )


### PR DESCRIPTION
Adds a full forgot/reset password flow.

**Backend:** `server/auth/passwordReset.js`, email builders, two new rate-limited endpoints (`POST /api/auth/forgot-password`, `POST /api/auth/reset-password`), and migration `003_create_password_reset_tokens.sql`.

**Web client:** `#/forgot-password` screen and `#/reset-password?token=xxx` screen with success/error landing, hash router updated to strip query params, "Forgot your password?" link on login screen.

**Tests (TDD):** `passwordReset.test.js`, updated `email.test.js` and `api.test.js`.

Related to #80

Generated with [Claude Code](https://claude.ai/code)) • [`claude/issue-80-20260331-2023`](https://github.com/dantonel/spades/tree/claude/issue-80-20260331-2023