### PR TITLE
feat: create table screen with optional name (issue #81)

### DIFF
--- a/client/web/index.html
+++ b/client/web/index.html
@@ -173,6 +173,19 @@
       .auth-resend {
         margin-bottom: 0.75rem;
       }
+
+      .lobby-actions {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        margin-top: 1.5rem;
+      }
+
+      .field-optional {
+        font-weight: 400;
+        color: #666;
+        font-size: 0.8rem;
+      }
     </style>
   </head>
   <body>

--- a/client/web/src/api.js
+++ b/client/web/src/api.js
@@ -93,6 +93,31 @@ export async function resetPassword({ token, newPassword }, fetchFn = globalThis
 }
 
 /**
+ * Create a new table. Requires a valid session.
+ * @param {{ name?: string, sessionId: string, playerId: string }} data
+ * @param {typeof fetch} [fetchFn]
+ * @returns {Promise<{ tableId: string, name: string|null }>}
+ */
+export async function createTable({ name, sessionId, playerId }, fetchFn = globalThis.fetch) {
+  const res = await fetchFn('/api/tables', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-session-id': sessionId,
+      'x-player-id': playerId,
+    },
+    body: JSON.stringify({ name: name || null }),
+  })
+  const body = await res.json()
+  if (!res.ok) {
+    const err = new Error(body.error || 'Failed to create table.')
+    err.status = res.status
+    throw err
+  }
+  return body
+}
+
+/**
  * Log in with email and password.
  * @param {{ email: string, password: string }} data
  * @param {typeof fetch} [fetchFn]

--- a/client/web/src/main.js
+++ b/client/web/src/main.js
@@ -4,6 +4,8 @@ import { renderRegisterScreen } from './screens/register.js'
 import { renderVerifyEmailSuccess, renderVerifyEmailError, renderVerifyEmailExpired } from './screens/verifyEmail.js'
 import { renderForgotPasswordScreen } from './screens/forgotPassword.js'
 import { renderResetPasswordScreen } from './screens/resetPassword.js'
+import { renderLobbyScreen } from './screens/lobby.js'
+import { renderCreateTableScreen } from './screens/createTable.js'
 
 const app = document.getElementById('app')
 
@@ -14,6 +16,8 @@ addRoute('#/verify-email-error', renderVerifyEmailError)
 addRoute('#/verify-email-expired', renderVerifyEmailExpired)
 addRoute('#/forgot-password', renderForgotPasswordScreen)
 addRoute('#/reset-password', renderResetPasswordScreen)
+addRoute('#/lobby', renderLobbyScreen)
+addRoute('#/create-table', renderCreateTableScreen)
 
 // Redirect authenticated users away from auth screens
 if (sessionStorage.getItem('sessionId') && window.location.hash !== '#/lobby') {

--- a/client/web/src/screens/createTable.js
+++ b/client/web/src/screens/createTable.js
@@ -1,0 +1,68 @@
+import { createTable } from '../api.js'
+import { navigate } from '../router.js'
+
+/**
+ * Render the create table screen into `container`.
+ * On success, navigates to the join table screen (#/join) for the new table.
+ * Name is optional — the PRD specifies it is displayed in the public lobby browser
+ * but is not required.
+ * @param {HTMLElement} container
+ */
+export function renderCreateTableScreen(container) {
+  container.innerHTML = `
+    <div class="auth-card">
+      <h1 class="auth-title">Create Table</h1>
+      <form id="create-table-form" novalidate>
+        <div class="form-group">
+          <label for="table-name">Table Name <span class="field-optional">(optional)</span></label>
+          <input
+            type="text"
+            id="table-name"
+            name="name"
+            maxlength="50"
+            autocomplete="off"
+            placeholder="e.g. Friday Night Spades"
+          />
+        </div>
+        <div class="form-error" id="create-table-error" role="alert" aria-live="polite"></div>
+        <button type="submit" id="create-table-btn" class="btn-primary">Create Table</button>
+      </form>
+      <p class="auth-link"><a href="#/lobby">Back to lobby</a></p>
+    </div>
+  `
+
+  const form = container.querySelector('#create-table-form')
+  const errorEl = container.querySelector('#create-table-error')
+  const btn = container.querySelector('#create-table-btn')
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault()
+    errorEl.textContent = ''
+
+    const name = form.querySelector('#table-name').value.trim()
+    if (name.length > 50) {
+      errorEl.textContent = 'Table name must be 50 characters or fewer.'
+      return
+    }
+
+    const sessionId = sessionStorage.getItem('sessionId')
+    const playerId = sessionStorage.getItem('playerId')
+    if (!sessionId || !playerId) {
+      navigate('#/login')
+      return
+    }
+
+    btn.disabled = true
+    btn.textContent = 'Creating\u2026'
+
+    try {
+      const { tableId } = await createTable({ name: name || null, sessionId, playerId })
+      console.log('Table created:', { tableId, name: name || null })
+      navigate(`#/join?tableId=${tableId}`)
+    } catch (err) {
+      errorEl.textContent = err.message
+      btn.disabled = false
+      btn.textContent = 'Create Table'
+    }
+  })
+}

