### PR TITLE
docs: add WebSocket real-time architecture to PRD and task list

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -56,7 +56,37 @@
 
 ---
 
-## Slice 2 — Full Lobby & Access Control
+## Slice 2 — Real-Time WebSocket Layer
+
+> Goal: all in-game state updates are delivered via WebSocket push instead of HTTP polling. This slice is a prerequisite for Slice 3 (spectating requires live updates) and Slice 4 (social presence requires connection state). Do not start Slice 3 until this slice is complete and merged to `dev`.
+>
+> See `docs/spades_prd.md` Section 6.4 for the full real-time architecture spec, event catalog, and disconnect/reconnect behaviour.
+
+### Backend
+
+- [ ] `P0` Build `server/ws/` WebSocket server: authenticated connection upgrade (`x-session-id` header), table room management (`table:{tableId}` rooms), heartbeat ping/pong (30 s interval, 10 s timeout)
+- [ ] `P0` Implement Redis pub/sub fan-out: each `table:{tableId}` room and the `lobby` channel map to a Redis pub/sub channel so all server instances can broadcast to connected clients
+- [ ] `P0` Emit in-game events after each validated state mutation: `HAND_DEALT` (per-player), `BID_PLACED`, `BLIND_NIL_EXCHANGE_PROMPT`, `CARD_PLAYED`, `TRICK_COMPLETE`, `HAND_SCORED`, `GAME_OVER`, `TURN_CHANGED`
+- [ ] `P0` Implement player disconnect detection: emit `PLAYER_DISCONNECTED` with a 60 s reconnect window on ping failure or clean close; emit `PLAYER_RECONNECTED` when the player re-joins within the window; stall game with "waiting for reconnect" indicator if window expires
+- [ ] `P1` Emit lobby events to the `lobby` channel: `TABLE_CREATED`, `TABLE_UPDATED`, `TABLE_REMOVED`
+
+### Web Client
+
+- [ ] `P0` Establish authenticated WSS connection on game screen mount; tear down on unmount
+- [ ] `P0` Remove `schedulePoll()` timeout loop from `client/web/src/screens/game.js`; re-render on incoming WebSocket events instead
+- [ ] `P0` On reconnect: call `GET /api/tables/:tableId/state` to re-hydrate, then resume WS event listener
+- [ ] `P1` Subscribe to lobby channel on lobby screen mount; update table list on `TABLE_CREATED`, `TABLE_UPDATED`, `TABLE_REMOVED` — eliminating the manual-refresh requirement
+
+### Testing
+
+- [ ] `P0` Unit tests (`test/ws/`): connection authentication, room join/leave, event emission after each game action, ping/pong lifecycle
+- [ ] `P0` Integration test: play a card action triggers `CARD_PLAYED` event received by all players in the room
+- [ ] `P0` Integration test: disconnect within reconnect window resumes game; expired window stalls game
+- [ ] `P1` Integration test: `TABLE_CREATED` / `TABLE_UPDATED` / `TABLE_REMOVED` events delivered to lobby channel subscribers
+
+---
+
+## Slice 3 — Full Lobby & Access Control
 
 > Goal: the complete table discovery and access model from the PRD is in place — public/friends-only/private visibility, join policies, shareable links, spectating, and the arrive-then-sit flow.
 
@@ -74,7 +104,7 @@
 
 ---
 
-## Slice 3 — Social Features
+## Slice 4 — Social Features
 
 > Goal: players can find and play with friends, see who is online, and communicate during games.
 
@@ -90,7 +120,7 @@
 
 ---
 
-## Slice 4 — UI Polish & Customization
+## Slice 5 — UI Polish & Customization
 
 > Goal: the game looks and feels good; players can personalise their experience.
 
@@ -102,11 +132,11 @@
 
 ---
 
-## Slice 5 — Scale, Harden & Mobile
+## Slice 6 — Scale, Harden & Mobile
 
-> Goal: the game meets its non-functional requirements and is available on mobile.
+> Goal: the game meets its non-functional requirements and is available on mobile. The <200ms p95 latency target is achieved by the WebSocket implementation in Slice 2; this slice validates it at scale.
 
-- [ ] `P0` Achieve <200ms p95 turn action latency (card play → all clients updated)
+- [ ] `P0` Load test and validate <200ms p95 turn action latency (card play → all clients updated) at 10,000+ concurrent sessions
 - [ ] `P0` Support 10,000+ concurrent game sessions at launch
 - [ ] `P0` Maintain 99.5% monthly uptime SLA
 - [ ] `P0` Build responsive web app for Chrome 100+, Firefox 100+, Safari 15+, Edge 100+ (desktop & tablet)

--- a/docs/spades_architecture.mermaid
+++ b/docs/spades_architecture.mermaid
@@ -20,7 +20,7 @@ graph TB
     end
 
     subgraph Realtime["Real-Time Layer"]
-        WS["WebSocket Server<br/>p95 latency < 200ms"]
+        WS["WebSocket Server<br/>p95 latency < 200ms<br/>──────────────────<br/>HAND_DEALT · CARD_PLAYED<br/>BID_PLACED · TRICK_COMPLETE<br/>HAND_SCORED · GAME_OVER<br/>TURN_CHANGED · PLAYER_DISCONNECTED<br/>TABLE_CREATED · TABLE_UPDATED"]
         ANTICHEAT["Anti-Cheat Engine<br/>Server-side State Validation<br/>Legal Move Enforcement<br/>Card Visibility Control"]
     end
 
