### PR TITLE
test: add game_over phase transition and API tests for game over screen

### DIFF
--- a/test/integration/game/table.test.js
+++ b/test/integration/game/table.test.js
@@ -893,3 +893,101 @@ describe('Card visibility: GET /api/tables/:tableId/state', { skip }, () => {
     }
   })
 })
+
+describe('GET /api/tables/:tableId/state — game_over phase', { skip }, () => {
+  let server, db, redis
+  const players = []
+  let tableId
+
+  before(async () => {
+    db = getDb()
+    redis = await getRedis()
+    await ensurePlayersTable(db)
+    for (let i = 1; i <= 4; i++) {
+      await insertVerifiedPlayer(db, {
+        email: `govplayer${i}@gtest.spades.invalid`,
+        username: `gtest_gov${i}`,
+        password: 'password123',
+      })
+    }
+    server = await startTestServer()
+    for (let i = 1; i <= 4; i++) {
+      const data = await loginPlayer(
+        server.baseUrl,
+        `govplayer${i}@gtest.spades.invalid`,
+        'password123',
+      )
+      players.push(data)
+    }
+
+    const createRes = await fetch(`${server.baseUrl}/api/tables`, {
+      method: 'POST',
+      headers: { 'x-session-id': players[0].sessionId, 'x-player-id': players[0].playerId },
+    })
+    const body = await createRes.json()
+    tableId = body.tableId
+
+    const seats = ['north', 'east', 'south', 'west']
+    for (let i = 0; i < 4; i++) {
+      await fetch(`${server.baseUrl}/api/tables/${tableId}/sit`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-session-id': players[i].sessionId,
+          'x-player-id': players[i].playerId,
+        },
+        body: JSON.stringify({ seat: seats[i] }),
+      })
+    }
+
+    // Inject a game_over state into Redis (NS wins with 270 pts)
+    const gameStateRaw = await redis.get(`game:${tableId}`)
+    const gameState = JSON.parse(gameStateRaw)
+    await redis.set(`game:${tableId}`, JSON.stringify({
+      ...gameState,
+      phase: 'game_over',
+      gameOver: true,
+      winner: 'ns',
+      scores: { ns: 270, ew: 40 },
+      bags: { ns: 2, ew: 0 },
+    }), { EX: 3600 })
+  })
+
+  after(async () => {
+    await server.close()
+    await closeDb()
+    await closeRedis()
+  })
+
+  it('returns phase=game_over with correct winner, scores, and bags', async () => {
+    const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
+      headers: { 'x-session-id': players[0].sessionId, 'x-player-id': players[0].playerId },
+    })
+    assert.equal(res.status, 200)
+    const body = await res.json()
+    assert.equal(body.phase, 'game_over')
+    assert.equal(body.winner, 'ns')
+    assert.deepEqual(body.scores, { ns: 270, ew: 40 })
+    assert.deepEqual(body.bags, { ns: 2, ew: 0 })
+  })
+
+  it('game_over state response does not expose the hands key', async () => {
+    const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
+      headers: { 'x-session-id': players[0].sessionId, 'x-player-id': players[0].playerId },
+    })
+    const body = await res.json()
+    assert.ok(!('hands' in body), 'response must not contain a hands key')
+  })
+
+  it('all four players see the same game_over result', async () => {
+    for (const player of players) {
+      const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
+        headers: { 'x-session-id': player.sessionId, 'x-player-id': player.playerId },
+      })
+      assert.equal(res.status, 200)
+      const body = await res.json()
+      assert.equal(body.phase, 'game_over', `player ${player.playerId} should see game_over`)
+      assert.equal(body.winner, 'ns', `player ${player.playerId} should see winner=ns`)
+    }
+  })
+})

--- a/test/unit/game/state.test.js
+++ b/test/unit/game/state.test.js
@@ -693,3 +693,99 @@ describe('dealer rotation', () => {
     assert.equal(state.currentBidderSeat, 'north')
   })
 })
