### PR TITLE
test: add unit and integration tests for game-start gate (issue #78)

### DIFF
--- a/test/integration/game/table.test.js
+++ b/test/integration/game/table.test.js
@@ -173,6 +173,39 @@ describe('POST /api/tables/:tableId/sit', { skip }, () => {
     assert.equal(state.myHand.length, 13, 'player should have 13 cards')
   })
 
+  it('game state remains waiting when only 3 of 4 seats are filled', async () => {
+    const { sessionId, playerId } = players[0]
+    const createRes = await fetch(`${server.baseUrl}/api/tables`, {
+      method: 'POST',
+      headers: { 'x-session-id': sessionId, 'x-player-id': playerId },
+    })
+    const { tableId } = await createRes.json()
+
+    const seats = ['north', 'east', 'south']
+    for (let i = 0; i < 3; i++) {
+      const p = players[i]
+      const sitRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/sit`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-session-id': p.sessionId,
+          'x-player-id': p.playerId,
+        },
+        body: JSON.stringify({ seat: seats[i] }),
+      })
+      assert.equal(sitRes.status, 200, `player ${i + 1} sit failed`)
+    }
+
+    // Game must NOT have started — state endpoint should report waiting
+    const stateRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
+      headers: { 'x-session-id': players[0].sessionId, 'x-player-id': players[0].playerId },
+    })
+    assert.equal(stateRes.status, 200)
+    const state = await stateRes.json()
+    assert.equal(state.status, 'waiting', 'game should still be waiting with only 3 seats filled')
+    assert.equal(state.phase, undefined, 'no game phase should exist yet')
+  })
+
   it('returns 409 when seat is already taken', async () => {
     const { sessionId, playerId } = players[0]
     const createRes = await fetch(`${server.baseUrl}/api/tables`, {

--- a/test/unit/lobby/table.test.js
+++ b/test/unit/lobby/table.test.js
@@ -1,0 +1,52 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { isTableFull } from '../../../server/lobby/table.js'
+
+function makeTable(overrides = {}) {
+  return {
+    tableId: 'test-table-id',
+    hostPlayerId: 'player-1',
+    name: null,
+    seats: { north: null, east: null, south: null, west: null },
+    status: 'waiting',
+    gameId: null,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+describe('isTableFull', () => {
+  it('returns false when no seats are filled (0/4)', () => {
+    const table = makeTable()
+    assert.equal(isTableFull(table), false)
+  })
+
+  it('returns false when 1 seat is filled (1/4)', () => {
+    const table = makeTable({ seats: { north: 'player-1', east: null, south: null, west: null } })
+    assert.equal(isTableFull(table), false)
+  })
+
+  it('returns false when 2 seats are filled (2/4)', () => {
+    const table = makeTable({ seats: { north: 'player-1', east: 'player-2', south: null, west: null } })
+    assert.equal(isTableFull(table), false)
+  })
+
+  it('returns false when 3 seats are filled (3/4)', () => {
+    const table = makeTable({
+      seats: { north: 'player-1', east: 'player-2', south: 'player-3', west: null },
+    })
+    assert.equal(isTableFull(table), false)
+  })
+
+  it('returns true when all 4 seats are filled (4/4)', () => {
+    const table = makeTable({
+      seats: {
+        north: 'player-1',
+        east: 'player-2',
+        south: 'player-3',
+        west: 'player-4',
+      },
+    })
+    assert.equal(isTableFull(table), true)
+  })
+})


### PR DESCRIPTION
Adds missing test coverage for the "gate game start until all 4 human seats are filled" requirement.

- `test/unit/lobby/table.test.js` — unit tests for `isTableFull` covering 0–4 seated players
- `test/integration/game/table.test.js` — integration test asserting game stays in `waiting` state with only 3/4 seats filled

Closes #78

Generated with [Claude Code](https://claude.ai/code)