### PR TITLE
feat: join table screen — list open tables and choose a seat

### DIFF
--- a/client/web/index.html
+++ b/client/web/index.html
@@ -186,6 +186,129 @@
         color: #666;
         font-size: 0.8rem;
       }
+
+      /* Join table screen — wider card to accommodate seat grid */
+      .join-table-card {
+        max-width: 480px;
+        margin: 0 auto;
+      }
+
+      .join-loading {
+        color: #888;
+        font-size: 0.9rem;
+        margin-bottom: 1rem;
+      }
+
+      /* Table list */
+      .table-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        margin-bottom: 0.5rem;
+      }
+
+      .table-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        background: #252525;
+        border: 1px solid #333;
+        border-radius: 4px;
+        padding: 0.625rem 0.75rem;
+        gap: 0.75rem;
+      }
+
+      .table-row-info {
+        display: flex;
+        flex-direction: column;
+        gap: 0.15rem;
+        min-width: 0;
+      }
+
+      .table-row-name {
+        font-size: 0.95rem;
+        color: #e8e8e8;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .table-row-seats {
+        font-size: 0.78rem;
+        color: #888;
+      }
+
+      .table-row .join-seat-btn {
+        width: auto;
+        flex-shrink: 0;
+        padding: 0.4rem 1rem;
+        margin-bottom: 0;
+        font-size: 0.85rem;
+      }
+
+      /* Seat picker grid */
+      .seat-grid {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.5rem;
+        margin: 1.25rem 0;
+      }
+
+      .seat-row-middle {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .seat-center {
+        width: 80px;
+        height: 60px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: 1px dashed #444;
+        border-radius: 4px;
+      }
+
+      .seat-center-label {
+        font-size: 0.75rem;
+        color: #555;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+
+      .seat-btn {
+        width: 90px;
+        padding: 0.625rem 0;
+        border-radius: 4px;
+        font-size: 0.9rem;
+        font-weight: 600;
+        cursor: pointer;
+        border: none;
+        transition: background 0.15s, color 0.15s;
+      }
+
+      .seat-btn--available {
+        background: #2e7d32;
+        color: #fff;
+      }
+
+      .seat-btn--available:hover:not(:disabled) {
+        background: #388e3c;
+      }
+
+      .seat-btn--taken {
+        background: #2a2a2a;
+        color: #555;
+        cursor: not-allowed;
+        border: 1px solid #333;
+      }
+
+      .seat-btn:disabled {
+        opacity: 0.7;
+        cursor: not-allowed;
+      }
     </style>
   </head>
   <body>

--- a/client/web/src/api.js
+++ b/client/web/src/api.js
@@ -118,6 +118,53 @@ export async function createTable({ name, sessionId, playerId }, fetchFn = globa
 }
 
 /**
+ * List all open (waiting) tables. Requires a valid session.
+ * @param {{ sessionId: string, playerId: string }} auth
+ * @param {typeof fetch} [fetchFn]
+ * @returns {Promise<{ tables: Array<{ tableId: string, name: string|null, seats: object, seatsAvailable: number }> }>}
+ */
+export async function listTables({ sessionId, playerId }, fetchFn = globalThis.fetch) {
+  const res = await fetchFn('/api/tables', {
+    headers: {
+      'x-session-id': sessionId,
+      'x-player-id': playerId,
+    },
+  })
+  const body = await res.json()
+  if (!res.ok) {
+    const err = new Error(body.error || 'Failed to list tables.')
+    err.status = res.status
+    throw err
+  }
+  return body
+}
+
+/**
+ * Sit at a seat at a table. Requires a valid session.
+ * @param {{ tableId: string, seat: string, sessionId: string, playerId: string }} data
+ * @param {typeof fetch} [fetchFn]
+ * @returns {Promise<{ tableId: string, seat: string }>}
+ */
+export async function sitAtTable({ tableId, seat, sessionId, playerId }, fetchFn = globalThis.fetch) {
+  const res = await fetchFn(`/api/tables/${tableId}/sit`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-session-id': sessionId,
+      'x-player-id': playerId,
+    },
+    body: JSON.stringify({ seat }),
+  })
+  const body = await res.json()
+  if (!res.ok) {
+    const err = new Error(body.error || 'Failed to sit at table.')
+    err.status = res.status
+    throw err
+  }
+  return body
+}
+
+/**
  * Log in with email and password.
  * @param {{ email: string, password: string }} data
  * @param {typeof fetch} [fetchFn]

--- a/client/web/src/main.js
+++ b/client/web/src/main.js
@@ -6,6 +6,7 @@ import { renderForgotPasswordScreen } from './screens/forgotPassword.js'
 import { renderResetPasswordScreen } from './screens/resetPassword.js'
 import { renderLobbyScreen } from './screens/lobby.js'
 import { renderCreateTableScreen } from './screens/createTable.js'
+import { renderJoinTableScreen } from './screens/joinTable.js'
 
 const app = document.getElementById('app')
 
@@ -18,6 +19,7 @@ addRoute('#/forgot-password', renderForgotPasswordScreen)
 addRoute('#/reset-password', renderResetPasswordScreen)
 addRoute('#/lobby', renderLobbyScreen)
 addRoute('#/create-table', renderCreateTableScreen)
+addRoute('#/join', renderJoinTableScreen)
 
 // Redirect authenticated users away from auth screens
 if (sessionStorage.getItem('sessionId') && window.location.hash !== '#/lobby') {

--- a/client/web/src/screens/joinTable.js
+++ b/client/web/src/screens/joinTable.js
@@ -1,0 +1,211 @@
+import { listTables, sitAtTable } from '../api.js'
+import { navigate } from '../router.js'
+
+/**
+ * Render the join table screen into `container`.
+ *
+ * If `?tableId=<id>` is in the URL query string, shows the seat picker for
+ * that specific table directly (used after creating a table). Otherwise
+ * shows a browsable list of all open (waiting) tables.
+ *
+ * After sitting, navigates to #/table?tableId=<id> (the game screen).
+ *
+ * @param {HTMLElement} container
+ */
+export function renderJoinTableScreen(container) {
+  const sessionId = sessionStorage.getItem('sessionId')
+  const playerId = sessionStorage.getItem('playerId')
+  if (!sessionId || !playerId) {
+    navigate('#/login')
+    return
+  }
+
+  const params = new URLSearchParams(window.location.hash.split('?')[1] || '')
+  const tableId = params.get('tableId')
+
+  if (tableId) {
+    renderSeatPicker(container, tableId, sessionId, playerId)
+  } else {
+    renderTableList(container, sessionId, playerId)
+  }
+}
+
+function escapeHtml(str) {
+  if (!str) return ''
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+async function renderTableList(container, sessionId, playerId) {
+  container.innerHTML = `
+    <div class="auth-card join-table-card">
+      <h1 class="auth-title">Join a Table</h1>
+      <p class="join-loading">Loading tables\u2026</p>
+    </div>
+  `
+
+  let tables
+  try {
+    const data = await listTables({ sessionId, playerId })
+    tables = data.tables
+  } catch (err) {
+    if (err.status === 401) {
+      navigate('#/login')
+      return
+    }
+    container.querySelector('.join-loading').textContent = 'Failed to load tables. Please try again.'
+    return
+  }
+
+  const card = container.querySelector('.join-table-card')
+
+  if (tables.length === 0) {
+    card.innerHTML = `
+      <h1 class="auth-title">Join a Table</h1>
+      <p class="auth-message">No open tables right now.</p>
+      <div class="lobby-actions">
+        <button id="create-table-btn" class="btn-primary">Create a Table</button>
+        <button id="refresh-btn" class="btn-secondary">Refresh</button>
+      </div>
+      <p class="auth-link"><a href="#/lobby">Back to lobby</a></p>
+    `
+    card.querySelector('#create-table-btn').addEventListener('click', () => navigate('#/create-table'))
+    card.querySelector('#refresh-btn').addEventListener('click', () => renderTableList(container, sessionId, playerId))
+    return
+  }
+
+  const rows = tables.map((t) => {
+    const name = escapeHtml(t.name) || '<em>Unnamed Table</em>'
+    const occupied = 4 - t.seatsAvailable
+    return `
+      <div class="table-row" data-table-id="${escapeHtml(t.tableId)}">
+        <div class="table-row-info">
+          <span class="table-row-name">${name}</span>
+          <span class="table-row-seats">${occupied}/4 seats filled</span>
+        </div>
+        <button class="btn-secondary join-seat-btn" data-table-id="${escapeHtml(t.tableId)}">Join</button>
+      </div>
+    `
+  }).join('')
+
+  card.innerHTML = `
+    <h1 class="auth-title">Join a Table</h1>
+    <div class="table-list">${rows}</div>
+    <div class="lobby-actions" style="margin-top: 1rem;">
+      <button id="refresh-btn" class="btn-secondary">Refresh</button>
+      <button id="create-table-btn" class="btn-secondary">Create a Table</button>
+    </div>
+    <p class="auth-link"><a href="#/lobby">Back to lobby</a></p>
+  `
+
+  card.querySelectorAll('.join-seat-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const tid = btn.dataset.tableId
+      navigate(`#/join?tableId=${tid}`)
+    })
+  })
+  card.querySelector('#refresh-btn').addEventListener('click', () => renderTableList(container, sessionId, playerId))
+  card.querySelector('#create-table-btn').addEventListener('click', () => navigate('#/create-table'))
+}
+
+async function renderSeatPicker(container, tableId, sessionId, playerId) {
+  container.innerHTML = `
+    <div class="auth-card join-table-card">
+      <h1 class="auth-title">Choose a Seat</h1>
+      <p class="join-loading">Loading table\u2026</p>
+    </div>
+  `
+
+  // Fetch table state to see which seats are taken
+  let seats
+  try {
+    const res = await fetch(`/api/tables/${tableId}/state`, {
+      headers: { 'x-session-id': sessionId, 'x-player-id': playerId },
+    })
+    if (res.status === 401) { navigate('#/login'); return }
+    if (res.status === 404) {
+      container.querySelector('.join-loading').textContent = 'Table not found.'
+      return
+    }
+    if (res.ok) {
+      const data = await res.json()
+      seats = data.seats
+    }
+  } catch (_) {
+    // If we can't fetch state (player not seated yet), get from list
+  }
+
+  // If we couldn't get seats from state (player not seated), try the list endpoint
+  if (!seats) {
+    try {
+      const listData = await listTables({ sessionId, playerId })
+      const found = listData.tables.find((t) => t.tableId === tableId)
+      seats = found ? found.seats : { north: null, east: null, south: null, west: null }
+    } catch (_) {
+      seats = { north: null, east: null, south: null, west: null }
+    }
+  }
+
+  const card = container.querySelector('.join-table-card')
+  const errorId = 'seat-error'
+
+  card.innerHTML = `
+    <h1 class="auth-title">Choose a Seat</h1>
+    <p class="auth-message">Select an available seat to join the table.</p>
+    <div class="seat-grid">
+      ${renderSeatButton('north', seats.north)}
+      <div class="seat-row-middle">
+        ${renderSeatButton('west', seats.west)}
+        <div class="seat-center">
+          <span class="seat-center-label">Table</span>
+        </div>
+        ${renderSeatButton('east', seats.east)}
+      </div>
+      ${renderSeatButton('south', seats.south)}
+    </div>
+    <div class="form-error" id="${errorId}" role="alert" aria-live="polite"></div>
+    <p class="auth-link"><a href="#/join">Back to table list</a></p>
+  `
+
+  const errorEl = card.querySelector(`#${errorId}`)
+
+  card.querySelectorAll('.seat-btn:not(:disabled)').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const seat = btn.dataset.seat
+      errorEl.textContent = ''
+      card.querySelectorAll('.seat-btn').forEach((b) => { b.disabled = true })
+      btn.textContent = 'Joining\u2026'
+
+      try {
+        await sitAtTable({ tableId, seat, sessionId, playerId })
+        console.log('Seated:', { tableId, seat })
+        navigate(`#/table?tableId=${tableId}`)
+      } catch (err) {
+        if (err.status === 401) { navigate('#/login'); return }
+        errorEl.textContent = err.message || 'Failed to sit at this seat.'
+        // Re-enable buttons except the one that's now taken
+        card.querySelectorAll('.seat-btn').forEach((b) => {
+          if (b.dataset.seat !== seat) b.disabled = false
+        })
+        btn.textContent = seatLabel(seat)
+      }
+    })
+  })
+}
+
+function renderSeatButton(seat, occupant) {
+  const label = seatLabel(seat)
+  const taken = occupant !== null
+  const disabled = taken ? 'disabled' : ''
+  const cls = taken ? 'seat-btn seat-btn--taken' : 'seat-btn seat-btn--available'
+  const text = taken ? 'Taken' : label
+  return `<button class="${cls}" data-seat="${seat}" ${disabled}>${text}</button>`
+}
+
+function seatLabel(seat) {
+  return seat.charAt(0).toUpperCase() + seat.slice(1)
+}

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -45,7 +45,7 @@
 
 - [x] `P0` Registration and login screens
 - [x] `P0` Create table screen: name only (no visibility/join policy yet)
