### PR TITLE
feat: add Last Trick viewer to game screen

### DIFF
--- a/client/web/index.html
+++ b/client/web/index.html
@@ -853,6 +853,86 @@
         text-transform: uppercase;
         letter-spacing: 0.04em;
       }
+
+      /* Trick wrap — holds the active trick and the Last Trick button */
+      .trick-wrap {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.4rem;
+      }
+
+      /* Last Trick button */
+      .last-trick-btn {
+        padding: 0.2rem 0.6rem;
+        background: transparent;
+        color: #888;
+        border: 1px solid #444;
+        border-radius: 4px;
+        font-size: 0.72rem;
+        cursor: pointer;
+        transition: color 0.15s, border-color 0.15s;
+      }
+
+      .last-trick-btn:hover {
+        color: #ccc;
+        border-color: #666;
+      }
+
+      /* Last trick overlay — full-screen backdrop */
+      .last-trick-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.65);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 100;
+      }
+
+      /* Modal card */
+      .last-trick-modal {
+        background: #1e2e1e;
+        border: 1px solid #3a3a3a;
+        border-radius: 8px;
+        padding: 1.25rem 1.5rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.75rem;
+        min-width: 200px;
+      }
+
+      .last-trick-title {
+        font-size: 0.78rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: #888;
+      }
+
+      .last-trick-winner-label {
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: #81c784;
+      }
+
+      .last-trick-close {
+        padding: 0.3rem 1rem;
+        background: transparent;
+        color: #888;
+        border: 1px solid #444;
+        border-radius: 4px;
+        font-size: 0.8rem;
+        cursor: pointer;
+        transition: color 0.15s, border-color 0.15s;
+      }
+
+      .last-trick-close:hover {
+        color: #ccc;
+        border-color: #666;
+      }
     </style>
   </head>
   <body>

