### PR TITLE
docs: visibility-aware lobby events in PRD and TASKS

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -68,14 +68,14 @@
 - [ ] `P0` Implement Redis pub/sub fan-out: each `table:{tableId}` room and the `lobby` channel map to a Redis pub/sub channel so all server instances can broadcast to connected clients
 - [ ] `P0` Emit in-game events after each validated state mutation: `HAND_DEALT` (per-player), `BID_PLACED`, `BLIND_NIL_EXCHANGE_PROMPT`, `CARD_PLAYED`, `TRICK_COMPLETE`, `HAND_SCORED`, `GAME_OVER`, `TURN_CHANGED`
 - [ ] `P0` Implement player disconnect detection: emit `PLAYER_DISCONNECTED` with a 60 s reconnect window on ping failure or clean close; emit `PLAYER_RECONNECTED` when the player re-joins within the window; stall game with "waiting for reconnect" indicator if window expires
-- [ ] `P1` Emit lobby events to the `lobby` channel: `TABLE_CREATED`, `TABLE_UPDATED`, `TABLE_REMOVED`
+- [ ] `P1` Emit lobby events to the `lobby` channel for **Public tables only**: `TABLE_CREATED`, `TABLE_UPDATED`, `TABLE_REMOVED` — visibility-aware routing (Friends-Only → `player:{id}:notify`, transitions on visibility change, friend-list side effects) is implemented in Slice 3 alongside the full visibility model
 
 ### Web Client
 
 - [ ] `P0` Establish authenticated WSS connection on game screen mount; tear down on unmount
 - [ ] `P0` Remove `schedulePoll()` timeout loop from `client/web/src/screens/game.js`; re-render on incoming WebSocket events instead
 - [ ] `P0` On reconnect: call `GET /api/tables/:tableId/state` to re-hydrate, then resume WS event listener
-- [ ] `P1` Subscribe to lobby channel on lobby screen mount; update table list on `TABLE_CREATED`, `TABLE_UPDATED`, `TABLE_REMOVED` — eliminating the manual-refresh requirement
+- [ ] `P1` Subscribe to lobby channel on lobby screen mount; update table list on `TABLE_CREATED`, `TABLE_UPDATED`, `TABLE_REMOVED` — eliminating the manual-refresh requirement for Public tables (Friends-Only table events arrive on the personal notification channel added in Slice 3)
 
 ### Testing
 
@@ -90,6 +90,12 @@
 
 > Goal: the complete table discovery and access model from the PRD is in place — public/friends-only/private visibility, join policies, shareable links, spectating, and the arrive-then-sit flow.
 
+- [ ] `P0` Subscribe each connected client to their personal notification channel `player:{playerId}:notify` on WebSocket connect; this channel delivers Friends-Only table events and Slice 4 social notifications (friend requests, in-app invites)
+- [ ] `P0` Implement visibility-aware lobby event routing: Public tables → `lobby` channel; Friends-Only tables → `player:{friendId}:notify` per friend of host; Private tables → no broadcast (see PRD Section 6.4.4)
+- [ ] `P0` Implement visibility transition events: when a host changes table visibility, send `TABLE_REMOVED` on the old audience's channel and `TABLE_CREATED` on the new audience's channel (all six transition combinations in PRD Section 6.4.4)
+- [ ] `P0` Implement friend-list side effects for Friends-Only tables: on host-removes-friend emit `TABLE_REMOVED` to that player's notify channel; on host-accepts-friend-request emit `TABLE_CREATED` (current state) to new friend's notify channel
+- [ ] `P0` Add `visibility` field to `TABLE_CREATED` and `TABLE_UPDATED` payloads
+- [ ] `P1` Integration tests: Friends-Only table events reach only host's friends; visibility transition correctly removes from old audience and adds to new; friend-list change side effects fire correctly
 - [ ] `P0` Implement full table creation config: visibility (Public / Friends-Only / Private), join policy (filtered by visibility), spectating toggle
 - [ ] `P0` Enforce join policy constraint: join policy cannot be less restrictive than visibility; hide join policy control for Private tables
 - [ ] `P0` Build public lobby browser showing table name, host, seat count, ruleset, and join policy

--- a/docs/spades_prd.md
+++ b/docs/spades_prd.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Version** | 1.3 — Real-Time Architecture |
+| **Version** | 1.4 — Visibility-Aware Lobby Events |
 | **Date** | April 2026 |
 | **Status** | For Review |
 | **Product** | Spades Online (Mobile & Web) |
@@ -199,7 +199,7 @@ All in-game state updates and lobby changes are delivered to clients via a persi
 
 - Clients establish an authenticated WebSocket connection on game screen mount (or lobby screen mount for lobby events).
 - Authentication occurs on the connection upgrade handshake using the player's session token (`x-session-id` header). Unauthenticated upgrade requests are rejected with HTTP 401.
