### PR TITLE
feat: hand display Spread and Hand Diagram modes (#84)

### DIFF
--- a/client/web/src/hand.js
+++ b/client/web/src/hand.js
@@ -1,0 +1,67 @@
+const SUIT_SYMBOL = { spades: '\u2660', hearts: '\u2665', diamonds: '\u2666', clubs: '\u2663' }
+const RED_SUIT = new Set(['hearts', 'diamonds'])
+
+function esc(s) {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+/**
+ * Render a single card as an HTML `<span>` element.
+ *
+ * @param {{ suit: string, rank: string }} card
+ * @param {string} [extraCls] - additional CSS class(es) to append
+ * @returns {string} HTML string
+ */
+export function cardHtml(card, extraCls) {
+  const s = SUIT_SYMBOL[card.suit]
+  const red = RED_SUIT.has(card.suit) ? ' card-red' : ''
+  const cls = extraCls ? ` ${extraCls}` : ''
+  return `<span class="card${red}${cls}" data-suit="${esc(card.suit)}" data-rank="${esc(card.rank)}">${esc(card.rank)}${s}</span>`
+}
+
+/**
+ * Render a hand of cards in Spread (fan) mode — each card displayed side-by-side.
+ *
+ * @param {Array<{ suit: string, rank: string }>} hand
+ * @param {function({ suit: string, rank: string }): string} extraClsFn - returns extra CSS classes for a given card
+ * @returns {string} HTML string
+ */
+export function handSpreadHtml(hand, extraClsFn) {
+  return hand.map((card) => cardHtml(card, extraClsFn(card))).join('')
+}
+
+/**
+ * Render a hand of cards in Hand Diagram mode — cards grouped by suit, one suit per row,
+ * with the suit symbol followed by the card ranks. Suits with no cards are omitted.
+ *
+ * Example output shape: ♠J32  ♥A32  ♦K32  ♣AQ32
+ *
+ * @param {Array<{ suit: string, rank: string }>} hand
+ * @param {function({ suit: string, rank: string }): string} extraClsFn - returns extra CSS classes for a given card
+ * @returns {string} HTML string
+ */
+export function handDiagramHtml(hand, extraClsFn) {
+  const bySuit = { spades: [], hearts: [], diamonds: [], clubs: [] }
+  for (const c of hand) bySuit[c.suit].push(c)
+
+  return Object.entries(bySuit)
+    .filter(([, cards]) => cards.length > 0)
+    .map(([suit, cards]) => {
+      const s = SUIT_SYMBOL[suit]
+      const red = RED_SUIT.has(suit) ? ' suit-red' : ''
+      const extra = extraClsFn
+      const cardsHtml = cards
+        .map((card) => {
+          const cls = extra(card)
+          return cardHtml(card, `card-compact${cls ? ' ' + cls : ''}`)
+        })
+        .join('')
+      return `<div class="diagram-row"><span class="diagram-suit${red}">${s}</span>${cardsHtml}</div>`
+    })
+    .join('')
+}

--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -5,6 +5,7 @@ import {
   submitBlindNilExchange as apiExchange,
 } from '../api.js'
 import { navigate } from '../router.js'
+import { handSpreadHtml, handDiagramHtml } from '../hand.js'
 
 const SUIT_SYMBOL = { spades: '\u2660', hearts: '\u2665', diamonds: '\u2666', clubs: '\u2663' }
 const RED_SUIT = new Set(['hearts', 'diamonds'])
@@ -44,13 +45,6 @@ function bidLabel(bid) {
   return String(bid)
 }
 
-function cardHtml(card, extraCls) {
-  const s = SUIT_SYMBOL[card.suit]
-  const red = RED_SUIT.has(card.suit) ? ' card-red' : ''
-  const cls = extraCls ? ` ${extraCls}` : ''
-  return `<span class="card${red}${cls}" data-suit="${esc(card.suit)}" data-rank="${esc(card.rank)}">${esc(card.rank)}${s}</span>`
-}
-
 function seatInfoHtml(state, seat, label) {
   const bid = state.bids[seat]
   const tricks = state.tricksWon[seat]
@@ -88,25 +82,6 @@ function trickHtml(state, rel) {
       </div>
       <div class="trick-row">${slot(rel.me)}</div>
     </div>`
-}
-
-function handSpreadHtml(hand, extraClsFn) {
-  return hand.map((card) => cardHtml(card, extraClsFn(card))).join('')
-}
-
-function handDiagramHtml(hand, extraClsFn) {
-  const bySuit = { spades: [], hearts: [], diamonds: [], clubs: [] }
-  for (const c of hand) bySuit[c.suit].push(c)
-
-  return Object.entries(bySuit)
-    .filter(([, cards]) => cards.length > 0)
-    .map(([suit, cards]) => {
-      const s = SUIT_SYMBOL[suit]
-      const red = RED_SUIT.has(suit) ? ' suit-red' : ''
-      const cardsHtml = cards.map((card) => cardHtml(card, `card-compact${extraClsFn(card) ? ' ' + extraClsFn(card) : ''}`)).join('')
-      return `<div class="diagram-row"><span class="diagram-suit${red}">${s}</span>${cardsHtml}</div>`
-    })
-    .join('')
 }
 
 /**

--- a/test/unit/web/hand.test.js
+++ b/test/unit/web/hand.test.js
@@ -1,0 +1,225 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { cardHtml, handSpreadHtml, handDiagramHtml } from '../../../client/web/src/hand.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const noExtra = () => ''
+
+function parseSpans(html) {
+  // Extract all <span> opening tag attribute strings
+  const spans = []
+  const re = /<span([^>]*)>/g
+  let m
+  while ((m = re.exec(html)) !== null) spans.push(m[1])
+  return spans
+}
+
+function attr(spanAttrs, name) {
+  const m = spanAttrs.match(new RegExp(`${name}="([^"]*)"`, ''))
+  return m ? m[1] : null
+}
+
+// ---------------------------------------------------------------------------
+// cardHtml
+// ---------------------------------------------------------------------------
+
+describe('cardHtml', () => {
+  it('renders rank and suit symbol inside a span', () => {
+    const html = cardHtml({ suit: 'spades', rank: 'A' }, '')
+    assert.ok(html.includes('A\u2660'), 'should contain rank + ♠')
+    assert.ok(html.startsWith('<span'), 'should be a span element')
+  })
+
+  it('sets data-suit and data-rank attributes', () => {
+    const html = cardHtml({ suit: 'hearts', rank: 'K' }, '')
+    assert.ok(html.includes('data-suit="hearts"'))
+    assert.ok(html.includes('data-rank="K"'))
+  })
+
+  it('adds card-red class for red suits', () => {
+    const hearts = cardHtml({ suit: 'hearts', rank: '2' }, '')
+    const diamonds = cardHtml({ suit: 'diamonds', rank: '2' }, '')
+    assert.ok(hearts.includes('card-red'), 'hearts should be red')
+    assert.ok(diamonds.includes('card-red'), 'diamonds should be red')
+  })
+
+  it('does not add card-red class for black suits', () => {
+    const spades = cardHtml({ suit: 'spades', rank: '2' }, '')
+    const clubs = cardHtml({ suit: 'clubs', rank: '2' }, '')
+    assert.ok(!spades.includes('card-red'), 'spades should not be red')
+    assert.ok(!clubs.includes('card-red'), 'clubs should not be red')
+  })
+
+  it('appends extra CSS class when provided', () => {
+    const html = cardHtml({ suit: 'spades', rank: 'Q' }, 'card-play')
+    assert.ok(html.includes('card-play'))
+  })
+
+  it('does not append extra whitespace when extraCls is empty string', () => {
+    const html = cardHtml({ suit: 'spades', rank: 'Q' }, '')
+    // class attribute should not end with a trailing space before the closing quote
+    assert.ok(!html.match(/class="[^"]*\s"/), 'should have no trailing space in class')
+  })
+
+  it('escapes HTML special characters in rank', () => {
+    const html = cardHtml({ suit: 'spades', rank: '<script>' }, '')
+    assert.ok(!html.includes('<script>'), 'raw HTML should be escaped')
+    assert.ok(html.includes('&lt;script&gt;'))
+  })
+
+  it('uses the correct symbol for each suit', () => {
+    assert.ok(cardHtml({ suit: 'spades', rank: 'A' }, '').includes('\u2660'))
+    assert.ok(cardHtml({ suit: 'hearts', rank: 'A' }, '').includes('\u2665'))
+    assert.ok(cardHtml({ suit: 'diamonds', rank: 'A' }, '').includes('\u2666'))
+    assert.ok(cardHtml({ suit: 'clubs', rank: 'A' }, '').includes('\u2663'))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handSpreadHtml — Spread (fan) mode
+// ---------------------------------------------------------------------------
+
+describe('handSpreadHtml', () => {
+  it('returns empty string for an empty hand', () => {
+    assert.equal(handSpreadHtml([], noExtra), '')
+  })
+
+  it('renders one span per card', () => {
+    const hand = [
+      { suit: 'spades', rank: 'A' },
+      { suit: 'hearts', rank: 'K' },
+      { suit: 'diamonds', rank: 'Q' },
+    ]
+    const html = handSpreadHtml(hand, noExtra)
+    const spans = parseSpans(html)
+    assert.equal(spans.length, 3)
+  })
+
+  it('renders cards in hand order', () => {
+    const hand = [
+      { suit: 'spades', rank: 'A' },
+      { suit: 'clubs', rank: '2' },
+    ]
+    const html = handSpreadHtml(hand, noExtra)
+    const sA = html.indexOf('data-rank="A"')
+    const s2 = html.indexOf('data-rank="2"')
+    assert.ok(sA < s2, 'Ace of spades should appear before 2 of clubs')
+  })
+
+  it('forwards extra CSS class returned by extraClsFn', () => {
+    const hand = [{ suit: 'spades', rank: 'A' }]
+    const html = handSpreadHtml(hand, () => 'card-play')
+    assert.ok(html.includes('card-play'))
+  })
+
+  it('does not add extra class when extraClsFn returns empty string', () => {
+    const hand = [{ suit: 'spades', rank: 'A' }]
+    const html = handSpreadHtml(hand, noExtra)
+    assert.ok(!html.includes('card-play'))
+  })
+
+  it('marks red-suit cards with card-red', () => {
+    const hand = [
+      { suit: 'hearts', rank: '5' },
+      { suit: 'spades', rank: '5' },
+    ]
+    const html = handSpreadHtml(hand, noExtra)
+    // Only the hearts card should get card-red
+    const heartsIdx = html.indexOf('data-suit="hearts"')
+    const spadesIdx = html.indexOf('data-suit="spades"')
+    // Grab the class attributes from each span block
+    const heartsSpan = html.slice(html.lastIndexOf('<span', heartsIdx), heartsIdx)
+    const spadesSpan = html.slice(html.lastIndexOf('<span', spadesIdx), spadesIdx)
+    assert.ok(heartsSpan.includes('card-red'))
+    assert.ok(!spadesSpan.includes('card-red'))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handDiagramHtml — Hand Diagram mode
+// ---------------------------------------------------------------------------
+
+describe('handDiagramHtml', () => {
+  it('returns empty string for an empty hand', () => {
+    assert.equal(handDiagramHtml([], noExtra), '')
+  })
+
+  it('creates one diagram-row div per suit present', () => {
+    const hand = [
+      { suit: 'spades', rank: 'A' },
+      { suit: 'hearts', rank: 'K' },
+      { suit: 'spades', rank: '2' },
+    ]
+    const html = handDiagramHtml(hand, noExtra)
+    const rows = (html.match(/class="diagram-row"/g) || []).length
+    assert.equal(rows, 2, 'only suits with cards should produce a row')
+  })
+
+  it('omits suits with no cards', () => {
+    const hand = [{ suit: 'spades', rank: 'A' }]
+    const html = handDiagramHtml(hand, noExtra)
+    assert.ok(!html.includes('\u2665'), 'hearts symbol should not appear')
+    assert.ok(!html.includes('\u2666'), 'diamonds symbol should not appear')
+    assert.ok(!html.includes('\u2663'), 'clubs symbol should not appear')
+  })
+
+  it('shows the suit symbol at the start of each row', () => {
+    const hand = [
+      { suit: 'spades', rank: 'A' },
+      { suit: 'hearts', rank: 'K' },
+    ]
+    const html = handDiagramHtml(hand, noExtra)
+    assert.ok(html.includes('class="diagram-suit"'), 'spades row should have diagram-suit class')
+    assert.ok(html.includes('class="diagram-suit suit-red"'), 'hearts row should have suit-red class')
+  })
+
+  it('renders all cards for a suit in a single row', () => {
+    const hand = [
+      { suit: 'spades', rank: 'A' },
+      { suit: 'spades', rank: 'K' },
+      { suit: 'spades', rank: '2' },
+    ]
+    const html = handDiagramHtml(hand, noExtra)
+    // All three should appear and there should be exactly one row
+    assert.equal((html.match(/class="diagram-row"/g) || []).length, 1)
+    assert.ok(html.includes('data-rank="A"'))
+    assert.ok(html.includes('data-rank="K"'))
+    assert.ok(html.includes('data-rank="2"'))
+  })
+
+  it('adds card-compact class to every card in diagram mode', () => {
+    const hand = [
+      { suit: 'spades', rank: 'A' },
+      { suit: 'hearts', rank: 'K' },
+    ]
+    const html = handDiagramHtml(hand, noExtra)
+    const cardSpans = (html.match(/card-compact/g) || []).length
+    assert.equal(cardSpans, 2)
+  })
+
+  it('forwards extra CSS class alongside card-compact', () => {
+    const hand = [{ suit: 'spades', rank: 'A' }]
+    const html = handDiagramHtml(hand, () => 'card-sel')
+    assert.ok(html.includes('card-compact card-sel'))
+  })
+
+  it('suit order is spades, hearts, diamonds, clubs', () => {
+    const hand = [
+      { suit: 'clubs', rank: '3' },
+      { suit: 'diamonds', rank: '4' },
+      { suit: 'hearts', rank: '5' },
+      { suit: 'spades', rank: '6' },
+    ]
+    const html = handDiagramHtml(hand, noExtra)
+    const spIdx = html.indexOf('\u2660')
+    const hIdx = html.indexOf('\u2665')
+    const dIdx = html.indexOf('\u2666')
+    const cIdx = html.indexOf('\u2663')
+    assert.ok(spIdx < hIdx, 'spades before hearts')
+    assert.ok(hIdx < dIdx, 'hearts before diamonds')
+    assert.ok(dIdx < cIdx, 'diamonds before clubs')
+  })
+})


### PR DESCRIPTION
Extract hand display mode functions into a dedicated testable module and add unit tests.

**Changes:**
- `client/web/src/hand.js`: exports `cardHtml`, `handSpreadHtml`, `handDiagramHtml`
- `test/unit/web/hand.test.js`: 20 unit tests covering both display modes
- `client/web/src/screens/game.js`: imports from hand.js, removes duplicate definitions

Closes #84

Generated with [Claude Code](https://claude.ai/code)