### PR TITLE
feat: game screen with hand display, bid input, card play, trick view, scoreboard

### DIFF
--- a/client/web/index.html
+++ b/client/web/index.html
@@ -309,6 +309,498 @@
         opacity: 0.7;
         cursor: not-allowed;
       }
+
+      /* ── Game screen ──────────────────────────────────────────────────── */
+
+      /* Expand #app to full width during a game */
+      .app--game {
+        max-width: none;
+        padding: 0;
+      }
+
+      .game-screen {
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        background: #1a3a1a;
+      }
+
+      /* Scoreboard */
+      .game-scoreboard {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        background: #111;
+        padding: 0.5rem 1rem;
+        border-bottom: 1px solid #333;
+        flex-shrink: 0;
+      }
+
+      .score-team {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .score-team-label {
+        font-size: 0.75rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        color: #888;
+      }
+
+      .score-pts {
+        font-size: 1.2rem;
+        font-weight: 700;
+        color: #fff;
+      }
+
+      .score-bags {
+        font-size: 0.75rem;
+        color: #777;
+      }
+
+      .score-meta {
+        font-size: 0.8rem;
+        color: #666;
+        text-align: center;
+      }
+
+      /* Game table layout */
+      .game-table {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        max-width: 640px;
+        width: 100%;
+        margin: 0 auto;
+        padding: 0.75rem;
+        gap: 0.5rem;
+      }
+
+      .table-top,
+      .table-bottom {
+        display: flex;
+        justify-content: center;
+        width: 100%;
+      }
+
+      .table-middle {
+        display: flex;
+        align-items: center;
+        width: 100%;
+        gap: 0.5rem;
+      }
+
+      .table-side {
+        flex: 0 0 auto;
+      }
+
+      /* Seat info boxes */
+      .seat-info {
+        background: #1e2e1e;
+        border: 1px solid #2e3e2e;
+        border-radius: 6px;
+        padding: 0.4rem 0.75rem;
+        min-width: 90px;
+        text-align: center;
+      }
+
+      .seat-info.seat-active {
+        border-color: #66bb6a;
+        background: #183018;
+      }
+
+      .seat-name {
+        display: block;
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        color: #888;
+        margin-bottom: 0.2rem;
+        letter-spacing: 0.05em;
+      }
+
+      .seat-stats {
+        display: flex;
+        gap: 0.5rem;
+        justify-content: center;
+        font-size: 0.75rem;
+        color: #b0b0b0;
+      }
+
+      /* Trick area */
+      .trick-area {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.25rem;
+        background: #163016;
+        border-radius: 8px;
+        padding: 0.5rem;
+        min-height: 130px;
+      }
+
+      .trick-row {
+        display: flex;
+        justify-content: center;
+      }
+
+      .trick-middle {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .trick-center {
+        width: 48px;
+        height: 48px;
+      }
+
+      .trick-slot {
+        width: 44px;
+        height: 64px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .trick-card {
+        background: #fff;
+        color: #222;
+        border-radius: 4px;
+        padding: 3px 5px;
+        font-size: 0.95rem;
+        font-weight: 700;
+        white-space: nowrap;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.4);
+      }
+
+      .trick-card.trick-red {
+        color: #c62828;
+      }
+
+      /* Status bar */
+      .game-status-bar {
+        background: #111;
+        border-top: 1px solid #333;
+        text-align: center;
+        padding: 0.375rem 1rem;
+        flex-shrink: 0;
+      }
+
+      .game-status-msg {
+        font-size: 0.875rem;
+        color: #b0b0b0;
+      }
+
+      /* Bid panel */
+      .bid-panel {
+        background: #1a1a1a;
+        border-top: 1px solid #2a2a2a;
+        padding: 0.75rem 1rem;
+        flex-shrink: 0;
+        max-width: 640px;
+        width: 100%;
+        margin: 0 auto;
+      }
+
+      .bid-title {
+        font-size: 0.78rem;
+        color: #888;
+        margin-bottom: 0.5rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+
+      .bid-grid {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.35rem;
+        margin-bottom: 0.5rem;
+      }
+
+      .bid-num-btn {
+        width: 38px;
+        height: 38px;
+        background: #2e7d32;
+        color: #fff;
+        border: none;
+        border-radius: 4px;
+        font-size: 0.9rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.15s;
+      }
+
+      .bid-num-btn:hover {
+        background: #388e3c;
+      }
+
+      .bid-special-row {
+        display: flex;
+        gap: 0.5rem;
+        margin-bottom: 0.5rem;
+      }
+
+      .bid-special-btn {
+        padding: 0.375rem 0.875rem;
+        background: transparent;
+        color: #66bb6a;
+        border: 1px solid #66bb6a;
+        border-radius: 4px;
+        font-size: 0.85rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.15s, color 0.15s;
+      }
+
+      .bid-special-btn:hover {
+        background: #66bb6a;
+        color: #1a1a1a;
+      }
+
+      .bid-blind-nil-btn {
+        color: #ffa726;
+        border-color: #ffa726;
+      }
+
+      .bid-blind-nil-btn:hover {
+        background: #ffa726;
+        color: #1a1a1a;
+      }
+
+      /* Exchange panel */
+      .exchange-panel {
+        background: #1a2030;
+        border-top: 1px solid #2a3040;
+        padding: 0.75rem 1rem;
+        flex-shrink: 0;
+        max-width: 640px;
+        width: 100%;
+        margin: 0 auto;
+      }
+
+      .exchange-hint {
+        font-size: 0.85rem;
+        color: #90caf9;
+        margin-bottom: 0.5rem;
+      }
+
+      .exchange-btn {
+        width: auto;
+        padding: 0.5rem 1.5rem;
+        margin-bottom: 0.5rem;
+        font-size: 0.875rem;
+      }
+
+      /* Hand section */
+      .game-hand-section {
+        background: #111;
+        border-top: 1px solid #2a2a2a;
+        padding: 0.75rem;
+        flex-shrink: 0;
+        max-width: 640px;
+        width: 100%;
+        margin: 0 auto;
+      }
+
+      .hand-mode-toggle {
+        display: flex;
+        gap: 0.4rem;
+        margin-bottom: 0.75rem;
+      }
+
+      .mode-btn {
+        padding: 0.2rem 0.625rem;
+        background: transparent;
+        color: #777;
+        border: 1px solid #444;
+        border-radius: 4px;
+        font-size: 0.78rem;
+        cursor: pointer;
+        transition: all 0.15s;
+      }
+
+      .mode-btn:hover,
+      .mode-btn.mode-btn-active {
+        background: #2e7d32;
+        color: #fff;
+        border-color: #2e7d32;
+      }
+
+      .hand-cards {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.35rem;
+        min-height: 36px;
+      }
+
+      /* Card styles */
+      .card {
+        display: inline-flex;
+        align-items: center;
+        background: #fff;
+        color: #222;
+        border-radius: 4px;
+        padding: 0.3rem 0.45rem;
+        font-size: 0.875rem;
+        font-weight: 700;
+        white-space: nowrap;
+        user-select: none;
+        border: 2px solid transparent;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.35);
+        transition: transform 0.1s, border-color 0.1s;
+      }
+
+      .card.card-red {
+        color: #c62828;
+      }
+
+      /* Card that can be played */
+      .card.card-play {
+        cursor: pointer;
+        border-color: #4caf50;
+      }
+
+      .card.card-play:hover {
+        transform: translateY(-5px);
+        border-color: #66bb6a;
+      }
+
+      /* Card selected for blind nil exchange */
+      .card.card-sel {
+        cursor: pointer;
+        border-color: #1976d2;
+        background: #e3f2fd;
+        transform: translateY(-5px);
+      }
+
+      /* Card in exchange mode but not yet selected */
+      .card.card-exch {
+        cursor: pointer;
+        border-color: #546e7a;
+      }
+
+      .card.card-exch:hover {
+        transform: translateY(-3px);
+        border-color: #78909c;
+      }
+
+      /* Compact cards for diagram mode */
+      .card.card-compact {
+        padding: 0.15rem 0.3rem;
+        font-size: 0.8rem;
+      }
+
+      /* Diagram hand layout */
+      .hand-diagram {
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+        width: 100%;
+      }
+
+      .diagram-row {
+        display: flex;
+        align-items: center;
+        gap: 0.3rem;
+        flex-wrap: wrap;
+      }
+
+      .diagram-suit {
+        width: 18px;
+        font-size: 1rem;
+        flex-shrink: 0;
+        color: #e8e8e8;
+      }
+
+      .diagram-suit.suit-red {
+        color: #ef5350;
+      }
+
+      /* Game over screen */
+      .game-over-card {
+        max-width: 380px;
+        margin: 0 auto;
+        text-align: center;
+      }
+
+      .game-over-scores {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 1rem;
+        margin: 1.5rem 0;
+      }
+
+      .game-over-team {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.2rem;
+        padding: 0.75rem 1rem;
+        background: #252525;
+        border: 1px solid #333;
+        border-radius: 6px;
+        min-width: 90px;
+      }
+
+      .game-over-team.game-over-winner {
+        border-color: #66bb6a;
+        background: #1a2e1a;
+      }
+
+      .game-over-team-label {
+        font-size: 0.75rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        color: #888;
+        letter-spacing: 0.05em;
+      }
+
+      .game-over-pts {
+        font-size: 1.5rem;
+        font-weight: 700;
+        color: #fff;
+      }
+
+      .game-over-bags {
+        font-size: 0.75rem;
+        color: #777;
+      }
+
+      .game-over-crown {
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: #66bb6a;
+        margin-top: 0.2rem;
+      }
+
+      .game-over-vs {
+        font-size: 0.85rem;
+        color: #555;
+        font-weight: 600;
+      }
+
+      /* General game msg */
+      .game-msg {
+        text-align: center;
+        color: #888;
+        padding: 3rem 1rem;
+        font-size: 0.95rem;
+      }
+
+      .game-msg a {
+        color: #66bb6a;
+        text-decoration: none;
+      }
+
+      .game-msg a:hover {
+        text-decoration: underline;
+      }
     </style>
   </head>
   <body>

--- a/client/web/src/api.js
+++ b/client/web/src/api.js
@@ -165,6 +165,103 @@ export async function sitAtTable({ tableId, seat, sessionId, playerId }, fetchFn
 }
 
 /**
+ * Get the current game state for a table (filtered to the requesting player's view).
+ * @param {{ tableId: string, sessionId: string, playerId: string }} data
+ * @param {typeof fetch} [fetchFn]
+ * @returns {Promise<object>} Player-specific game state
+ */
+export async function getGameState({ tableId, sessionId, playerId }, fetchFn = globalThis.fetch) {
+  const res = await fetchFn(`/api/tables/${tableId}/state`, {
+    headers: {
+      'x-session-id': sessionId,
+      'x-player-id': playerId,
+    },
+  })
+  const body = await res.json()
+  if (!res.ok) {
+    const err = new Error(body.error || 'Failed to get game state.')
+    err.status = res.status
+    throw err
+  }
+  return body
+}
+
+/**
+ * Place a bid during the bidding phase.
+ * @param {{ tableId: string, bid: number|'nil'|'blind_nil', sessionId: string, playerId: string }} data
+ * @param {typeof fetch} [fetchFn]
+ * @returns {Promise<object>} Updated player-specific game state
+ */
+export async function placeBid({ tableId, bid, sessionId, playerId }, fetchFn = globalThis.fetch) {
+  const res = await fetchFn(`/api/tables/${tableId}/bid`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-session-id': sessionId,
+      'x-player-id': playerId,
+    },
+    body: JSON.stringify({ bid }),
+  })
+  const body = await res.json()
+  if (!res.ok) {
+    const err = new Error(body.error || 'Failed to place bid.')
+    err.status = res.status
+    throw err
+  }
+  return body
+}
+
+/**
+ * Play a card during the playing phase.
+ * @param {{ tableId: string, card: { suit: string, rank: string }, sessionId: string, playerId: string }} data
+ * @param {typeof fetch} [fetchFn]
+ * @returns {Promise<object>} Updated player-specific game state
+ */
+export async function playCard({ tableId, card, sessionId, playerId }, fetchFn = globalThis.fetch) {
+  const res = await fetchFn(`/api/tables/${tableId}/play`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-session-id': sessionId,
+      'x-player-id': playerId,
+    },
+    body: JSON.stringify({ card }),
+  })
+  const body = await res.json()
+  if (!res.ok) {
+    const err = new Error(body.error || 'Failed to play card.')
+    err.status = res.status
+    throw err
+  }
+  return body
+}
+
+/**
+ * Submit cards for the blind nil exchange.
+ * @param {{ tableId: string, cards: Array<{suit: string, rank: string}>, sessionId: string, playerId: string }} data
+ * @param {typeof fetch} [fetchFn]
+ * @returns {Promise<object>} Updated player-specific game state
+ */
+export async function submitBlindNilExchange({ tableId, cards, sessionId, playerId }, fetchFn = globalThis.fetch) {
+  const res = await fetchFn(`/api/tables/${tableId}/blind-nil-exchange`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-session-id': sessionId,
+      'x-player-id': playerId,
+    },
+    body: JSON.stringify({ cards }),
+  })
+  const body = await res.json()
+  if (!res.ok) {
+    const err = new Error(body.error || 'Failed to submit blind nil exchange.')
+    err.status = res.status
+    throw err
+  }
+  return body
+}
+
+/**
  * Log in with email and password.
  * @param {{ email: string, password: string }} data
  * @param {typeof fetch} [fetchFn]

--- a/client/web/src/main.js
+++ b/client/web/src/main.js
@@ -7,6 +7,8 @@ import { renderResetPasswordScreen } from './screens/resetPassword.js'
 import { renderLobbyScreen } from './screens/lobby.js'
 import { renderCreateTableScreen } from './screens/createTable.js'
 import { renderJoinTableScreen } from './screens/joinTable.js'
+import { renderGameScreen } from './screens/game.js'
+import { renderGameOverScreen } from './screens/gameOver.js'
 
 const app = document.getElementById('app')
 
@@ -20,9 +22,14 @@ addRoute('#/reset-password', renderResetPasswordScreen)
 addRoute('#/lobby', renderLobbyScreen)
 addRoute('#/create-table', renderCreateTableScreen)
 addRoute('#/join', renderJoinTableScreen)
+addRoute('#/table', renderGameScreen)
+addRoute('#/game-over', renderGameOverScreen)
 
-// Redirect authenticated users away from auth screens
-if (sessionStorage.getItem('sessionId') && window.location.hash !== '#/lobby') {
+// Redirect unauthenticated users to login from protected screens, and redirect
+// authenticated users away from auth-only screens to lobby.
+const authOnlyScreens = new Set(['', '#/login', '#/register', '#/forgot-password', '#/reset-password'])
+const currentRoute = window.location.hash.split('?')[0]
+if (sessionStorage.getItem('sessionId') && authOnlyScreens.has(currentRoute)) {
   window.location.hash = '#/lobby'
 }
 

--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -1,0 +1,393 @@
+import {
+  getGameState,
+  placeBid as apiBid,
+  playCard as apiPlay,
+  submitBlindNilExchange as apiExchange,
+} from '../api.js'
+import { navigate } from '../router.js'
+
+const SUIT_SYMBOL = { spades: '\u2660', hearts: '\u2665', diamonds: '\u2666', clubs: '\u2663' }
+const RED_SUIT = new Set(['hearts', 'diamonds'])
+const CW = ['north', 'east', 'south', 'west']
+const PARTNER = { north: 'south', south: 'north', east: 'west', west: 'east' }
+const TEAM = { north: 'ns', south: 'ns', east: 'ew', west: 'ew' }
+
+function esc(s) {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function getSeatForPlayer(players, playerId) {
+  return Object.entries(players).find(([, pid]) => pid === playerId)?.[0] ?? null
+}
+
+// Returns seats from the current player's perspective:
+//   me = bottom, right = clockwise neighbour, across = partner, left = counter-clockwise neighbour
+function relSeats(seat) {
+  const i = CW.indexOf(seat)
+  return {
+    me: CW[i],
+    right: CW[(i + 1) % 4],
+    across: CW[(i + 2) % 4],
+    left: CW[(i + 3) % 4],
+  }
+}
+
+function bidLabel(bid) {
+  if (bid === null) return '?'
+  if (bid === 'nil') return 'Nil'
+  if (bid === 'blind_nil') return 'Blind Nil'
+  return String(bid)
+}
+
+function cardHtml(card, extraCls) {
+  const s = SUIT_SYMBOL[card.suit]
+  const red = RED_SUIT.has(card.suit) ? ' card-red' : ''
+  const cls = extraCls ? ` ${extraCls}` : ''
+  return `<span class="card${red}${cls}" data-suit="${esc(card.suit)}" data-rank="${esc(card.rank)}">${esc(card.rank)}${s}</span>`
+}
+
+function seatInfoHtml(state, seat, label) {
+  const bid = state.bids[seat]
+  const tricks = state.tricksWon[seat]
+  const isActive = state.currentBidderSeat === seat || state.currentPlayerSeat === seat
+  const activeCls = isActive ? ' seat-active' : ''
+  return `
+    <div class="seat-info${activeCls}">
+      <span class="seat-name">${esc(label)}</span>
+      <div class="seat-stats">
+        <span>Bid: ${esc(bidLabel(bid))}</span>
+        <span>Tricks: ${tricks}</span>
+      </div>
+    </div>`
+}
+
+function trickHtml(state, rel) {
+  const bySeats = {}
+  for (const { seat, card } of state.currentTrick) bySeats[seat] = card
+
+  function slot(seat) {
+    const card = bySeats[seat]
+    if (!card) return '<div class="trick-slot"></div>'
+    const s = SUIT_SYMBOL[card.suit]
+    const red = RED_SUIT.has(card.suit) ? ' trick-red' : ''
+    return `<div class="trick-slot"><div class="trick-card${red}">${esc(card.rank)}${s}</div></div>`
+  }
+
+  return `
+    <div class="trick-area">
+      <div class="trick-row">${slot(rel.across)}</div>
+      <div class="trick-row trick-middle">
+        ${slot(rel.left)}
+        <div class="trick-center"></div>
+        ${slot(rel.right)}
+      </div>
+      <div class="trick-row">${slot(rel.me)}</div>
+    </div>`
+}
+
+function handSpreadHtml(hand, extraClsFn) {
+  return hand.map((card) => cardHtml(card, extraClsFn(card))).join('')
+}
+
+function handDiagramHtml(hand, extraClsFn) {
+  const bySuit = { spades: [], hearts: [], diamonds: [], clubs: [] }
+  for (const c of hand) bySuit[c.suit].push(c)
+
+  return Object.entries(bySuit)
+    .filter(([, cards]) => cards.length > 0)
+    .map(([suit, cards]) => {
+      const s = SUIT_SYMBOL[suit]
+      const red = RED_SUIT.has(suit) ? ' suit-red' : ''
+      const cardsHtml = cards.map((card) => cardHtml(card, `card-compact${extraClsFn(card) ? ' ' + extraClsFn(card) : ''}`)).join('')
+      return `<div class="diagram-row"><span class="diagram-suit${red}">${s}</span>${cardsHtml}</div>`
+    })
+    .join('')
+}
+
+/**
+ * Render the full game screen into `container`.
+ * Polls the server every 2 seconds for state updates.
+ *
+ * @param {HTMLElement} container
+ */
+export function renderGameScreen(container) {
+  const sessionId = sessionStorage.getItem('sessionId')
+  const playerId = sessionStorage.getItem('playerId')
+  if (!sessionId || !playerId) { navigate('#/login'); return }
+
+  const params = new URLSearchParams(window.location.hash.split('?')[1] || '')
+  const tableId = params.get('tableId')
+  if (!tableId) { navigate('#/lobby'); return }
+
+  const appEl = document.getElementById('app')
+  if (appEl) appEl.classList.add('app--game')
+
+  let state = null
+  let handMode = 'spread'
+  let selectedCards = []
+  let pollTimer = null
+  let acting = false
+  let mounted = true
+
+  function cleanup() {
+    mounted = false
+    clearTimeout(pollTimer)
+    if (appEl) appEl.classList.remove('app--game')
+  }
+  window.addEventListener('hashchange', cleanup, { once: true })
+
+  function schedulePoll() {
+    clearTimeout(pollTimer)
+    if (!mounted) return
+    pollTimer = setTimeout(async () => {
+      if (!mounted || acting) return
+      try {
+        const s = await getGameState({ tableId, sessionId, playerId })
+        if (!mounted) return
+        state = s
+        render()
+      } catch (_) {
+        // silent — retry on next poll
+      }
+      schedulePoll()
+    }, 2000)
+  }
+
+  function render() {
+    if (!state) return
+    if (state.phase === 'game_over') {
+      navigate(`#/game-over?tableId=${tableId}`)
+      return
+    }
+
+    const seat = getSeatForPlayer(state.players, playerId)
+    if (!seat) {
+      container.innerHTML = '<div class="game-screen"><p class="game-msg">You are not seated at this table.</p></div>'
+      return
+    }
+
+    const rel = relSeats(seat)
+    const isMyBidTurn = state.phase === 'bidding' && state.currentBidderSeat === seat
+    const isMyPlayTurn = state.phase === 'playing' && state.currentPlayerSeat === seat
+    const bne = state.blindNilExchange
+    const isMyExchangeTurn = state.phase === 'blind_nil_exchange' && bne && (
+      (bne.step === 'blind_to_partner' && bne.currentBlindNilSeat === seat) ||
+      (bne.step === 'partner_to_blind' && PARTNER[bne.currentBlindNilSeat] === seat)
+    )
+
+    const selectedSet = new Set(selectedCards.map((c) => `${c.suit}-${c.rank}`))
+
+    function cardExtraCls(card) {
+      const key = `${card.suit}-${card.rank}`
+      if (isMyPlayTurn) return 'card-play'
+      if (isMyExchangeTurn) return selectedSet.has(key) ? 'card-sel' : 'card-exch'
+      return ''
+    }
+
+    const handHtml = handMode === 'spread'
+      ? handSpreadHtml(state.myHand, cardExtraCls)
+      : `<div class="hand-diagram">${handDiagramHtml(state.myHand, cardExtraCls)}</div>`
+
+    let statusMsg = ''
+    if (state.phase === 'bidding') {
+      statusMsg = isMyBidTurn ? 'Your turn to bid' : `Waiting for ${esc(state.currentBidderSeat)} to bid\u2026`
+    } else if (state.phase === 'blind_nil_exchange') {
+      statusMsg = isMyExchangeTurn
+        ? (bne.step === 'blind_to_partner' ? 'Select 2 cards to send to your partner' : 'Select 2 cards to return to the Blind Nil player')
+        : 'Waiting for blind nil card exchange\u2026'
+    } else if (state.phase === 'playing') {
+      statusMsg = isMyPlayTurn ? 'Your turn \u2014 click a card to play' : `Waiting for ${esc(state.currentPlayerSeat)} to play\u2026`
+    }
+
+    const myTeam = TEAM[seat]
+    const oppTeam = myTeam === 'ns' ? 'ew' : 'ns'
+    const blindNilEligible = (state.scores[oppTeam] - state.scores[myTeam]) >= 100
+
+    const bidPanelHtml = isMyBidTurn ? `
+      <div class="bid-panel">
+        <p class="bid-title">Choose your bid:</p>
+        <div class="bid-grid">
+          ${Array.from({ length: 14 }, (_, i) => `<button class="bid-num-btn" data-bid="${i}">${i}</button>`).join('')}
+        </div>
+        <div class="bid-special-row">
+          <button class="bid-special-btn" data-bid="nil">Nil</button>
+          ${blindNilEligible ? '<button class="bid-special-btn bid-blind-nil-btn" data-bid="blind_nil">Blind Nil</button>' : ''}
+        </div>
+        <div class="form-error bid-err" role="alert" aria-live="polite"></div>
+      </div>` : ''
+
+    const exchangePanelHtml = isMyExchangeTurn ? `
+      <div class="exchange-panel">
+        <p class="exchange-hint">
+          ${bne.step === 'blind_to_partner' ? 'Select 2 cards to give your partner' : 'Select 2 cards to return to the Blind Nil player'}
+          (${selectedCards.length}/2 selected)
+        </p>
+        <button class="btn-primary exchange-btn" id="exchange-submit-btn" ${selectedCards.length === 2 ? '' : 'disabled'}>Send Cards</button>
+        <div class="form-error exchange-err" role="alert" aria-live="polite"></div>
+      </div>` : ''
+
+    container.innerHTML = `
+      <div class="game-screen">
+        <div class="game-scoreboard">
+          <div class="score-team score-ns">
+            <span class="score-team-label">N/S</span>
+            <span class="score-pts">${state.scores.ns}</span>
+            <span class="score-bags">${state.bags.ns} bag${state.bags.ns !== 1 ? 's' : ''}</span>
+          </div>
+          <div class="score-meta">Hand #${state.handNumber}${state.spadesbroken ? ' \u00b7 \u2660 broken' : ''}</div>
+          <div class="score-team score-ew">
+            <span class="score-team-label">E/W</span>
+            <span class="score-pts">${state.scores.ew}</span>
+            <span class="score-bags">${state.bags.ew} bag${state.bags.ew !== 1 ? 's' : ''}</span>
+          </div>
+        </div>
+
+        <div class="game-table">
+          <div class="table-top">
+            ${seatInfoHtml(state, rel.across, rel.across.charAt(0).toUpperCase() + rel.across.slice(1))}
+          </div>
+          <div class="table-middle">
+            <div class="table-side table-left">
+              ${seatInfoHtml(state, rel.left, rel.left.charAt(0).toUpperCase() + rel.left.slice(1))}
+            </div>
+            ${trickHtml(state, rel)}
+            <div class="table-side table-right">
+              ${seatInfoHtml(state, rel.right, rel.right.charAt(0).toUpperCase() + rel.right.slice(1))}
+            </div>
+          </div>
+          <div class="table-bottom">
+            ${seatInfoHtml(state, rel.me, 'You')}
+          </div>
+        </div>
+
+        <div class="game-status-bar">
+          <span class="game-status-msg">${statusMsg}</span>
+        </div>
+
+        ${bidPanelHtml}
+        ${exchangePanelHtml}
+
+        <div class="game-hand-section">
+          <div class="hand-mode-toggle">
+            <button class="mode-btn${handMode === 'spread' ? ' mode-btn-active' : ''}" data-mode="spread">Spread</button>
+            <button class="mode-btn${handMode === 'diagram' ? ' mode-btn-active' : ''}" data-mode="diagram">Diagram</button>
+          </div>
+          <div class="hand-cards" id="hand-cards">${handHtml}</div>
+          <div class="form-error play-err" role="alert" aria-live="polite"></div>
+        </div>
+      </div>`
+
+    // Mode toggle
+    container.querySelectorAll('.mode-btn').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        handMode = btn.dataset.mode
+        render()
+      })
+    })
+
+    // Bid buttons
+    if (isMyBidTurn) {
+      container.querySelectorAll('[data-bid]').forEach((btn) => {
+        btn.addEventListener('click', async () => {
+          if (acting) return
+          acting = true
+          clearTimeout(pollTimer)
+          const raw = btn.dataset.bid
+          const bid = /^\d+$/.test(raw) ? Number(raw) : raw
+          try {
+            const s = await apiBid({ tableId, bid, sessionId, playerId })
+            if (!mounted) return
+            state = s
+            selectedCards = []
+            render()
+          } catch (err) {
+            if (!mounted) return
+            const errEl = container.querySelector('.bid-err')
+            if (errEl) errEl.textContent = err.message || 'Failed to place bid.'
+          } finally {
+            acting = false
+            schedulePoll()
+          }
+        })
+      })
+    }
+
+    // Hand card interactions (play or exchange)
+    const handIsInteractive = isMyPlayTurn || isMyExchangeTurn
+    if (handIsInteractive) {
+      container.querySelectorAll('#hand-cards [data-suit]').forEach((el) => {
+        el.addEventListener('click', async () => {
+          const card = { suit: el.dataset.suit, rank: el.dataset.rank }
+
+          if (isMyPlayTurn) {
+            if (acting) return
+            acting = true
+            clearTimeout(pollTimer)
+            try {
+              const s = await apiPlay({ tableId, card, sessionId, playerId })
+              if (!mounted) return
+              state = s
+              render()
+            } catch (err) {
+              if (!mounted) return
+              const errEl = container.querySelector('.play-err')
+              if (errEl) errEl.textContent = err.message || 'Cannot play that card.'
+            } finally {
+              acting = false
+              schedulePoll()
+            }
+          } else if (isMyExchangeTurn) {
+            const key = `${card.suit}-${card.rank}`
+            const idx = selectedCards.findIndex((c) => `${c.suit}-${c.rank}` === key)
+            if (idx >= 0) {
+              selectedCards.splice(idx, 1)
+            } else if (selectedCards.length < 2) {
+              selectedCards.push(card)
+            }
+            render()
+          }
+        })
+      })
+    }
+
+    // Exchange submit
+    container.querySelector('#exchange-submit-btn')?.addEventListener('click', async () => {
+      if (acting || selectedCards.length !== 2) return
+      acting = true
+      clearTimeout(pollTimer)
+      try {
+        const s = await apiExchange({ tableId, cards: [...selectedCards], sessionId, playerId })
+        if (!mounted) return
+        state = s
+        selectedCards = []
+        render()
+      } catch (err) {
+        if (!mounted) return
+        const errEl = container.querySelector('.exchange-err')
+        if (errEl) errEl.textContent = err.message || 'Failed to exchange cards.'
+      } finally {
+        acting = false
+        schedulePoll()
+      }
+    })
+  }
+
+  // Initial load
+  container.innerHTML = '<div class="game-screen"><p class="game-msg">Loading game\u2026</p></div>'
+  getGameState({ tableId, sessionId, playerId }).then((s) => {
+    if (!mounted) return
+    state = s
+    render()
+    schedulePoll()
+  }).catch((err) => {
+    if (!mounted) return
+    if (err.status === 401) { navigate('#/login'); return }
+    if (err.status === 403) { navigate('#/lobby'); return }
+    container.innerHTML = '<div class="game-screen"><p class="game-msg">Failed to load game. <a href="#/lobby">Back to lobby</a></p></div>'
+  })
+}

