### PR TITLE
feat: DEV_AUTO_VERIFY + simple bot players for manual testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,41 @@ npm start
 | `PUSH_API_KEY` | No | — | Push notification service API key |
 | `GIT_BRANCH` | No | — | Current branch (set by CI) |
 | `GIT_COMMIT_SHA` | No | — | Current commit SHA (set by CI) |
+| `DEV_AUTO_VERIFY` | No | — | Set to `true` to skip email verification on registration. **Local dev only — never set in production.** |
+
+### Dev & Testing Tools
+
+These tools exist to make manual testing easier during development. They are not production features.
+
+#### `DEV_AUTO_VERIFY` — skip email verification
+
+If you do not have an SMTP server configured, you cannot verify more than one account using the normal email flow. Set `DEV_AUTO_VERIFY=true` when starting the server:
+
+```bash
+DEV_AUTO_VERIFY=true npm start
+```
+
+With this flag set, `POST /api/auth/register` marks accounts as verified immediately — no email is sent, no token is required, and you can log in straight away. The flag is read at request time, so it can be toggled without a restart.
+
+#### Bot players — fill seats for solo testing
+
+The table host can fill any empty seat with a bot:
+
+```http
+POST /api/tables/:tableId/add-bot
+Headers: x-session-id, x-player-id
+Body: { "seat": "north" }  // or "east", "south", "west"
+```
+
+Bot behaviour:
+- **Bid:** counts the number of spades in its hand and bids that number
+- **Play:** picks a random card from the set of legal plays
+
+Bot turns are processed server-side automatically — after each human action (bid or card play), the server immediately plays all consecutive bot turns until it is a human's turn again. The human player just polls `GET /api/tables/:tableId/state` as normal.
+
+Bot player IDs follow the pattern `bot:<seat>` (e.g. `bot:north`). A table can have any mix of human and bot seats. Once all 4 seats are filled (by humans and/or bots), the game starts automatically.
+
+> These bots are intentionally minimal — they are a testing convenience, not the production AI opponent planned for v1.1.
 
 ### Running Tests
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -9,6 +9,8 @@
 
 ## ✅ Completed
 
+- [x] `DEV` `DEV_AUTO_VERIFY` env var — when set to `true`, registration skips email verification and marks the player as verified immediately. Enables registering multiple test accounts without an email server. Never set in production.
+- [x] `DEV` Simple bot players — `POST /api/tables/:tableId/add-bot` lets the table host add a bot to any empty seat. Bots bid the number of spades in their hand and play a random legal card. Bot turns advance automatically server-side after each human action; no client round-trips needed. Bot IDs follow the pattern `bot:<seat>` and are scoped to dev/test use — they do not affect the production bot design in v1.1.
 - [x] `P0` Implement email/password registration with required email verification
 - [x] `P0` Resend verification email flow: `POST /api/auth/resend-verification` + UI prompt on login 403 and registration success screen
 - [x] `P0` Forgot password flow: `POST /api/auth/forgot-password`, `POST /api/auth/reset-password`, forgot/reset password screens with proper success/error landing pages

--- a/server/auth/registration.js
+++ b/server/auth/registration.js
@@ -44,13 +44,17 @@ export async function registerPlayer(db, { email, username, password }, sendVeri
   const trimmedUsername = username.trim()
   const passwordHash = await hashPassword(password)
 
+  // DEV_AUTO_VERIFY=true skips email verification entirely — for local testing only.
+  // Never set this in production.
+  const autoVerify = process.env.DEV_AUTO_VERIFY === 'true'
+
   let player
   try {
     const result = await db.query(
       `INSERT INTO players (email, username, password_hash, is_verified)
-       VALUES ($1, $2, $3, FALSE)
+       VALUES ($1, $2, $3, $4)
        RETURNING id`,
-      [normalizedEmail, trimmedUsername, passwordHash],
+      [normalizedEmail, trimmedUsername, passwordHash, autoVerify],
     )
     player = result.rows[0]
   } catch (err) {
@@ -64,6 +68,11 @@ export async function registerPlayer(db, { email, username, password }, sendVeri
       }
     }
     throw err
+  }
+
+  if (autoVerify) {
+    console.log('DEV_AUTO_VERIFY: skipped email verification for player', player.id)
+    return { playerId: player.id }
   }
 
   const token = generateVerificationToken()

