### PR TITLE
test: expand card visibility tests for getPlayerView and API routes

### DIFF
--- a/test/integration/game/table.test.js
+++ b/test/integration/game/table.test.js
@@ -736,3 +736,127 @@ describe('POST /api/tables/:tableId/blind-nil-exchange', { skip }, () => {
     assert.equal(res.status, 400)
   })
 })
+
+describe('Card visibility: GET /api/tables/:tableId/state', { skip }, () => {
+  let server, db, redis
+  const players = []
+  let tableId
+
+  before(async () => {
+    db = getDb()
+    redis = await getRedis()
+    await ensurePlayersTable(db)
+    for (let i = 1; i <= 4; i++) {
+      await insertVerifiedPlayer(db, {
+        email: `visplayer${i}@gtest.spades.invalid`,
+        username: `gtest_vis${i}`,
+        password: 'password123',
+      })
+    }
+    server = await startTestServer()
+    for (let i = 1; i <= 4; i++) {
+      const data = await loginPlayer(
+        server.baseUrl,
+        `visplayer${i}@gtest.spades.invalid`,
+        'password123',
+      )
+      players.push(data)
+    }
+
+    // Create table and seat all 4 players
+    const createRes = await fetch(`${server.baseUrl}/api/tables`, {
+      method: 'POST',
+      headers: { 'x-session-id': players[0].sessionId, 'x-player-id': players[0].playerId },
+    })
+    const body = await createRes.json()
+    tableId = body.tableId
+
+    const seats = ['north', 'east', 'south', 'west']
+    for (let i = 0; i < 4; i++) {
+      await fetch(`${server.baseUrl}/api/tables/${tableId}/sit`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-session-id': players[i].sessionId,
+          'x-player-id': players[i].playerId,
+        },
+        body: JSON.stringify({ seat: seats[i] }),
+      })
+    }
+  })
+
+  after(async () => {
+    await server.close()
+    await closeDb()
+    await closeRedis()
+  })
+
+  it('state response never contains a hands key for any player', async () => {
+    for (const p of players) {
+      const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
+        headers: { 'x-session-id': p.sessionId, 'x-player-id': p.playerId },
+      })
+      assert.equal(res.status, 200)
+      const body = await res.json()
+      assert.ok(!('hands' in body), 'response must not contain a hands key')
+    }
+  })
+
+  it('each player receives exactly 13 cards in myHand', async () => {
+    for (const p of players) {
+      const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
+        headers: { 'x-session-id': p.sessionId, 'x-player-id': p.playerId },
+      })
+      const body = await res.json()
+      assert.ok(Array.isArray(body.myHand), 'myHand should be an array')
+      assert.equal(body.myHand.length, 13, `player should have 13 cards, got ${body.myHand.length}`)
+    }
+  })
+
+  it('each player receives a distinct myHand (no two players share any card)', async () => {
+    const hands = []
+    for (const p of players) {
+      const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
+        headers: { 'x-session-id': p.sessionId, 'x-player-id': p.playerId },
+      })
+      const body = await res.json()
+      hands.push(body.myHand)
+    }
+
+    const cardKey = (c) => `${c.suit}:${c.rank}`
+    for (let i = 0; i < hands.length; i++) {
+      const keysI = new Set(hands[i].map(cardKey))
+      for (let j = i + 1; j < hands.length; j++) {
+        const keysJ = new Set(hands[j].map(cardKey))
+        for (const k of keysI) {
+          assert.ok(!keysJ.has(k), `player ${i} and player ${j} share card ${k}`)
+        }
+      }
+    }
+  })
+
+  it('state response after a bid still contains no hands key', async () => {
+    // players[1] is east — first to bid (north deals, east bids first)
+    const bidRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/bid`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': players[1].sessionId,
+        'x-player-id': players[1].playerId,
+      },
+      body: JSON.stringify({ bid: 3 }),
+    })
+    assert.equal(bidRes.status, 200)
+    const bidBody = await bidRes.json()
+    assert.ok(!('hands' in bidBody), 'bid response must not contain a hands key')
+
+    // Also check GET /state for each player after the bid
+    for (const p of players) {
+      const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
+        headers: { 'x-session-id': p.sessionId, 'x-player-id': p.playerId },
+      })
+      const body = await res.json()
+      assert.ok(!('hands' in body), 'state response after bid must not contain a hands key')
+    }
+  })
+})

--- a/test/unit/game/state.test.js
+++ b/test/unit/game/state.test.js
@@ -378,6 +378,67 @@ describe('getPlayerView', () => {
     const view = getPlayerView(state, 'north')
     assert.ok(!view.hands || !view.hands.east, 'should not expose other players hands')
   })
+
+  it('strictly excludes the hands key for all 4 seats', () => {
+    const state = createGame('table-1', PLAYER_IDS)
+    for (const seat of ['north', 'east', 'south', 'west']) {
+      const view = getPlayerView(state, seat)
+      assert.ok(!('hands' in view), `hands key must be absent for ${seat}`)
+    }
+  })
+
+  it('myHand exactly matches the dealt cards for each seat', () => {
+    const state = createGame('table-1', PLAYER_IDS)
+    for (const seat of ['north', 'east', 'south', 'west']) {
+      const view = getPlayerView(state, seat)
+      assert.deepEqual(view.myHand, state.hands[seat], `myHand must exactly match dealt hand for ${seat}`)
+    }
+  })
+
+  it('each seat receives a unique hand (no two myHands share any card)', () => {
+    const state = createGame('table-1', PLAYER_IDS)
+    const seats = ['north', 'east', 'south', 'west']
+    const hands = seats.map((seat) => getPlayerView(state, seat).myHand)
+
+    // Build a set of card keys for each hand and verify no overlap
+    const cardKey = (c) => `${c.suit}:${c.rank}`
+    for (let i = 0; i < seats.length; i++) {
+      const keysI = new Set(hands[i].map(cardKey))
+      for (let j = i + 1; j < seats.length; j++) {
+        const keysJ = new Set(hands[j].map(cardKey))
+        for (const k of keysI) {
+          assert.ok(!keysJ.has(k), `${seats[i]} and ${seats[j]} share card ${k}`)
+        }
+      }
+    }
+  })
+
+  it('includes currentTrick in the view (public info)', () => {
+    const state = createGame('table-1', PLAYER_IDS)
+    // currentTrick is public — it must be present in the player view
+    const view = getPlayerView(state, 'north')
+    assert.ok('currentTrick' in view, 'currentTrick must be present in player view')
+    assert.ok(Array.isArray(view.currentTrick))
+  })
+
+  it('does not expose opponent card identity through any top-level key', () => {
+    const state = createGame('table-1', PLAYER_IDS)
+    const northView = getPlayerView(state, 'north')
+    const northHandKeys = new Set(northView.myHand.map((c) => `${c.suit}:${c.rank}`))
+
+    // Build the full set of cards belonging to other seats
+    const otherCards = new Set()
+    for (const seat of ['east', 'south', 'west']) {
+      for (const card of state.hands[seat]) {
+        otherCards.add(`${card.suit}:${card.rank}`)
+      }
+    }
+
+    // None of the cards that belong to other seats should appear in northView's myHand
+    for (const cardKey of northHandKeys) {
+      assert.ok(!otherCards.has(cardKey), `opponent card ${cardKey} leaked into north's myHand`)
+    }
+  })
 })
 
 describe('CLOCKWISE_SEATS', () => {


### PR DESCRIPTION
Adds unit and integration tests enforcing the card visibility security boundary (issue #76).

**Unit tests** (`test/unit/game/state.test.js`): strict absence of `hands` key, exact card identity per seat, disjoint hands across all 4 seats, currentTrick present, no opponent card leakage.

**Integration tests** (`test/integration/game/table.test.js`): no `hands` key in state or bid responses, 13 cards per player, disjoint hand sets across all players.

Closes #76

Generated with [Claude Code](https://claude.ai/code)