### PR TITLE
Add logout button to lobby screen

### DIFF
--- a/client/web/src/api.js
+++ b/client/web/src/api.js
@@ -262,6 +262,26 @@ export async function submitBlindNilExchange({ tableId, cards, sessionId, player
 }
 
 /**
+ * Log out the current session.
+ * @param {{ sessionId: string }} data
+ * @param {typeof fetch} [fetchFn]
+ * @returns {Promise<{ message: string }>}
+ */
+export async function logoutUser({ sessionId }, fetchFn = globalThis.fetch) {
+  const res = await fetchFn('/api/auth/logout', {
+    method: 'POST',
+    headers: { 'x-session-id': sessionId },
+  })
+  const body = await res.json()
+  if (!res.ok) {
+    const err = new Error(body.error || 'Logout failed.')
+    err.status = res.status
+    throw err
+  }
+  return body
+}
+
+/**
  * Log in with email and password.
  * @param {{ email: string, password: string }} data
  * @param {typeof fetch} [fetchFn]

--- a/client/web/src/screens/lobby.js
+++ b/client/web/src/screens/lobby.js
@@ -1,4 +1,5 @@
 import { navigate } from '../router.js'
+import { logoutUser } from '../api.js'
 
 /**
  * Render the lobby screen into `container`.
@@ -15,6 +16,7 @@ export function renderLobbyScreen(container) {
       <div class="lobby-actions">
         <button id="create-table-btn" class="btn-primary">Create Table</button>
         <button id="join-table-btn" class="btn-secondary">Join Table</button>
+        <button id="logout-btn" class="btn-link">Log out</button>
       </div>
     </div>
   `
@@ -25,6 +27,19 @@ export function renderLobbyScreen(container) {
 
   container.querySelector('#join-table-btn').addEventListener('click', () => {
     navigate('#/join')
+  })
+
+  container.querySelector('#logout-btn').addEventListener('click', async () => {
+    const sessionId = sessionStorage.getItem('sessionId')
+    try {
+      await logoutUser({ sessionId })
+    } catch (err) {
+      console.log('Logout error (proceeding anyway):', { error: err.message })
+    }
+    sessionStorage.removeItem('sessionId')
+    sessionStorage.removeItem('playerId')
+    sessionStorage.removeItem('username')
+    navigate('#/login')
   })
 }
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -17,6 +17,7 @@
 - [x] `P0` Implement login and session management
 - [x] `P0` Apply rate limiting on all authentication endpoints
 - [x] `P1` Build player profile page (username, avatar, career win/loss record, recent 20 games, cosmetics)
+- [x] `P1` Add logout button to the lobby screen (`client/web/src/screens/lobby.js`): calls `POST /api/auth/logout`, clears `sessionStorage`, and redirects to the login screen
 
 ---
 

--- a/test/unit/web/api.test.js
+++ b/test/unit/web/api.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { registerUser, loginUser, resendVerification, forgotPassword, resetPassword, createTable, listTables, sitAtTable, getGameState, placeBid, playCard, submitBlindNilExchange } from '../../../client/web/src/api.js'
+import { registerUser, loginUser, logoutUser, resendVerification, forgotPassword, resetPassword, createTable, listTables, sitAtTable, getGameState, placeBid, playCard, submitBlindNilExchange } from '../../../client/web/src/api.js'
 
 /**
  * Build a minimal mock fetch that returns the given status and JSON body.
@@ -124,6 +124,26 @@ describe('resetPassword', () => {
         ),
       (err) => {
         assert.equal(err.status, 400)
+        return true
+      },
+    )
+  })
+})
+
+describe('logoutUser', () => {
+  it('resolves with message on 200', async () => {
+    const result = await logoutUser(
+      { sessionId: 'sess-1' },
+      mockFetch(200, { message: 'Logged out successfully.' }),
+    )
+    assert.ok(result.message)
+  })
+
+  it('throws on server error', async () => {
+    await assert.rejects(
+      () => logoutUser({ sessionId: 'sess-1' }, mockFetch(500, { error: 'Internal server error' })),
+      (err) => {
+        assert.equal(err.status, 500)
         return true
       },
     )


### PR DESCRIPTION
Adds a "Log out" button to the lobby screen. Calls POST /api/auth/logout, clears sessionStorage, and redirects to the login screen.

Closes #127

Generated with [Claude Code](https://claude.ai/code)