### PR TITLE
Remove player from waiting tables on logout

### DIFF
--- a/server/lobby/table.js
+++ b/server/lobby/table.js
@@ -177,6 +177,30 @@ export async function saveGameState(redis, tableId, gameState) {
 }
 
 /**
+ * Remove a player from any waiting table they are currently seated at.
+ * Only affects tables with status 'waiting' — in-progress games require
+ * separate disconnect handling.
+ *
+ * @param {import('redis').RedisClientType} redis
+ * @param {string} playerId
+ */
+export async function removePlayerFromTables(redis, playerId) {
+  const raw = await redis.hGetAll('lobby:tables')
+  for (const json of Object.values(raw)) {
+    const entry = JSON.parse(json)
+    if (entry.status !== 'waiting') continue
+    const table = await getTable(redis, entry.tableId)
+    if (!table || table.status !== 'waiting') continue
+    const seatEntry = Object.entries(table.seats).find(([, id]) => id === playerId)
+    if (!seatEntry) continue
+    const [seat] = seatEntry
+    const updated = { ...table, seats: { ...table.seats, [seat]: null } }
+    await saveTable(redis, updated)
+    console.log('Player removed from table on logout:', { tableId: table.tableId, playerId, seat })
+  }
+}
+
+/**
  * List all open (waiting) tables from the lobby index.
  * Fetches full table state for each waiting entry to include seat info.
  *

--- a/server/server.js
+++ b/server/server.js
@@ -3,7 +3,7 @@ import { forgotPassword, resetPassword } from './auth/passwordReset.js'
 import { sendVerificationEmail as defaultMailer, sendPasswordResetEmail as defaultPasswordResetMailer } from './auth/email.js'
 import { getPlayerProfile, isValidUuid } from './social/profile.js'
 import { loginPlayer } from './auth/login.js'
-import { createSession, deleteSession, validateAuthHeaders } from './auth/session.js'
+import { createSession, deleteSession, getSession, validateAuthHeaders } from './auth/session.js'
 import { getDb } from './db.js'
 import { getRedis } from './redis.js'
 import { createRateLimiter } from './middleware/rateLimiter.js'
@@ -17,6 +17,7 @@ import {
   saveGameState,
   listTables,
   addBotToTable,
+  removePlayerFromTables,
 } from './lobby/table.js'
 import { createGame, placeBid, playCard, submitBlindNilExchange, getPlayerView } from './game/state.js'
 import { getSeatForPlayer, validateCardPlay, validateBidTurn } from './anticheat/validate.js'
@@ -196,6 +197,10 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
     const sessionId = req.headers['x-session-id']
     try {
       const redis = await getRedis()
+      const session = await getSession(redis, sessionId)
+      if (session) {
+        await removePlayerFromTables(redis, session.playerId)
+      }
       await deleteSession(redis, sessionId)
       sendJSON(res, 200, { message: 'Logged out successfully.' })
     } catch (err) {

--- a/test/integration/auth/login.test.js
+++ b/test/integration/auth/login.test.js
@@ -210,6 +210,44 @@ describe('POST /api/auth/logout', { skip }, () => {
     })
     assert.equal(res.status, 200)
   })
+
+  it('removes the player from any waiting table they are seated at', async () => {
+    const loginRes = await fetch(`${server.baseUrl}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'logout_ok@test.spades.invalid', password: 'password123' }),
+    })
+    const { sessionId, playerId } = await loginRes.json()
+
+    // Create a table and sit in a seat
+    const createRes = await fetch(`${server.baseUrl}/api/tables`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-session-id': sessionId, 'x-player-id': playerId },
+      body: JSON.stringify({}),
+    })
+    const { tableId } = await createRes.json()
+
+    await fetch(`${server.baseUrl}/api/tables/${tableId}/sit`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-session-id': sessionId, 'x-player-id': playerId },
+      body: JSON.stringify({ seat: 'north' }),
+    })
+
+    // Confirm seated before logout
+    const tableBefore = JSON.parse(await redis.get(`table:${tableId}`))
+    assert.equal(tableBefore.seats.north, playerId, 'player should be seated before logout')
+
+    // Logout
+    const logoutRes = await fetch(`${server.baseUrl}/api/auth/logout`, {
+      method: 'POST',
+      headers: { 'x-session-id': sessionId, 'x-player-id': playerId },
+    })
+    assert.equal(logoutRes.status, 200)
+
+    // Player should be removed from the seat
+    const tableAfter = JSON.parse(await redis.get(`table:${tableId}`))
+    assert.equal(tableAfter.seats.north, null, 'player should be removed from table after logout')
+  })
 })
 
 describe('Auth header validation', { skip }, () => {


### PR DESCRIPTION
When a player logs out, the server now vacates any seat they occupy in waiting tables before deleting their session.

Related to #128

Generated with [Claude Code](https://claude.ai/code)