-- Clients join a **room** corresponding to `table:{tableId}` upon seating or spectating. Lobby subscribers join a `lobby` channel.
+- Clients join a **room** corresponding to `table:{tableId}` upon seating or spectating. Lobby subscribers join a `lobby` channel. Each authenticated client also subscribes to their own **personal notification channel** `player:{playerId}:notify` on connect — this is the delivery rail for Friends-Only table events and Slice 4 social notifications (friend requests, in-app invites).
 - The server emits a heartbeat ping every 30 seconds; clients must respond with a pong within 10 seconds or the connection is considered dead.
 - On reconnect, clients call `GET /api/tables/:tableId/state` to re-hydrate from authoritative server state, then resume listening for WebSocket events.
 
@@ -230,11 +230,35 @@ Events must not change shape in a backward-incompatible way without coordinating
 
 #### 6.4.4 Lobby Events
 
-| Event | Audience | Key Payload Fields |
+Lobby events are routed by visibility so that Friends-Only and Private table information is never broadcast to players who should not know the table exists.
+
+| Event | Channel | Key Payload Fields |
 |---|---|---|
-| `TABLE_CREATED` | Lobby channel | `id`, `name`, `host`, `seats`, `ruleset`, `joinPolicy` |
-| `TABLE_UPDATED` | Lobby channel | `tableId`, updated fields |
-| `TABLE_REMOVED` | Lobby channel | `tableId` |
+| `TABLE_CREATED` | `lobby` (Public tables) · `player:{friendId}:notify` per friend of host (Friends-Only) · *(no broadcast)* (Private) | `tableId`, `name`, `host`, `seats`, `ruleset`, `visibility`, `joinPolicy` |
+| `TABLE_UPDATED` | Same routing as `TABLE_CREATED` for the table's *current* visibility. When visibility changes, the server sends `TABLE_REMOVED` on the old audience's channel and `TABLE_CREATED` on the new audience's channel (see transitions below). | `tableId`, changed fields — always includes `visibility` |
+| `TABLE_REMOVED` | `lobby` (was Public) · `player:{friendId}:notify` per friend of host (was Friends-Only) · *(no broadcast)* (was Private) | `tableId` |
+
+The `visibility` field is included in every `TABLE_CREATED` and `TABLE_UPDATED` payload so clients can route the event to the correct UI surface (lobby browser for Public; friends/notifications panel for Friends-Only).
+
+##### Visibility Transitions
+
+When a host changes a table's visibility setting, the server must close out the old audience and open the new one atomically to prevent ghost entries or leaks:
+
+| Old → New | Server action |
+|---|---|
+| Public → Friends-Only | Send `TABLE_REMOVED` to `lobby`; send `TABLE_CREATED` to each friend's `player:{id}:notify` |
+| Public → Private | Send `TABLE_REMOVED` to `lobby` |
+| Friends-Only → Public | Send `TABLE_REMOVED` to each friend's `player:{id}:notify`; send `TABLE_CREATED` to `lobby` |
+| Friends-Only → Private | Send `TABLE_REMOVED` to each friend's `player:{id}:notify` |
+| Private → Public | Send `TABLE_CREATED` to `lobby` |
+| Private → Friends-Only | Send `TABLE_CREATED` to each friend's `player:{id}:notify` |
+
+##### Friend List Changes While a Table Is Live
+
+When a Friends-Only table is active, changes to the host's friend list require immediate side-effect events:
+
+- **Host removes or blocks a player:** send `TABLE_REMOVED` to that player's `player:{id}:notify` so the table disappears from their view immediately.
+- **Host accepts a new friend request:** send `TABLE_CREATED` (with current state) to the new friend's `player:{id}:notify` so the table appears in their friends list.
 
 #### 6.4.5 Fan-Out Architecture
 
@@ -381,4 +405,4 @@ Variants may introduce separate casual lobbies.
 
 ---
 
-*End of Document — Spades Online PRD v1.3*
+*End of Document — Spades Online PRD v1.4*


### PR DESCRIPTION
Updates PRD to v1.4 and TASKS.md with visibility-aware lobby event routing design.

## Changes

**PRD Section 6.4.1**: documents `player:{playerId}:notify` as a first-class WebSocket channel that every authenticated client subscribes to on connect.

**PRD Section 6.4.4**: replaces the single-channel lobby event table with visibility-aware routing (Public → `lobby`, Friends-Only → `player:{id}:notify` per friend, Private → no broadcast); adds `visibility` to payloads; documents all six visibility transition cases and friend-list side effects.

**TASKS.md Slice 2**: scopes P1 lobby tasks to Public-only; notes visibility-aware routing is Slice 3 work.

**TASKS.md Slice 3**: adds six new tasks covering personal notify channel subscription, visibility-aware routing, visibility transitions, friend-list side effects, payload changes, and integration tests.

Closes #103 (step 2 and 3 updates for visibility-aware events).

Generated with [Claude Code](https://claude.ai/code)