--- a/client/web/src/screens/lobby.js
+++ b/client/web/src/screens/lobby.js
@@ -1,0 +1,38 @@
+import { navigate } from '../router.js'
+
+/**
+ * Render the lobby screen into `container`.
+ * This is the main menu after login — from here players can create or join a table.
+ * @param {HTMLElement} container
+ */
+export function renderLobbyScreen(container) {
+  const username = sessionStorage.getItem('username') || 'Player'
+
+  container.innerHTML = `
+    <div class="auth-card">
+      <h1 class="auth-title">Lobby</h1>
+      <p class="auth-message">Welcome back, <strong>${escapeHtml(username)}</strong>!</p>
+      <div class="lobby-actions">
+        <button id="create-table-btn" class="btn-primary">Create Table</button>
+        <button id="join-table-btn" class="btn-secondary">Join Table</button>
+      </div>
+    </div>
+  `
+
+  container.querySelector('#create-table-btn').addEventListener('click', () => {
+    navigate('#/create-table')
+  })
+
+  container.querySelector('#join-table-btn').addEventListener('click', () => {
+    navigate('#/join')
+  })
+}
+
+function escapeHtml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -44,7 +44,7 @@
 ### Web UI (minimal — enough to play)
 
 - [x] `P0` Registration and login screens
-- [ ] `P0` Create table screen: name only (no visibility/join policy yet)
+- [x] `P0` Create table screen: name only (no visibility/join policy yet)
 - [ ] `P0` Join table screen: list of open tables, click to join and choose a seat
 - [ ] `P0` Game screen: display hand, bid input, card play, current trick, scoreboard
 - [ ] `P0` Build hand display in Spread (fan) and Hand Diagram modes

--- a/server/lobby/table.js
+++ b/server/lobby/table.js
@@ -6,6 +6,7 @@ const TABLE_TTL_SECONDS = 3600 // 1 hour of inactivity
  * @typedef {Object} TableState
  * @property {string} tableId
  * @property {string} hostPlayerId
+ * @property {string|null} name
  * @property {{ north: string|null, east: string|null, south: string|null, west: string|null }} seats
  * @property {'waiting'|'playing'} status
  * @property {string|null} gameId
@@ -16,14 +17,15 @@ const TABLE_TTL_SECONDS = 3600 // 1 hour of inactivity
  * Create a new table in Redis and return its ID.
  *
  * @param {import('redis').RedisClientType} redis
- * @param {{ hostPlayerId: string }} opts
+ * @param {{ hostPlayerId: string, name?: string }} opts
  * @returns {Promise<TableState>}
  */
