### PR TITLE
feat: wire anticheat validators into bid and play route handlers

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -18,7 +18,7 @@ import {
   listTables,
 } from './lobby/table.js'
 import { createGame, placeBid, playCard, submitBlindNilExchange, getPlayerView } from './game/state.js'
-import { getSeatForPlayer } from './anticheat/validate.js'
+import { getSeatForPlayer, validateCardPlay, validateBidTurn } from './anticheat/validate.js'
 
 function sendJSON(res, statusCode, data) {
   res.status(statusCode).json(data)
@@ -281,6 +281,7 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
       const gameState = await getGameState(redisClient, tableId)
       if (!gameState) return sendJSON(res, 409, { error: 'Game has not started' })
 
+      validateBidTurn(gameState, seat)
       const newState = placeBid(gameState, seat, bid)
       await saveGameState(redisClient, tableId, newState)
       sendJSON(res, 200, getPlayerView(newState, seat))
@@ -343,6 +344,7 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
       const gameState = await getGameState(redisClient, tableId)
       if (!gameState) return sendJSON(res, 409, { error: 'Game has not started' })
 
+      validateCardPlay(gameState, seat, card)
       const newState = playCard(gameState, seat, card)
       await saveGameState(redisClient, tableId, newState)
       sendJSON(res, 200, getPlayerView(newState, seat))

--- a/test/unit/anticheat/validate.test.js
+++ b/test/unit/anticheat/validate.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { validateCardPlay } from '../../../server/anticheat/validate.js'
+import { validateCardPlay, validateBidTurn } from '../../../server/anticheat/validate.js'
 
 /**
  * Build a minimal game state for anticheat validation tests.
@@ -126,6 +126,37 @@ describe('validateCardPlay — no Spade lead on first trick', () => {
       () => validateCardPlay(state, 'east', { suit: 'hearts', rank: '7' }),
       (e) => e.code === 'ILLEGAL_PLAY',
     )
+  })
+})
+
+describe('validateBidTurn — phase and turn checks', () => {
+  function makeBidState(overrides = {}) {
+    return {
+      phase: 'bidding',
+      currentBidderSeat: 'north',
+      ...overrides,
+    }
+  }
+
+  it('throws INVALID_ACTION when game is not in bidding phase', () => {
+    const state = makeBidState({ phase: 'playing' })
+    assert.throws(
+      () => validateBidTurn(state, 'north'),
+      (e) => e.code === 'INVALID_ACTION',
+    )
+  })
+
+  it('throws NOT_YOUR_TURN when it is not the player\'s turn to bid', () => {
+    const state = makeBidState({ currentBidderSeat: 'east' })
+    assert.throws(
+      () => validateBidTurn(state, 'north'),
+      (e) => e.code === 'NOT_YOUR_TURN',
+    )
+  })
+
+  it('does not throw when phase is bidding and it is the player\'s turn', () => {
+    const state = makeBidState()
+    assert.doesNotThrow(() => validateBidTurn(state, 'north'))
   })
 })
 


### PR DESCRIPTION
Calls `validateBidTurn` and `validateCardPlay` from `server/anticheat/validate.js` before `placeBid` and `playCard` respectively in the API route handlers, satisfying the requirement that all game actions go through the dedicated anticheat layer before being applied to game state.

Also adds unit tests for `validateBidTurn` — previously only `validateCardPlay` had coverage.

Closes #75

Generated with [Claude Code](https://claude.ai/code)