### PR TITLE
fix: swap left/right in relSeats — play order appearing counterclockwise

### DIFF
--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -7,10 +7,10 @@ import {
 } from '../api.js'
 import { navigate } from '../router.js'
 import { handSpreadHtml, handDiagramHtml, lastTrickHtml } from '../hand.js'
+import { relSeats } from '../seatUtils.js'
 
 const SUIT_SYMBOL = { spades: '\u2660', hearts: '\u2665', diamonds: '\u2666', clubs: '\u2663' }
 const RED_SUIT = new Set(['hearts', 'diamonds'])
-const CW = ['north', 'east', 'south', 'west']
 const PARTNER = { north: 'south', south: 'north', east: 'west', west: 'east' }
 const TEAM = { north: 'ns', south: 'ns', east: 'ew', west: 'ew' }
 
@@ -25,18 +25,6 @@ function esc(s) {
 
 function getSeatForPlayer(players, playerId) {
   return Object.entries(players).find(([, pid]) => pid === playerId)?.[0] ?? null
-}
-
-// Returns seats from the current player's perspective:
-//   me = bottom, right = clockwise neighbour, across = partner, left = counter-clockwise neighbour
-function relSeats(seat) {
-  const i = CW.indexOf(seat)
-  return {
-    me: CW[i],
-    right: CW[(i + 1) % 4],
-    across: CW[(i + 2) % 4],
-    left: CW[(i + 3) % 4],
-  }
 }
 
 function bidLabel(bid) {

--- a/client/web/src/seatUtils.js
+++ b/client/web/src/seatUtils.js
@@ -1,0 +1,17 @@
+// Clockwise seat order as viewed from above the table (N → E → S → W → N).
+// In a standard card game, play passes to the LEFT, which is the next seat
+// in this clockwise order.
+export const CW = ['north', 'east', 'south', 'west']
+
+// Returns seats from the current player's perspective:
+//   me = bottom, left = clockwise neighbour, across = partner, right = counter-clockwise neighbour
+// Play passes to the LEFT (clockwise): e.g. South's left neighbour is West.
+export function relSeats(seat) {
+  const i = CW.indexOf(seat)
+  return {
+    me: CW[i],
+    left: CW[(i + 1) % 4],    // clockwise neighbour — play passes here
+    across: CW[(i + 2) % 4],
+    right: CW[(i + 3) % 4],   // counter-clockwise neighbour
+  }
+}

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -9,6 +9,8 @@
 
 ## ✅ Completed
 
+- [x] `BUG` Fix play/bid order appearing counterclockwise in the web UI: `relSeats()` in `client/web/src/screens/game.js` had `left` and `right` swapped, making each player's clockwise neighbour appear on the wrong side of the screen. Extracted `relSeats` and `CW` to `client/web/src/seatUtils.js` and added unit tests. Server engine was unaffected.
+
 - [x] `DEV` `DEV_AUTO_VERIFY` env var — when set to `true`, registration skips email verification and marks the player as verified immediately. Enables registering multiple test accounts without an email server. Never set in production.
 - [x] `DEV` Simple bot players — `POST /api/tables/:tableId/add-bot` lets the table host add a bot to any empty seat. Bots bid the number of spades in their hand and play a random legal card. Bot turns advance automatically server-side after each human action; no client round-trips needed. Bot IDs follow the pattern `bot:<seat>` and are scoped to dev/test use — they do not affect the production bot design in v1.1.
 - [x] `P0` Implement email/password registration with required email verification

--- a/test/unit/web/hand.test.js
+++ b/test/unit/web/hand.test.js
@@ -229,7 +229,7 @@ describe('handDiagramHtml', () => {
 // ---------------------------------------------------------------------------
 
 describe('lastTrickHtml', () => {
-  const rel = { me: 'south', right: 'west', across: 'north', left: 'east' }
+  const rel = { me: 'south', right: 'east', across: 'north', left: 'west' }
 
   const fullTrick = {
     winner: 'north',

--- a/test/unit/web/seatUtils.test.js
+++ b/test/unit/web/seatUtils.test.js
@@ -1,0 +1,58 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { relSeats } from '../../../client/web/src/seatUtils.js'
+
+// In a standard card game, play passes to the LEFT (clockwise from above).
+// Each player faces the player across from them; the clockwise neighbour is
+// physically to their left.
+//
+// Seat layout (player perspective from the bottom seat):
+//
+//        [across]
+//  [left]        [right]
+//        [ me  ]
+//
+// CW order: north → east → south → west → north
+
+describe('relSeats', () => {
+  it('south: left=west (clockwise), right=east, across=north', () => {
+    const rel = relSeats('south')
+    assert.equal(rel.me, 'south')
+    assert.equal(rel.left, 'west',  'clockwise from south is west — to south\'s left')
+    assert.equal(rel.across, 'north')
+    assert.equal(rel.right, 'east', 'counter-clockwise from south is east — to south\'s right')
+  })
+
+  it('north: left=east (clockwise), right=west, across=south', () => {
+    const rel = relSeats('north')
+    assert.equal(rel.me, 'north')
+    assert.equal(rel.left, 'east',  'clockwise from north is east — to north\'s left')
+    assert.equal(rel.across, 'south')
+    assert.equal(rel.right, 'west', 'counter-clockwise from north is west — to north\'s right')
+  })
+
+  it('east: left=south (clockwise), right=north, across=west', () => {
+    const rel = relSeats('east')
+    assert.equal(rel.me, 'east')
+    assert.equal(rel.left, 'south', 'clockwise from east is south — to east\'s left')
+    assert.equal(rel.across, 'west')
+    assert.equal(rel.right, 'north', 'counter-clockwise from east is north — to east\'s right')
+  })
+
+  it('west: left=north (clockwise), right=south, across=east', () => {
+    const rel = relSeats('west')
+    assert.equal(rel.me, 'west')
+    assert.equal(rel.left, 'north', 'clockwise from west is north — to west\'s left')
+    assert.equal(rel.across, 'east')
+    assert.equal(rel.right, 'south', 'counter-clockwise from west is south — to west\'s right')
+  })
+
+  it('play order passes left: me → left → across → right → me', () => {
+    // Starting from each seat, four left-turns should return to the same seat
+    for (const start of ['north', 'east', 'south', 'west']) {
+      let seat = start
+      for (let i = 0; i < 4; i++) seat = relSeats(seat).left
+      assert.equal(seat, start, `four left-turns from ${start} should return to ${start}`)
+    }
+  })
+})


### PR DESCRIPTION
Fixes #136

## What changed

`relSeats()` in `client/web/src/screens/game.js` had `left` and `right` swapped. For South (facing North): East is to the right, West is to the left — but the code placed West on the right and East on the left. This made each player's clockwise neighbour appear on the wrong side of the screen, causing play and bid order to visually flip counterclockwise.

## Changes

- **`client/web/src/seatUtils.js`** (new) — extracted `CW` and `relSeats` as an exported module for testability
- **`client/web/src/screens/game.js`** — removed local `CW`/`relSeats`, imports from `seatUtils.js`
- **`test/unit/web/seatUtils.test.js`** (new) — unit tests for all 4 seats
- **`test/unit/web/hand.test.js`** — corrected hardcoded `rel` fixture
- **`docs/TASKS.md`** — recorded fix in completed section

Server game engine was unaffected — display-only bug.

Generated with [Claude Code](https://claude.ai/code)