--- a/client/web/src/screens/gameOver.js
+++ b/client/web/src/screens/gameOver.js
@@ -1,0 +1,85 @@
+import { getGameState } from '../api.js'
+import { navigate } from '../router.js'
+
+const TEAM = { north: 'ns', south: 'ns', east: 'ew', west: 'ew' }
+
+function getSeatForPlayer(players, playerId) {
+  return Object.entries(players).find(([, pid]) => pid === playerId)?.[0] ?? null
+}
+
+/**
+ * Render the game over screen into `container`.
+ * Fetches the final game state and displays the result.
+ *
+ * @param {HTMLElement} container
+ */
+export function renderGameOverScreen(container) {
+  const sessionId = sessionStorage.getItem('sessionId')
+  const playerId = sessionStorage.getItem('playerId')
+  if (!sessionId || !playerId) { navigate('#/login'); return }
+
+  const params = new URLSearchParams(window.location.hash.split('?')[1] || '')
+  const tableId = params.get('tableId')
+  if (!tableId) { navigate('#/lobby'); return }
+
+  container.innerHTML = `
+    <div class="auth-card">
+      <h1 class="auth-title">Game Over</h1>
+      <p class="auth-message">Loading results\u2026</p>
+    </div>`
+
+  getGameState({ tableId, sessionId, playerId }).then((state) => {
+    const mySeat = getSeatForPlayer(state.players, playerId)
+    const myTeam = mySeat ? TEAM[mySeat] : null
+    const winner = state.winner
+    const iWon = myTeam && winner === myTeam
+
+    const nsScore = state.scores.ns
+    const ewScore = state.scores.ew
+    const nsBags = state.bags.ns
+    const ewBags = state.bags.ew
+
+    const winnerLabel = winner === 'ns' ? 'North / South' : 'East / West'
+    const resultMsg = iWon ? 'Your team wins!' : (myTeam ? 'Your team loses.' : `${winnerLabel} wins!`)
+
+    container.innerHTML = `
+      <div class="auth-card game-over-card">
+        <h1 class="auth-title">Game Over</h1>
+        <p class="auth-message">${resultMsg}</p>
+
+        <div class="game-over-scores">
+          <div class="game-over-team${winner === 'ns' ? ' game-over-winner' : ''}">
+            <span class="game-over-team-label">N/S</span>
+            <span class="game-over-pts">${nsScore}</span>
+            <span class="game-over-bags">${nsBags} bag${nsBags !== 1 ? 's' : ''}</span>
+            ${winner === 'ns' ? '<span class="game-over-crown">Winner</span>' : ''}
+          </div>
+          <div class="game-over-vs">vs</div>
+          <div class="game-over-team${winner === 'ew' ? ' game-over-winner' : ''}">
+            <span class="game-over-team-label">E/W</span>
+            <span class="game-over-pts">${ewScore}</span>
+            <span class="game-over-bags">${ewBags} bag${ewBags !== 1 ? 's' : ''}</span>
+            ${winner === 'ew' ? '<span class="game-over-crown">Winner</span>' : ''}
+          </div>
+        </div>
+
+        <div class="lobby-actions" style="margin-top: 1.5rem;">
+          <button id="lobby-btn" class="btn-primary">Back to Lobby</button>
+        </div>
+      </div>`
+
+    container.querySelector('#lobby-btn').addEventListener('click', () => navigate('#/lobby'))
+  }).catch((err) => {
+    if (err.status === 401) { navigate('#/login'); return }
+
+    container.innerHTML = `
+      <div class="auth-card">
+        <h1 class="auth-title">Game Over</h1>
+        <p class="auth-message">Failed to load results.</p>
+        <div class="lobby-actions" style="margin-top: 1rem;">
+          <button id="lobby-btn" class="btn-primary">Back to Lobby</button>
+        </div>
+      </div>`
+    container.querySelector('#lobby-btn').addEventListener('click', () => navigate('#/lobby'))
+  })
+}

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -46,9 +46,9 @@
 - [x] `P0` Registration and login screens
 - [x] `P0` Create table screen: name only (no visibility/join policy yet)
 - [x] `P0` Join table screen: list of open tables, click to join and choose a seat
