### PR TITLE
fix: sort hand highest to lowest with suits Spades > Hearts > Clubs > Diamonds

### DIFF
--- a/server/game/deck.js
+++ b/server/game/deck.js
@@ -1,4 +1,4 @@
-export const SUITS = ['clubs', 'diamonds', 'hearts', 'spades']
+export const SUITS = ['spades', 'hearts', 'clubs', 'diamonds']
 export const RANKS = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A']
 
 const SUIT_ORDER = Object.fromEntries(SUITS.map((s, i) => [s, i]))
@@ -49,7 +49,7 @@ export function rankValue(rank) {
 }
 
 /**
- * Sort a hand by suit (clubs < diamonds < hearts < spades) then rank (2 < … < A).
+ * Sort a hand by suit (spades > hearts > clubs > diamonds) then rank (A > … > 2).
  * Returns a new array — does not mutate the input.
  * @param {Card[]} hand
  * @returns {Card[]}
@@ -59,7 +59,7 @@ export function sortHand(hand) {
     if (SUIT_ORDER[a.suit] !== SUIT_ORDER[b.suit]) {
       return SUIT_ORDER[a.suit] - SUIT_ORDER[b.suit]
     }
-    return RANK_ORDER[a.rank] - RANK_ORDER[b.rank]
+    return RANK_ORDER[b.rank] - RANK_ORDER[a.rank]
   })
 }
 

--- a/test/unit/game/deck.test.js
+++ b/test/unit/game/deck.test.js
@@ -90,7 +90,7 @@ describe('deal', () => {
 })
 
 describe('sortHand', () => {
-  it('sorts clubs before diamonds before hearts before spades', () => {
+  it('sorts spades before hearts before clubs before diamonds', () => {
     const hand = [
       { suit: 'spades', rank: '2' },
       { suit: 'hearts', rank: '3' },
@@ -98,13 +98,13 @@ describe('sortHand', () => {
       { suit: 'diamonds', rank: '5' },
     ]
     const sorted = sortHand(hand)
-    assert.equal(sorted[0].suit, 'clubs')
-    assert.equal(sorted[1].suit, 'diamonds')
-    assert.equal(sorted[2].suit, 'hearts')
-    assert.equal(sorted[3].suit, 'spades')
+    assert.equal(sorted[0].suit, 'spades')
+    assert.equal(sorted[1].suit, 'hearts')
+    assert.equal(sorted[2].suit, 'clubs')
+    assert.equal(sorted[3].suit, 'diamonds')
   })
 
-  it('sorts by rank ascending within the same suit', () => {
+  it('sorts by rank descending within the same suit', () => {
     const hand = [
       { suit: 'clubs', rank: 'A' },
       { suit: 'clubs', rank: '2' },
@@ -114,7 +114,7 @@ describe('sortHand', () => {
     const sorted = sortHand(hand)
     assert.deepEqual(
       sorted.map((c) => c.rank),
-      ['2', '10', 'K', 'A'],
+      ['A', 'K', '10', '2'],
     )
   })
 

--- a/test/unit/game/state.test.js
+++ b/test/unit/game/state.test.js
@@ -53,11 +53,11 @@ describe('createGame', () => {
       for (let i = 1; i < hand.length; i++) {
         const prev = hand[i - 1]
         const curr = hand[i]
-        const suitOrder = ['clubs', 'diamonds', 'hearts', 'spades']
+        const suitOrder = ['spades', 'hearts', 'clubs', 'diamonds']
         const rankOrder = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A']
         if (prev.suit === curr.suit) {
           assert.ok(
-            rankOrder.indexOf(prev.rank) <= rankOrder.indexOf(curr.rank),
+            rankOrder.indexOf(prev.rank) >= rankOrder.indexOf(curr.rank),
             `hand not sorted by rank for ${seat}`,
           )
         } else {
@@ -234,7 +234,8 @@ describe('playCard', () => {
 
   it('removes played card from hand', () => {
     let state = getToPlayingPhase()
-    const card = state.hands.east[0]
+    // east[0] may be a spade (illegal on trick 1); pick first non-spade card instead
+    const card = state.hands.east.find((c) => c.suit !== 'spades')
     state = playCard(state, 'east', card)
     assert.equal(state.hands.east.length, 12)
     assert.ok(!state.hands.east.some((c) => c.suit === card.suit && c.rank === card.rank))


### PR DESCRIPTION
Fixes #132

## Changes

- Reorder `SUITS` constant to `['spades', 'hearts', 'clubs', 'diamonds']` so `SUIT_ORDER` indices place spades first
- Flip rank comparison in `sortHand` to descending so A sorts before 2
- Update `sortHand` tests to assert the new expected order

Generated with [Claude Code](https://claude.ai/code)