-- [ ] `P0` Join table screen: list of open tables, click to join and choose a seat
+- [x] `P0` Join table screen: list of open tables, click to join and choose a seat
 - [ ] `P0` Game screen: display hand, bid input, card play, current trick, scoreboard
 - [ ] `P0` Build hand display in Spread (fan) and Hand Diagram modes
 - [ ] `P0` Game over screen: show final score and winner

--- a/server/lobby/table.js
+++ b/server/lobby/table.js
@@ -162,3 +162,30 @@ export async function getGameState(redis, tableId) {
 export async function saveGameState(redis, tableId, gameState) {
   await redis.set(`game:${tableId}`, JSON.stringify(gameState), { EX: TABLE_TTL_SECONDS })
 }
+
+/**
+ * List all open (waiting) tables from the lobby index.
+ * Fetches full table state for each waiting entry to include seat info.
+ *
+ * @param {import('redis').RedisClientType} redis
+ * @returns {Promise<Array<{ tableId: string, name: string|null, hostPlayerId: string, seats: object, seatsAvailable: number }>>}
+ */
+export async function listTables(redis) {
+  const raw = await redis.hGetAll('lobby:tables')
+  const result = []
+  for (const json of Object.values(raw)) {
+    const entry = JSON.parse(json)
+    if (entry.status !== 'waiting') continue
+    const table = await getTable(redis, entry.tableId)
+    if (!table || table.status !== 'waiting') continue
+    const seatsAvailable = Object.values(table.seats).filter((p) => p === null).length
+    result.push({
+      tableId: table.tableId,
+      name: table.name,
+      hostPlayerId: table.hostPlayerId,
+      seats: table.seats,
+      seatsAvailable,
+    })
+  }
+  return result
+}

--- a/server/server.js
+++ b/server/server.js
@@ -15,6 +15,7 @@ import {
   markTablePlaying,
   getGameState,
   saveGameState,
+  listTables,
 } from './lobby/table.js'
 import { createGame, placeBid, playCard, submitBlindNilExchange, getPlayerView } from './game/state.js'
 import { getSeatForPlayer } from './anticheat/validate.js'
@@ -174,6 +175,20 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
   // ──────────────────────────────────────────────────────────────────────────
   // Table & Game Routes (all require authentication)
   // ──────────────────────────────────────────────────────────────────────────
+
+  // GET /api/tables — list open (waiting) tables
+  app.get('/api/tables', async (req, res) => {
+    try {
+      const redisClient = await getRedis()
+      await validateAuthHeaders(redisClient, req)
+      const tables = await listTables(redisClient)
+      sendJSON(res, 200, { tables })
+    } catch (err) {
+      if (err.code === 'UNAUTHORIZED') return sendJSON(res, 401, { error: err.message })
+      console.error('List tables error:', { error: err.message })
+      sendJSON(res, 500, { error: 'Internal server error' })
+    }
+  })
 
   // POST /api/tables — create a new table
   app.post('/api/tables', async (req, res) => {

--- a/test/integration/game/table.test.js
+++ b/test/integration/game/table.test.js
@@ -322,6 +322,122 @@ describe('POST /api/tables/:tableId/bid', { skip }, () => {
   })
 })
 
+describe('GET /api/tables', { skip }, () => {
+  let server, db, redis
+
+  before(async () => {
+    db = getDb()
+    redis = await getRedis()
+    await ensurePlayersTable(db)
+    await insertVerifiedPlayer(db, {
+      email: 'listhost@gtest.spades.invalid',
+      username: 'gtest_listhost',
+      password: 'password123',
+    })
+    server = await startTestServer()
+  })
+
+  after(async () => {
+    await server.close()
+    await closeDb()
+    await closeRedis()
+  })
+
+  it('returns 401 without auth headers', async () => {
+    const res = await fetch(`${server.baseUrl}/api/tables`)
+    assert.equal(res.status, 401)
+  })
+
+  it('returns 200 with tables array when authenticated', async () => {
+    const { sessionId, playerId } = await loginPlayer(
+      server.baseUrl,
+      'listhost@gtest.spades.invalid',
+      'password123',
+    )
+    const res = await fetch(`${server.baseUrl}/api/tables`, {
+      headers: { 'x-session-id': sessionId, 'x-player-id': playerId },
+    })
+    assert.equal(res.status, 200)
+    const body = await res.json()
+    assert.ok(Array.isArray(body.tables), 'should return a tables array')
+  })
+
+  it('includes newly created waiting tables in the list', async () => {
+    const { sessionId, playerId } = await loginPlayer(
+      server.baseUrl,
+      'listhost@gtest.spades.invalid',
+      'password123',
+    )
+    const createRes = await fetch(`${server.baseUrl}/api/tables`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': sessionId,
+        'x-player-id': playerId,
+      },
+      body: JSON.stringify({ name: 'Test List Table' }),
+    })
+    const { tableId } = await createRes.json()
+
+    const listRes = await fetch(`${server.baseUrl}/api/tables`, {
+      headers: { 'x-session-id': sessionId, 'x-player-id': playerId },
+    })
+    assert.equal(listRes.status, 200)
+    const body = await listRes.json()
+    const found = body.tables.find((t) => t.tableId === tableId)
+    assert.ok(found, 'newly created table should appear in list')
+    assert.equal(found.name, 'Test List Table')
+    assert.ok(found.seats, 'table entry should include seats')
+    assert.equal(found.seatsAvailable, 4)
+  })
+
+  it('does not include tables that are already playing', async () => {
+    const players = []
+    for (let i = 1; i <= 4; i++) {
+      await insertVerifiedPlayer(db, {
+        email: `listplay${i}@gtest.spades.invalid`,
+        username: `gtest_listplay${i}`,
+        password: 'password123',
+      })
+    }
+    for (let i = 1; i <= 4; i++) {
+      const data = await loginPlayer(
+        server.baseUrl,
+        `listplay${i}@gtest.spades.invalid`,
+        'password123',
+      )
+      players.push(data)
+    }
+
+    // Create a table and fill all seats (triggers game start)
+    const createRes = await fetch(`${server.baseUrl}/api/tables`, {
+      method: 'POST',
+      headers: { 'x-session-id': players[0].sessionId, 'x-player-id': players[0].playerId },
+    })
+    const { tableId } = await createRes.json()
+
+    const seats = ['north', 'east', 'south', 'west']
+    for (let i = 0; i < 4; i++) {
+      await fetch(`${server.baseUrl}/api/tables/${tableId}/sit`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-session-id': players[i].sessionId,
+          'x-player-id': players[i].playerId,
+        },
+        body: JSON.stringify({ seat: seats[i] }),
+      })
+    }
+
+    const listRes = await fetch(`${server.baseUrl}/api/tables`, {
+      headers: { 'x-session-id': players[0].sessionId, 'x-player-id': players[0].playerId },
+    })
+    const body = await listRes.json()
+    const found = body.tables.find((t) => t.tableId === tableId)
+    assert.equal(found, undefined, 'playing table should not appear in list')
+  })
+})
+
 describe('POST /api/tables/:tableId/blind-nil-exchange', { skip }, () => {
   let server, db, redis
   const players = []

--- a/test/unit/web/api.test.js
+++ b/test/unit/web/api.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { registerUser, loginUser, resendVerification, forgotPassword, resetPassword, createTable } from '../../../client/web/src/api.js'
+import { registerUser, loginUser, resendVerification, forgotPassword, resetPassword, createTable, listTables, sitAtTable } from '../../../client/web/src/api.js'
 
 /**
  * Build a minimal mock fetch that returns the given status and JSON body.
@@ -224,6 +224,72 @@ describe('createTable', () => {
       (err) => {
         assert.equal(err.status, 400)
         assert.match(err.message, /50 characters/)
+        return true
+      },
+    )
+  })
+})
+
+describe('listTables', () => {
+  const auth = { sessionId: 'sess-1', playerId: 'player-1' }
+
+  it('resolves with tables array on 200', async () => {
+    const tables = [
+      { tableId: 'table-1', name: 'Friday Night', seats: { north: null, east: null, south: null, west: null }, seatsAvailable: 4 },
+    ]
+    const result = await listTables(auth, mockFetch(200, { tables }))
+    assert.deepEqual(result.tables, tables)
+  })
+
+  it('resolves with empty array when no tables', async () => {
+    const result = await listTables(auth, mockFetch(200, { tables: [] }))
+    assert.deepEqual(result.tables, [])
+  })
+
+  it('throws with status 401 when unauthenticated', async () => {
+    await assert.rejects(
+      () => listTables(auth, mockFetch(401, { error: 'Unauthorized.' })),
+      (err) => {
+        assert.equal(err.status, 401)
+        return true
+      },
+    )
+  })
+})
+
+describe('sitAtTable', () => {
+  const auth = { sessionId: 'sess-1', playerId: 'player-1' }
+
+  it('resolves on 200 with tableId and seat', async () => {
+    const result = await sitAtTable(
+      { tableId: 'table-1', seat: 'north', ...auth },
+      mockFetch(200, { tableId: 'table-1', seat: 'north' }),
+    )
+    assert.equal(result.tableId, 'table-1')
+    assert.equal(result.seat, 'north')
+  })
+
+  it('throws with status 409 when seat is taken', async () => {
+    await assert.rejects(
+      () => sitAtTable(
+        { tableId: 'table-1', seat: 'north', ...auth },
+        mockFetch(409, { error: 'Seat is already taken' }),
+      ),
+      (err) => {
+        assert.equal(err.status, 409)
+        return true
+      },
+    )
+  })
+
+  it('throws with status 401 when unauthenticated', async () => {
+    await assert.rejects(
+      () => sitAtTable(
+        { tableId: 'table-1', seat: 'north', ...auth },
+        mockFetch(401, { error: 'Unauthorized.' }),
+      ),
+      (err) => {
+        assert.equal(err.status, 401)
         return true
       },
     )


### PR DESCRIPTION
Implements the join table screen for Slice 1 (issue #82).

## Changes

**Backend**
- `GET /api/tables` — lists all open (waiting) tables with seat occupancy, requires auth
- `listTables(redis)` in `server/lobby/table.js`

**Frontend**
- `client/web/src/screens/joinTable.js` — table browser + N/S/E/W seat picker
- `client/web/src/api.js` — `listTables` and `sitAtTable` helpers
- `#/join` route registered; `?tableId` param goes directly to seat picker

**Tests**
- Integration: `GET /api/tables` (auth, list, excludes playing tables)
- Unit: `listTables` and `sitAtTable` API client functions

Closes #82

Generated with [Claude Code](https://claude.ai/code)