--- a/client/web/src/hand.js
+++ b/client/web/src/hand.js
@@ -36,6 +36,52 @@ export function handSpreadHtml(hand, extraClsFn) {
 }
 
 /**
+ * Render the completed last trick as a modal overlay.
+ *
+ * Shows all 4 cards in the same positional layout as the active trick area,
+ * along with a label identifying the winner. Intended to be injected into the
+ * page and controlled via `last-trick-overlay` and `last-trick-close` element IDs.
+ *
+ * @param {{ winner: string, plays: Array<{ seat: string, card: { suit: string, rank: string } }> }} lastTrick
+ * @param {{ me: string, right: string, across: string, left: string }} rel - seat positions from current player's perspective
+ * @returns {string} HTML string
+ */
+export function lastTrickHtml(lastTrick, rel) {
+  const bySeats = {}
+  for (const { seat, card } of lastTrick.plays) bySeats[seat] = card
+
+  function slot(seat) {
+    const card = bySeats[seat]
+    if (!card) return '<div class="trick-slot"></div>'
+    const s = SUIT_SYMBOL[card.suit]
+    const red = RED_SUIT.has(card.suit) ? ' trick-red' : ''
+    return `<div class="trick-slot"><div class="trick-card${red}">${esc(card.rank)}${s}</div></div>`
+  }
+
+  const winnerLabel = lastTrick.winner === rel.me
+    ? 'You'
+    : esc(lastTrick.winner.charAt(0).toUpperCase() + lastTrick.winner.slice(1))
+
+  return `
+    <div class="last-trick-overlay" id="last-trick-overlay">
+      <div class="last-trick-modal">
+        <div class="last-trick-title">Last Trick</div>
+        <div class="last-trick-winner-label">Won by ${winnerLabel}</div>
+        <div class="trick-area">
+          <div class="trick-row">${slot(rel.across)}</div>
+          <div class="trick-row trick-middle">
+            ${slot(rel.left)}
+            <div class="trick-center"></div>
+            ${slot(rel.right)}
+          </div>
+          <div class="trick-row">${slot(rel.me)}</div>
+        </div>
+        <button class="last-trick-close" id="last-trick-close">Close</button>
+      </div>
+    </div>`
+}
+
+/**
  * Render a hand of cards in Hand Diagram mode — cards grouped by suit, one suit per row,
  * with the suit symbol followed by the card ranks. Suits with no cards are omitted.
  *

--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -6,7 +6,7 @@ import {
   addBotToTable as apiAddBot,
 } from '../api.js'
 import { navigate } from '../router.js'
-import { handSpreadHtml, handDiagramHtml } from '../hand.js'
+import { handSpreadHtml, handDiagramHtml, lastTrickHtml } from '../hand.js'
 
 const SUIT_SYMBOL = { spades: '\u2660', hearts: '\u2665', diamonds: '\u2666', clubs: '\u2663' }
 const RED_SUIT = new Set(['hearts', 'diamonds'])
@@ -106,6 +106,7 @@ export function renderGameScreen(container) {
   let state = null
   let handMode = 'spread'
   let selectedCards = []
+  let showLastTrick = false
   let pollTimer = null
   let acting = false
   let mounted = true
@@ -200,6 +201,9 @@ export function renderGameScreen(container) {
       return
     }
 
+    // Dismiss last trick overlay at the start of each new hand
+    if (state.completedTricks.length === 0) showLastTrick = false
+
     const rel = relSeats(seat)
     const isMyBidTurn = state.phase === 'bidding' && state.currentBidderSeat === seat
     const isMyPlayTurn = state.phase === 'playing' && state.currentPlayerSeat === seat
@@ -284,7 +288,12 @@ export function renderGameScreen(container) {
             <div class="table-side table-left">
               ${seatInfoHtml(state, rel.left, rel.left.charAt(0).toUpperCase() + rel.left.slice(1))}
             </div>
-            ${trickHtml(state, rel)}
+            <div class="trick-wrap">
+              ${trickHtml(state, rel)}
+              ${state.phase === 'playing' && state.completedTricks.length > 0
+                ? '<button class="last-trick-btn" id="last-trick-btn">Last Trick</button>'
+                : ''}
+            </div>
             <div class="table-side table-right">
               ${seatInfoHtml(state, rel.right, rel.right.charAt(0).toUpperCase() + rel.right.slice(1))}
             </div>
@@ -309,6 +318,10 @@ export function renderGameScreen(container) {
           <div class="hand-cards" id="hand-cards">${handHtml}</div>
           <div class="form-error play-err" role="alert" aria-live="polite"></div>
         </div>
+
+        ${showLastTrick && state.completedTricks.length > 0
+          ? lastTrickHtml(state.completedTricks[state.completedTricks.length - 1], rel)
+          : ''}
       </div>`
 
     // Mode toggle
@@ -317,6 +330,20 @@ export function renderGameScreen(container) {
         handMode = btn.dataset.mode
         render()
       })
+    })
+
+    // Last trick button — show overlay
+    container.querySelector('#last-trick-btn')?.addEventListener('click', () => {
+      showLastTrick = true
+      render()
+    })
+
+    // Last trick overlay — dismiss on backdrop click or close button
+    container.querySelector('#last-trick-overlay')?.addEventListener('click', (e) => {
+      if (e.target.id === 'last-trick-overlay' || e.target.id === 'last-trick-close') {
+        showLastTrick = false
+        render()
+      }
     })
 
     // Bid buttons

--- a/test/unit/web/hand.test.js
+++ b/test/unit/web/hand.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { cardHtml, handSpreadHtml, handDiagramHtml } from '../../../client/web/src/hand.js'
+import { cardHtml, handSpreadHtml, handDiagramHtml, lastTrickHtml } from '../../../client/web/src/hand.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -221,5 +221,85 @@ describe('handDiagramHtml', () => {
     assert.ok(spIdx < hIdx, 'spades before hearts')
     assert.ok(hIdx < dIdx, 'hearts before diamonds')
     assert.ok(dIdx < cIdx, 'diamonds before clubs')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// lastTrickHtml
+// ---------------------------------------------------------------------------
+
+describe('lastTrickHtml', () => {
+  const rel = { me: 'south', right: 'west', across: 'north', left: 'east' }
+
+  const fullTrick = {
+    winner: 'north',
+    plays: [
+      { seat: 'north', card: { suit: 'spades', rank: 'A' } },
+      { seat: 'east',  card: { suit: 'clubs',  rank: '2' } },
+      { seat: 'south', card: { suit: 'hearts', rank: 'K' } },
+      { seat: 'west',  card: { suit: 'diamonds', rank: 'Q' } },
+    ],
+  }
+
+  it('renders all 4 cards', () => {
+    const html = lastTrickHtml(fullTrick, rel)
+    assert.ok(html.includes('A\u2660'), 'should contain A♠')
+    assert.ok(html.includes('2\u2663'), 'should contain 2♣')
+    assert.ok(html.includes('K\u2665'), 'should contain K♥')
+    assert.ok(html.includes('Q\u2666'), 'should contain Q♦')
+  })
+
+  it('shows "Won by You" when current player won', () => {
+    const trick = { winner: 'south', plays: fullTrick.plays }
+    const html = lastTrickHtml(trick, rel)
+    assert.ok(html.includes('Won by You'), 'should say "Won by You"')
+  })
+
+  it('shows capitalized seat name when an opponent won', () => {
+    const html = lastTrickHtml(fullTrick, rel)
+    assert.ok(html.includes('Won by North'), 'should say "Won by North"')
+  })
+
+  it('applies trick-red class to red-suit cards', () => {
+    const html = lastTrickHtml(fullTrick, rel)
+    // hearts (K) and diamonds (Q) should have trick-red
+    const redCount = (html.match(/trick-red/g) || []).length
+    assert.equal(redCount, 2, 'exactly 2 red-suit cards should have trick-red')
+  })
+
+  it('does not apply trick-red to black-suit cards', () => {
+    const blackOnly = {
+      winner: 'north',
+      plays: [
+        { seat: 'north', card: { suit: 'spades',  rank: 'A' } },
+        { seat: 'east',  card: { suit: 'clubs',   rank: '2' } },
+        { seat: 'south', card: { suit: 'spades',  rank: '3' } },
+        { seat: 'west',  card: { suit: 'clubs',   rank: '4' } },
+      ],
+    }
+    const html = lastTrickHtml(blackOnly, rel)
+    assert.equal((html.match(/trick-red/g) || []).length, 0)
+  })
+
+  it('escapes HTML special characters in card rank', () => {
+    const trick = {
+      winner: 'north',
+      plays: [
+        { seat: 'north', card: { suit: 'spades', rank: '<b>' } },
+        { seat: 'east',  card: { suit: 'clubs',  rank: '2' } },
+        { seat: 'south', card: { suit: 'hearts', rank: '3' } },
+        { seat: 'west',  card: { suit: 'diamonds', rank: '4' } },
+      ],
+    }
+    const html = lastTrickHtml(trick, rel)
+    assert.ok(!html.includes('<b>'), 'raw HTML should be escaped')
+    assert.ok(html.includes('&lt;b&gt;'))
+  })
+
+  it('renders the overlay and modal wrapper elements', () => {
+    const html = lastTrickHtml(fullTrick, rel)
+    assert.ok(html.includes('last-trick-overlay'), 'should include overlay element')
+    assert.ok(html.includes('last-trick-modal'), 'should include modal element')
+    assert.ok(html.includes('last-trick-close'), 'should include close button')
   })
 })


### PR DESCRIPTION
Adds a "Last Trick" button below the trick area once the first trick of a hand completes. Clicking it opens a modal overlay showing all 4 cards from the most recently completed trick in the same positional layout as the live table, with a "Won by" label. Dismiss via backdrop or Close button.

No server changes needed — completedTricks was already tracked and sent to the client.

Closes #133

Generated with [Claude Code](https://claude.ai/code)