+
+describe('game over — phase transition', () => {
+  /**
+   * Build a state one trick from hand completion with fixed bids.
+   * Bidding order: east, south, west, north
+   *   NS team total: 7 (north is second bidder)
+   *   EW team total: 6 (west is second bidder)
+   * East leads and wins the 13th trick with the Ace of clubs.
+   *
+   * @param {{ initialScores: {ns,ew}, tricksWon12: {north,east,south,west} }} opts
+   *   tricksWon12 must sum to 12 (tricks before the final one).
+   */
+  function buildNearEndState({ initialScores, tricksWon12 }) {
+    let state = createGame('table-1', PLAYER_IDS)
+    state = { ...state, scores: initialScores, bags: { ns: 0, ew: 0 } }
+    // Bidding order: east, south, west, north
+    state = placeBid(state, 'east', 2)   // EW advisory
+    state = placeBid(state, 'south', 4)  // NS advisory
+    state = placeBid(state, 'west', 6)   // EW second bidder → team total 6
+    state = placeBid(state, 'north', 7)  // NS second bidder → team total 7
+    const hands = {
+      north: [{ suit: 'clubs', rank: '2' }],
+      east:  [{ suit: 'clubs', rank: 'A' }],
+      south: [{ suit: 'clubs', rank: '4' }],
+      west:  [{ suit: 'clubs', rank: '5' }],
+    }
+    state = {
+      ...state,
+      phase: 'playing',
+      hands,
+      completedTricks: Array.from({ length: 12 }, () => ({ winner: 'north', plays: [] })),
+      tricksWon: tricksWon12,
+      currentPlayerSeat: 'east',
+      leadSeat: 'east',
+      isFirstTrick: false,
+      spadesbroken: true,
+      currentTrick: [],
+    }
+    for (const seat of ['east', 'south', 'west', 'north']) {
+      state = playCard(state, seat, state.hands[seat][0])
+    }
+    return state
+  }
+
+  it('transitions to game_over with winner=ns when NS score reaches 250', () => {
+    // After hand: NS=9 tricks (north:4+south:5) vs bid 7 → +70 → 200+70=270 ≥ 250
+    //             EW=4 tricks (east:3+west:1) vs bid 6 → -60 → 100-60=40
+    const state = buildNearEndState({
+      initialScores: { ns: 200, ew: 100 },
+      tricksWon12: { north: 4, east: 2, south: 5, west: 1 }, // sum=12
+    })
+    assert.equal(state.phase, 'game_over')
+    assert.equal(state.winner, 'ns')
+    assert.equal(state.gameOver, true)
+    assert.equal(state.scores.ns, 270)
+  })
+
+  it('starts next hand in bidding phase when neither team reaches a threshold', () => {
+    // After hand: NS=9 vs bid 7 → +70 → 0+70=70 (< 250); EW=4 vs bid 6 → -60 (> -250)
+    const state = buildNearEndState({
+      initialScores: { ns: 0, ew: 0 },
+      tricksWon12: { north: 4, east: 2, south: 5, west: 1 },
+    })
+    assert.equal(state.phase, 'bidding', 'should start the next hand')
+    assert.equal(state.winner, null)
+    assert.equal(state.gameOver, false)
+    assert.equal(state.handNumber, 2)
+  })
+
+  it('transitions to game_over with winner=ew when NS score drops to -250 or below', () => {
+    // After hand: NS=3 tricks (north:1+south:2) vs bid 7 → -70 → -200-70=-270 ≤ -250
+    //             EW=10 tricks (east:6+west:4) vs bid 6 → +60 + 4 bags → 100+60=160
+    const state = buildNearEndState({
+      initialScores: { ns: -200, ew: 100 },
+      tricksWon12: { north: 1, east: 5, south: 2, west: 4 }, // sum=12
+    })
+    assert.equal(state.phase, 'game_over')
+    assert.equal(state.winner, 'ew')
+    assert.equal(state.gameOver, true)
+    assert.equal(state.scores.ns, -270)
+  })
+
+  it('getPlayerView in game_over state exposes winner and scores but not all hands', () => {
+    const state = buildNearEndState({
+      initialScores: { ns: 200, ew: 100 },
+      tricksWon12: { north: 4, east: 2, south: 5, west: 1 },
+    })
+    const view = getPlayerView(state, 'north')
+    assert.equal(view.phase, 'game_over')
+    assert.equal(view.winner, 'ns')
+    assert.ok('scores' in view, 'view should include scores')
+    assert.ok('bags' in view, 'view should include bags')
+    assert.ok(!('hands' in view), 'view must not expose the full hands object')
+    assert.ok('myHand' in view, 'view must expose myHand for the requesting player')
+  })
+})


### PR DESCRIPTION
Closes #85

## Summary

- The game over screen was already fully implemented (TASKS.md marks it `[x]`): `gameOver.js` renders final scores, bags, and a personalized win/loss message; `game.js` redirects to `#/game-over` on `phase === 'game_over'`; the server sets `phase`, `winner`, `scores`, and `bags` correctly
- Added unit tests verifying the `game_over` phase transition: win condition, loss condition, no-threshold continuation, and that `getPlayerView` strips `hands` in game_over state
- Added integration tests confirming the GET `/state` API returns `phase=game_over`, `winner`, `scores`, `bags` correctly and never exposes the `hands` key

## Test plan

- [x] Unit: `test/unit/game/state.test.js` — `game over — phase transition` describe block
- [x] Integration: `test/integration/game/table.test.js` — `GET /api/tables/:tableId/state — game_over phase` describe block

Generated with [Claude Code](https://claude.ai/code)