-- [ ] `P0` Game screen: display hand, bid input, card play, current trick, scoreboard
-- [ ] `P0` Build hand display in Spread (fan) and Hand Diagram modes
-- [ ] `P0` Game over screen: show final score and winner
+- [x] `P0` Game screen: display hand, bid input, card play, current trick, scoreboard
+- [x] `P0` Build hand display in Spread (fan) and Hand Diagram modes
+- [x] `P0` Game over screen: show final score and winner
 
 ### Testing
 

--- a/test/unit/web/api.test.js
+++ b/test/unit/web/api.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { registerUser, loginUser, resendVerification, forgotPassword, resetPassword, createTable, listTables, sitAtTable } from '../../../client/web/src/api.js'
+import { registerUser, loginUser, resendVerification, forgotPassword, resetPassword, createTable, listTables, sitAtTable, getGameState, placeBid, playCard, submitBlindNilExchange } from '../../../client/web/src/api.js'
 
 /**
  * Build a minimal mock fetch that returns the given status and JSON body.
@@ -292,6 +292,157 @@ describe('sitAtTable', () => {
         assert.equal(err.status, 401)
         return true
       },
+    )
+  })
+})
+
+describe('getGameState', () => {
+  const auth = { tableId: 'table-1', sessionId: 'sess-1', playerId: 'player-1' }
+
+  it('resolves with game state on 200', async () => {
+    const gameState = { phase: 'bidding', myHand: [], scores: { ns: 0, ew: 0 }, bags: { ns: 0, ew: 0 } }
+    const result = await getGameState(auth, mockFetch(200, gameState))
+    assert.equal(result.phase, 'bidding')
+    assert.deepEqual(result.myHand, [])
+  })
+
+  it('throws with status 401 when unauthenticated', async () => {
+    await assert.rejects(
+      () => getGameState(auth, mockFetch(401, { error: 'Unauthorized.' })),
+      (err) => { assert.equal(err.status, 401); return true },
+    )
+  })
+
+  it('throws with status 403 when not seated at table', async () => {
+    await assert.rejects(
+      () => getGameState(auth, mockFetch(403, { error: 'You are not seated at this table' })),
+      (err) => { assert.equal(err.status, 403); return true },
+    )
+  })
+
+  it('throws with status 404 when table not found', async () => {
+    await assert.rejects(
+      () => getGameState(auth, mockFetch(404, { error: 'Table not found' })),
+      (err) => { assert.equal(err.status, 404); return true },
+    )
+  })
+})
+
+describe('placeBid', () => {
+  const auth = { tableId: 'table-1', bid: 3, sessionId: 'sess-1', playerId: 'player-1' }
+
+  it('resolves with updated state on 200', async () => {
+    const state = { phase: 'bidding', bids: { north: null, east: 3, south: null, west: null }, currentBidderSeat: 'south' }
+    const result = await placeBid(auth, mockFetch(200, state))
+    assert.equal(result.bids.east, 3)
+    assert.equal(result.currentBidderSeat, 'south')
+  })
+
+  it('throws with status 409 when not this player\'s turn', async () => {
+    await assert.rejects(
+      () => placeBid(auth, mockFetch(409, { error: 'Not your turn to bid' })),
+      (err) => { assert.equal(err.status, 409); return true },
+    )
+  })
+
+  it('throws with status 400 on invalid bid value', async () => {
+    await assert.rejects(
+      () => placeBid({ ...auth, bid: 14 }, mockFetch(400, { error: 'Invalid bid value: 14' })),
+      (err) => { assert.equal(err.status, 400); return true },
+    )
+  })
+
+  it('throws with status 400 when not eligible for blind nil', async () => {
+    await assert.rejects(
+      () => placeBid({ ...auth, bid: 'blind_nil' }, mockFetch(400, { error: 'Not eligible for Blind Nil' })),
+      (err) => {
+        assert.equal(err.status, 400)
+        assert.match(err.message, /Blind Nil/)
+        return true
+      },
+    )
+  })
+
+  it('throws with status 401 when unauthenticated', async () => {
+    await assert.rejects(
+      () => placeBid(auth, mockFetch(401, { error: 'Unauthorized.' })),
+      (err) => { assert.equal(err.status, 401); return true },
+    )
+  })
+})
+
+describe('playCard', () => {
+  const card = { suit: 'spades', rank: 'A' }
+  const auth = { tableId: 'table-1', card, sessionId: 'sess-1', playerId: 'player-1' }
+
+  it('resolves with updated state on 200', async () => {
+    const state = { phase: 'playing', currentTrick: [{ seat: 'east', card }] }
+    const result = await playCard(auth, mockFetch(200, state))
+    assert.equal(result.phase, 'playing')
+    assert.equal(result.currentTrick.length, 1)
+  })
+
+  it('throws with status 409 when not this player\'s turn', async () => {
+    await assert.rejects(
+      () => playCard(auth, mockFetch(409, { error: 'Not your turn to play' })),
+      (err) => { assert.equal(err.status, 409); return true },
+    )
+  })
+
+  it('throws with status 400 on illegal play', async () => {
+    await assert.rejects(
+      () => playCard(auth, mockFetch(400, { error: 'Illegal play' })),
+      (err) => { assert.equal(err.status, 400); return true },
+    )
+  })
+
+  it('throws with status 400 when card not in hand', async () => {
+    await assert.rejects(
+      () => playCard(auth, mockFetch(400, { error: 'Card not in hand' })),
+      (err) => { assert.equal(err.status, 400); return true },
+    )
+  })
+
+  it('throws with status 401 when unauthenticated', async () => {
+    await assert.rejects(
+      () => playCard(auth, mockFetch(401, { error: 'Unauthorized.' })),
+      (err) => { assert.equal(err.status, 401); return true },
+    )
+  })
+})
+
+describe('submitBlindNilExchange', () => {
+  const cards = [{ suit: 'spades', rank: 'A' }, { suit: 'hearts', rank: 'K' }]
+  const auth = { tableId: 'table-1', cards, sessionId: 'sess-1', playerId: 'player-1' }
+
+  it('resolves with updated state on 200', async () => {
+    const state = { phase: 'playing', currentPlayerSeat: 'east' }
+    const result = await submitBlindNilExchange(auth, mockFetch(200, state))
+    assert.equal(result.phase, 'playing')
+  })
+
+  it('throws with status 400 on invalid exchange (wrong number of cards)', async () => {
+    await assert.rejects(
+      () => submitBlindNilExchange({ ...auth, cards: [cards[0]] }, mockFetch(400, { error: 'Must submit exactly 2 cards' })),
+      (err) => {
+        assert.equal(err.status, 400)
+        assert.match(err.message, /2 cards/)
+        return true
+      },
+    )
+  })
+
+  it('throws with status 400 when wrong player tries to exchange', async () => {
+    await assert.rejects(
+      () => submitBlindNilExchange(auth, mockFetch(400, { error: 'Blind Nil player must send cards first' })),
+      (err) => { assert.equal(err.status, 400); return true },
+    )
+  })
+
+  it('throws with status 401 when unauthenticated', async () => {
+    await assert.rejects(
+      () => submitBlindNilExchange(auth, mockFetch(401, { error: 'Unauthorized.' })),
+      (err) => { assert.equal(err.status, 401); return true },
     )
   })
 })


### PR DESCRIPTION
Closes #83

Implements the Slice 1 web game UI:

- `client/web/src/screens/game.js` — full game screen with 2s polling, scoreboard, 4-seat table view, trick display, bid panel, blind nil exchange, card play, Spread / Diagram hand modes
- `client/web/src/screens/gameOver.js` — final score and winner display
- `client/web/src/api.js` — adds `getGameState`, `placeBid`, `playCard`, `submitBlindNilExchange`
- `client/web/src/main.js` — registers `#/table` and `#/game-over` routes; fixes auth redirect
- `client/web/index.html` — game screen CSS
- `test/unit/web/api.test.js` — unit tests for new API methods (TDD)
- `docs/TASKS.md` — marks three Slice 1 web UI tasks complete

Generated with [Claude Code](https://claude.ai/code)