-export async function createTable(redis, { hostPlayerId }) {
+export async function createTable(redis, { hostPlayerId, name = null }) {
   const tableId = uuidv4()
   const table = {
     tableId,
     hostPlayerId,
+    name,
     seats: { north: null, east: null, south: null, west: null },
     status: 'waiting',
     gameId: null,
@@ -34,9 +36,9 @@ export async function createTable(redis, { hostPlayerId }) {
   await redis.set(key, JSON.stringify(table), { EX: TABLE_TTL_SECONDS })
 
   // Add to the lobby index
-  await redis.hSet('lobby:tables', tableId, JSON.stringify({ tableId, hostPlayerId, status: 'waiting' }))
+  await redis.hSet('lobby:tables', tableId, JSON.stringify({ tableId, hostPlayerId, name, status: 'waiting' }))
 
-  console.log('Table created:', { tableId, hostPlayerId })
+  console.log('Table created:', { tableId, hostPlayerId, name })
   return table
 }
 

--- a/server/server.js
+++ b/server/server.js
@@ -177,11 +177,18 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
 
   // POST /api/tables — create a new table
   app.post('/api/tables', async (req, res) => {
+    const { name } = req.body ?? {}
+    if (name !== undefined && name !== null) {
+      if (typeof name !== 'string') return sendJSON(res, 400, { error: 'Table name must be a string.' })
+      const trimmed = name.trim()
+      if (trimmed.length > 50) return sendJSON(res, 400, { error: 'Table name must be 50 characters or fewer.' })
+    }
     try {
       const redisClient = await getRedis()
       const session = await validateAuthHeaders(redisClient, req)
-      const table = await createTable(redisClient, { hostPlayerId: session.playerId })
-      sendJSON(res, 201, { tableId: table.tableId })
+      const resolvedName = (typeof name === 'string' && name.trim()) ? name.trim() : null
+      const table = await createTable(redisClient, { hostPlayerId: session.playerId, name: resolvedName })
+      sendJSON(res, 201, { tableId: table.tableId, name: table.name })
     } catch (err) {
       if (err.code === 'UNAUTHORIZED') return sendJSON(res, 401, { error: err.message })
       console.error('Create table error:', { error: err.message })

--- a/test/unit/web/api.test.js
+++ b/test/unit/web/api.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { registerUser, loginUser, resendVerification, forgotPassword, resetPassword } from '../../../client/web/src/api.js'
+import { registerUser, loginUser, resendVerification, forgotPassword, resetPassword, createTable } from '../../../client/web/src/api.js'
 
 /**
  * Build a minimal mock fetch that returns the given status and JSON body.
@@ -178,6 +178,52 @@ describe('loginUser', () => {
         ),
       (err) => {
         assert.equal(err.status, 400)
+        return true
+      },
+    )
+  })
+})
+
+describe('createTable', () => {
+  const auth = { sessionId: 'sess-1', playerId: 'player-1' }
+
+  it('resolves with tableId and name on 201', async () => {
+    const result = await createTable(
+      { name: 'Friday Night', ...auth },
+      mockFetch(201, { tableId: 'table-uuid', name: 'Friday Night' }),
+    )
+    assert.equal(result.tableId, 'table-uuid')
+    assert.equal(result.name, 'Friday Night')
+  })
+
+  it('resolves with null name when no name provided', async () => {
+    const result = await createTable(
+      { ...auth },
+      mockFetch(201, { tableId: 'table-uuid', name: null }),
+    )
+    assert.equal(result.tableId, 'table-uuid')
+    assert.equal(result.name, null)
+  })
+
+  it('throws with status 401 when unauthenticated', async () => {
+    await assert.rejects(
+      () => createTable({ ...auth }, mockFetch(401, { error: 'Unauthorized.' })),
+      (err) => {
+        assert.equal(err.status, 401)
+        return true
+      },
+    )
+  })
+
+  it('throws with status 400 when name is too long', async () => {
+    await assert.rejects(
+      () => createTable(
+        { name: 'x'.repeat(51), ...auth },
+        mockFetch(400, { error: 'Table name must be 50 characters or fewer.' }),
+      ),
+      (err) => {
+        assert.equal(err.status, 400)
+        assert.match(err.message, /50 characters/)
         return true
       },
     )


### PR DESCRIPTION
Implements the Slice 1 create table screen (name only, no visibility/join policy).

## Changes

- `POST /api/tables` now accepts an optional `name` field (string, max 50 chars)
- Table state and lobby index store the name
- New `createTable` API function in web client
- `#/create-table` screen with optional name input and validation
- Minimal `#/lobby` screen with Create Table / Join Table buttons
- 4 new unit tests for `createTable` API function
- `docs/TASKS.md` updated

Closes #81

Generated with [Claude Code](https://claude.ai/code)