--- a/server/game/bot.js
+++ b/server/game/bot.js
@@ -1,0 +1,47 @@
+import { getLegalPlays } from './trick.js'
+
+/**
+ * Return true if a player ID belongs to a bot seat.
+ * Bot IDs follow the pattern "bot:<seat>".
+ *
+ * @param {*} playerId
+ * @returns {boolean}
+ */
+export function isBot(playerId) {
+  return typeof playerId === 'string' && playerId.startsWith('bot:')
+}
+
+/**
+ * Return the canonical bot player ID for a given seat.
+ * @param {string} seat
+ * @returns {string}
+ */
+export function getBotPlayerId(seat) {
+  return `bot:${seat}`
+}
+
+/**
+ * Compute the bot's bid: count the number of spades in its hand.
+ * This is a legal bid value (0–13) under all conditions.
+ *
+ * @param {Array<{suit: string, rank: string}>} hand
+ * @returns {number}
+ */
+export function botBid(hand) {
+  return hand.filter((c) => c.suit === 'spades').length
+}
+
+/**
+ * Choose a card for the bot to play.
+ * Picks uniformly at random from the set of legal plays.
+ *
+ * @param {Array<{suit: string, rank: string}>} hand
+ * @param {Array<{seat: string, card: {suit: string, rank: string}}>} currentTrick
+ * @param {boolean} spadesbroken
+ * @param {boolean} isFirstTrick
+ * @returns {{suit: string, rank: string}}
+ */
+export function botPlay(hand, currentTrick, spadesbroken, isFirstTrick) {
+  const legal = getLegalPlays(hand, currentTrick, spadesbroken, isFirstTrick)
+  return legal[Math.floor(Math.random() * legal.length)]
+}