@@ -37,7 +37,7 @@ graph TB
     end
 
     WEB & IOS & AND -->|HTTPS| GW
-    WEB & IOS & AND <-->|WSS| WS
+    WEB & IOS & AND <-->|"WSS (authenticated)"| WS
 
     GW --> AUTH
     AUTH --> SESSION
@@ -50,6 +50,7 @@ graph TB
 
     WS --> ANTICHEAT
     ANTICHEAT --> MATCH
+    WS <-->|"pub/sub (fan-out)"| CACHE
 
     MATCH --> GAMEDB
     MATCH --> CACHE

--- a/docs/spades_prd.md
+++ b/docs/spades_prd.md
@@ -2,8 +2,8 @@
 
 | Field | Value |
 |---|---|
-| **Version** | 1.2 — Rules Clarifications |
-| **Date** | March 2026 |
+| **Version** | 1.3 — Real-Time Architecture |
+| **Date** | April 2026 |
 | **Status** | For Review |
 | **Product** | Spades Online (Mobile & Web) |
 
@@ -191,6 +191,61 @@ The bidding sequence follows a partnership model designed to allow informed team
 - **Account security:** email/password with required email verification; optional 2FA via authenticator app.
 - Rate limiting on all authentication and social endpoints to prevent abuse.
 
+### 6.4 Real-Time Architecture
+
+All in-game state updates and lobby changes are delivered to clients via a persistent WebSocket connection rather than polling. The REST API remains the **action** mechanism (clients POST bids, card plays, etc.); WebSockets are the **notification** mechanism (the server pushes authoritative state updates to all interested clients immediately after each state change).
+
+#### 6.4.1 Connection Lifecycle
+
+- Clients establish an authenticated WebSocket connection on game screen mount (or lobby screen mount for lobby events).
+- Authentication occurs on the connection upgrade handshake using the player's session token (`x-session-id` header). Unauthenticated upgrade requests are rejected with HTTP 401.
+- Clients join a **room** corresponding to `table:{tableId}` upon seating or spectating. Lobby subscribers join a `lobby` channel.
+- The server emits a heartbeat ping every 30 seconds; clients must respond with a pong within 10 seconds or the connection is considered dead.
+- On reconnect, clients call `GET /api/tables/:tableId/state` to re-hydrate from authoritative server state, then resume listening for WebSocket events.
+
+#### 6.4.2 Event Shape
+
+All WebSocket events follow the envelope:
+
+```json
+{ "type": "EVENT_NAME", "payload": { ... } }
+```
+
+Events must not change shape in a backward-incompatible way without coordinating a client release.
+
+#### 6.4.3 In-Game Events
+
+| Event | Audience | Key Payload Fields |
+|---|---|---|
+| `HAND_DEALT` | Per-player (4 individual sends) | `myHand`, `dealer`, `biddingOrder` |
+| `BID_PLACED` | All in room | `seat`, `bidType` (`nil` / `blindNil` / `number`); numeric value hidden until end-of-hand scoring |
+| `BLIND_NIL_EXCHANGE_PROMPT` | Specific player | `direction` (`send` / `receive`), `count` |
+| `CARD_PLAYED` | All in room | `seat`, `card` |
+| `TRICK_COMPLETE` | All in room | `winnerSeat`, `plays` |
+| `HAND_SCORED` | All in room | `scoreDelta`, `newTotals`, `bags` |
+| `GAME_OVER` | All in room | `winningTeam`, `finalScores` |
+| `TURN_CHANGED` | All in room | `activeSeat`, `phase` |
+| `PLAYER_DISCONNECTED` | All in room | `seat`, `reconnectWindowSeconds` |
+| `PLAYER_RECONNECTED` | All in room | `seat` |
+
+#### 6.4.4 Lobby Events
+
+| Event | Audience | Key Payload Fields |
+|---|---|---|
+| `TABLE_CREATED` | Lobby channel | `id`, `name`, `host`, `seats`, `ruleset`, `joinPolicy` |
+| `TABLE_UPDATED` | Lobby channel | `tableId`, updated fields |
+| `TABLE_REMOVED` | Lobby channel | `tableId` |
+
+#### 6.4.5 Fan-Out Architecture
+
+The WebSocket server uses Redis pub/sub as its broadcast bus. Each room (`table:{tableId}`, `lobby`) maps to a Redis pub/sub channel. This allows multiple server instances to fan out events to all connected clients in a room, ensuring horizontal scalability without sticky sessions.
+
+#### 6.4.6 Player Disconnect & Reconnect
+
+1. When a WebSocket connection drops (ping failure or clean close), the server emits `PLAYER_DISCONNECTED` to the room with a countdown (default 60 seconds).
+2. If the player reconnects and re-authenticates within the window, they re-join the room and receive a full state re-hydration via `GET /api/tables/:tableId/state`.
+3. If the reconnect window expires: the game stalls for other players with a "waiting for reconnect" indicator. The v1.1 disconnect-fill bot (see [Section 9](#9-post-launch-roadmap)) takes over at the start of the next hand once this infrastructure is in place.
+
 ---
 
 ## 7. Open Questions
@@ -326,4 +381,4 @@ Variants may introduce separate casual lobbies.
 
 ---
 
-*End of Document — Spades Online PRD v1.2*
+*End of Document — Spades Online PRD v1.3*


### PR DESCRIPTION
Adds PRD Section 6.4 documenting the event-based real-time architecture, inserts a new WebSocket task slice in TASKS.md, and updates the architecture diagram.

Closes #103 (step 2, 3, and 4).

Generated with [Claude Code](https://claude.ai/code)