--- a/server/lobby/table.js
+++ b/server/lobby/table.js
@@ -116,6 +116,19 @@ export function isTableFull(table) {
 }
 
 /**
+ * Add a bot player to an empty seat. The bot's player ID is "bot:<seat>".
+ * Reuses sitAtTable's validation (seat must be empty, game must not have started).
+ *
+ * @param {import('redis').RedisClientType} redis
+ * @param {string} tableId
+ * @param {'north'|'east'|'south'|'west'} seat
+ * @returns {Promise<TableState>}
+ */
+export async function addBotToTable(redis, tableId, seat) {
+  return sitAtTable(redis, tableId, `bot:${seat}`, seat)
+}
+
+/**
  * Mark the table as in-game and record the gameId.
  *
  * @param {import('redis').RedisClientType} redis

--- a/server/server.js
+++ b/server/server.js
@@ -16,12 +16,44 @@ import {
   getGameState,
   saveGameState,
   listTables,
+  addBotToTable,
 } from './lobby/table.js'
 import { createGame, placeBid, playCard, submitBlindNilExchange, getPlayerView } from './game/state.js'
 import { getSeatForPlayer, validateCardPlay, validateBidTurn } from './anticheat/validate.js'
+import { isBot, botBid, botPlay } from './game/bot.js'
 
 function sendJSON(res, statusCode, data) {
   res.status(statusCode).json(data)
+}
+
+/**
+ * Automatically advance the game state through any consecutive bot turns.
+ * Loops until it is a human player's turn or the game is over.
+ *
+ * @param {object} state - Current game state
+ * @returns {object} Updated game state after all bot actions are applied
+ */
+function advanceBotTurns(state) {
+  let current = state
+  while (true) {
+    if (current.phase === 'bidding') {
+      const seat = current.currentBidderSeat
+      if (!seat || !isBot(current.players[seat])) break
+      const bid = botBid(current.hands[seat])
+      console.log('Bot bid:', { seat, bid, tableId: current.tableId })
+      current = placeBid(current, seat, bid)
+    } else if (current.phase === 'playing') {
+      const seat = current.currentPlayerSeat
+      if (!seat || !isBot(current.players[seat])) break
+      const card = botPlay(current.hands[seat], current.currentTrick, current.spadesbroken, current.isFirstTrick)
+      console.log('Bot play:', { seat, card, tableId: current.tableId })
+      current = playCard(current, seat, card)
+    } else {
+      // blind_nil_exchange or game_over — bots never bid blind nil, nothing to auto-advance
+      break
+    }
+  }
+  return current
 }
 
 /**
@@ -220,10 +252,11 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
       const session = await validateAuthHeaders(redisClient, req)
       const table = await sitAtTable(redisClient, tableId, session.playerId, seat)
 
-      // If table is now full, start the game
+      // If table is now full, start the game and advance any leading bot turns
       if (isTableFull(table)) {
         const players = table.seats // { north, east, south, west } → playerIds
-        const gameState = createGame(tableId, players)
+        let gameState = createGame(tableId, players)
+        gameState = advanceBotTurns(gameState)
         await saveGameState(redisClient, tableId, gameState)
         await markTablePlaying(redisClient, tableId, gameState.gameId)
         console.log('Game started:', { tableId, gameId: gameState.gameId })
@@ -238,6 +271,43 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
       if (err.code === 'ALREADY_SEATED') return sendJSON(res, 409, { error: err.message })
       if (err.code === 'INVALID_SEAT') return sendJSON(res, 400, { error: err.message })
       console.error('Sit at table error:', { tableId, error: err.message })
+      sendJSON(res, 500, { error: 'Internal server error' })
+    }
+  })
+
+  // POST /api/tables/:tableId/add-bot — add a bot to an empty seat (host only)
+  app.post('/api/tables/:tableId/add-bot', async (req, res) => {
+    const { tableId } = req.params
+    const { seat } = req.body ?? {}
+    try {
+      const redisClient = await getRedis()
+      const session = await validateAuthHeaders(redisClient, req)
+      const table = await getTable(redisClient, tableId)
+      if (!table) return sendJSON(res, 404, { error: 'Table not found' })
+      if (table.hostPlayerId !== session.playerId) {
+        return sendJSON(res, 403, { error: 'Only the host can add bots' })
+      }
+
+      const updated = await addBotToTable(redisClient, tableId, seat)
+
+      // If table is now full, start the game and advance any leading bot turns
+      if (isTableFull(updated)) {
+        const players = updated.seats
+        let gameState = createGame(tableId, players)
+        gameState = advanceBotTurns(gameState)
+        await saveGameState(redisClient, tableId, gameState)
+        await markTablePlaying(redisClient, tableId, gameState.gameId)
+        console.log('Game started with bots:', { tableId, gameId: gameState.gameId })
+      }
+
+      sendJSON(res, 200, { tableId, seat })
+    } catch (err) {
+      if (err.code === 'UNAUTHORIZED') return sendJSON(res, 401, { error: err.message })
+      if (err.code === 'NOT_FOUND') return sendJSON(res, 404, { error: err.message })
+      if (err.code === 'GAME_IN_PROGRESS') return sendJSON(res, 409, { error: err.message })
+      if (err.code === 'SEAT_TAKEN') return sendJSON(res, 409, { error: err.message })
+      if (err.code === 'INVALID_SEAT') return sendJSON(res, 400, { error: err.message })
+      console.error('Add bot error:', { tableId, error: err.message })
       sendJSON(res, 500, { error: 'Internal server error' })
     }
   })
@@ -282,7 +352,8 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
       if (!gameState) return sendJSON(res, 409, { error: 'Game has not started' })
 
       validateBidTurn(gameState, seat)
-      const newState = placeBid(gameState, seat, bid)
+      let newState = placeBid(gameState, seat, bid)
+      newState = advanceBotTurns(newState)
       await saveGameState(redisClient, tableId, newState)
       sendJSON(res, 200, getPlayerView(newState, seat))
     } catch (err) {
@@ -314,7 +385,8 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
       const gameState = await getGameState(redisClient, tableId)
       if (!gameState) return sendJSON(res, 409, { error: 'Game has not started' })
 
-      const newState = submitBlindNilExchange(gameState, seat, cards)
+      let newState = submitBlindNilExchange(gameState, seat, cards)
+      newState = advanceBotTurns(newState)
       await saveGameState(redisClient, tableId, newState)
       sendJSON(res, 200, getPlayerView(newState, seat))
     } catch (err) {
@@ -345,7 +417,8 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
       if (!gameState) return sendJSON(res, 409, { error: 'Game has not started' })
 
       validateCardPlay(gameState, seat, card)
-      const newState = playCard(gameState, seat, card)
+      let newState = playCard(gameState, seat, card)
+      newState = advanceBotTurns(newState)
       await saveGameState(redisClient, tableId, newState)
       sendJSON(res, 200, getPlayerView(newState, seat))
     } catch (err) {

--- a/test/unit/auth/registration.test.js
+++ b/test/unit/auth/registration.test.js
@@ -175,6 +175,53 @@ describe('resendVerificationEmail', () => {
   })
 })
 
+describe('registerPlayer — DEV_AUTO_VERIFY', () => {
+  it('skips email and token when DEV_AUTO_VERIFY=true', async () => {
+    process.env.DEV_AUTO_VERIFY = 'true'
+    const queries = []
+    const emailsSent = []
+    const db = {
+      query: async (sql, params) => {
+        queries.push({ sql, params })
+        if (sql.includes('INSERT INTO players')) return { rows: [{ id: 'auto-id' }] }
+        return { rows: [] }
+      },
+    }
+    const result = await registerPlayer(
+      db,
+      { email: 'dev@example.com', username: 'devuser', password: 'password123' },
+      async (email) => emailsSent.push(email),
+    )
+    delete process.env.DEV_AUTO_VERIFY
+
+    assert.equal(result.playerId, 'auto-id')
+    assert.equal(emailsSent.length, 0, 'should not send verification email')
+    const tokenInsert = queries.find((q) => q.sql.includes('email_verification_tokens'))
+    assert.ok(!tokenInsert, 'should not insert a verification token')
+    const playerInsert = queries.find((q) => q.sql.includes('INSERT INTO players'))
+    // is_verified param should be true
+    assert.equal(playerInsert.params[3], true)
+  })
+
+  it('sends email normally when DEV_AUTO_VERIFY is not set', async () => {
+    delete process.env.DEV_AUTO_VERIFY
+    const emailsSent = []
+    const db = {
+      query: async (sql) => {
+        if (sql.includes('INSERT INTO players')) return { rows: [{ id: 'normal-id' }] }
+        return { rows: [] }
+      },
+    }
+    await registerPlayer(
+      db,
+      { email: 'user@example.com', username: 'normaluser', password: 'password123' },
+      async (email) => emailsSent.push(email),
+    )
+    assert.equal(emailsSent.length, 1)
+    assert.equal(emailsSent[0], 'user@example.com')
+  })
+})
+
 describe('verifyEmailToken — input validation', () => {
   it('throws VALIDATION_ERROR when token is missing', async () => {
     const db = {}

--- a/test/unit/game/bot.test.js
+++ b/test/unit/game/bot.test.js
@@ -1,0 +1,116 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { isBot, getBotPlayerId, botBid, botPlay } from '../../../server/game/bot.js'
+
+describe('isBot', () => {
+  it('returns true for bot player IDs', () => {
+    assert.equal(isBot('bot:north'), true)
+    assert.equal(isBot('bot:south'), true)
+    assert.equal(isBot('bot:east'), true)
+    assert.equal(isBot('bot:west'), true)
+  })
+
+  it('returns false for human player IDs', () => {
+    assert.equal(isBot('some-uuid-player-id'), false)
+    assert.equal(isBot(null), false)
+    assert.equal(isBot(undefined), false)
+    assert.equal(isBot(''), false)
+  })
+})
+
+describe('getBotPlayerId', () => {
+  it('returns bot:<seat> for each seat', () => {
+    assert.equal(getBotPlayerId('north'), 'bot:north')
+    assert.equal(getBotPlayerId('south'), 'bot:south')
+    assert.equal(getBotPlayerId('east'), 'bot:east')
+    assert.equal(getBotPlayerId('west'), 'bot:west')
+  })
+})
+
+describe('botBid', () => {
+  it('counts spades in hand', () => {
+    const hand = [
+      { suit: 'spades', rank: 'A' },
+      { suit: 'spades', rank: 'K' },
+      { suit: 'hearts', rank: 'Q' },
+      { suit: 'clubs', rank: '7' },
+    ]
+    assert.equal(botBid(hand), 2)
+  })
+
+  it('returns 0 when no spades in hand', () => {
+    const hand = [
+      { suit: 'hearts', rank: 'A' },
+      { suit: 'clubs', rank: 'K' },
+      { suit: 'diamonds', rank: 'Q' },
+    ]
+    assert.equal(botBid(hand), 0)
+  })
+
+  it('returns 13 when hand is all spades', () => {
+    const hand = [
+      { suit: 'spades', rank: 'A' },
+      { suit: 'spades', rank: 'K' },
+      { suit: 'spades', rank: 'Q' },
+      { suit: 'spades', rank: 'J' },
+      { suit: 'spades', rank: '10' },
+      { suit: 'spades', rank: '9' },
+      { suit: 'spades', rank: '8' },
+      { suit: 'spades', rank: '7' },
+      { suit: 'spades', rank: '6' },
+      { suit: 'spades', rank: '5' },
+      { suit: 'spades', rank: '4' },
+      { suit: 'spades', rank: '3' },
+      { suit: 'spades', rank: '2' },
+    ]
+    assert.equal(botBid(hand), 13)
+  })
+})
+
+describe('botPlay', () => {
+  it('returns a card that is in the hand', () => {
+    const hand = [
+      { suit: 'hearts', rank: 'A' },
+      { suit: 'clubs', rank: 'K' },
+      { suit: 'spades', rank: 'Q' },
+    ]
+    const card = botPlay(hand, [], true, false)
+    assert.ok(hand.some((c) => c.suit === card.suit && c.rank === card.rank))
+  })
+
+  it('does not lead spades on the first trick when alternatives exist', () => {
+    const hand = [
+      { suit: 'hearts', rank: 'A' },
+      { suit: 'spades', rank: 'K' },
+    ]
+    const card = botPlay(hand, [], false, true)
+    assert.equal(card.suit, 'hearts')
+  })
+
+  it('follows suit if possible', () => {
+    const hand = [
+      { suit: 'hearts', rank: 'A' },
+      { suit: 'spades', rank: 'K' },
+    ]
+    const currentTrick = [{ seat: 'north', card: { suit: 'hearts', rank: '7' } }]
+    const card = botPlay(hand, currentTrick, false, false)
+    assert.equal(card.suit, 'hearts')
+  })
+
+  it('can play any card when cannot follow suit', () => {
+    const hand = [
+      { suit: 'spades', rank: 'K' },
+      { suit: 'clubs', rank: '5' },
+    ]
+    const currentTrick = [{ seat: 'north', card: { suit: 'hearts', rank: '7' } }]
+    const card = botPlay(hand, currentTrick, false, false)
+    assert.ok(hand.some((c) => c.suit === card.suit && c.rank === card.rank))
+  })
+
+  it('returns a card from a single-card hand', () => {
+    const hand = [{ suit: 'clubs', rank: '2' }]
+    const card = botPlay(hand, [], false, false)
+    assert.equal(card.suit, 'clubs')
+    assert.equal(card.rank, '2')
+  })
+})


### PR DESCRIPTION
Implements two dev testing tools requested in #111:

- `DEV_AUTO_VERIFY=true` env var skips email verification on registration, enabling multiple test accounts without an SMTP server
- `POST /api/tables/:tableId/add-bot`: host can fill any empty seat with a bot (bids spade count, plays random legal card)
- Bot turns auto-advance server-side after each human action
- Documented in README and TASKS.md

Generated with [Claude Code](https://claude.ai/code)