### PR TITLE
docs: blind nil hand hiding — PRD v1.5 + Slice 1 tasks

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -34,6 +34,7 @@
 - [x] `P0` Implement partnership bidding: first bidder bids individually, second bidder sets team total (first bidder's number is advisory only)
 - [x] `P0` Implement Nil bid (+50 / -50)
 - [x] `P0` Implement Blind Nil bid (+100 / -100): eligibility check (≥100 pts behind), one-per-team limit, card exchange after all bids but before opening lead
+- [ ] `P0` Blind Nil hand hiding — server-side enforcement: when a team is eligible for Blind Nil at deal time, omit `myHand` from `HAND_DEALT` for those players and set `blindNilEligible: true`; add `POST /api/tables/:tableId/reveal-hand` that validates bidding phase, player eligibility, and no bid yet placed — then emits `HAND_REVEALED` with `myHand` to that player only; bidding Blind Nil also triggers the hand reveal to the server's game state as normal
 - [x] `P0` Implement team bid of 0: legal, not treated as Nil; every trick taken is a bag
 - [x] `P0` Enforce no Spade lead on first trick rule
 - [x] `P0` Implement Spades-breaking logic
@@ -52,12 +53,15 @@
 - [x] `P0` Create table screen: name only (no visibility/join policy yet)
 - [x] `P0` Join table screen: list of open tables, click to join and choose a seat
 - [x] `P0` Game screen: display hand, bid input, card play, current trick, scoreboard
+- [ ] `P0` Blind Nil hand hiding — web UI: when `HAND_DEALT` arrives with `blindNilEligible: true` and no `myHand`, render face-down card backs in the hand area and show "Reveal Hand" and "Bid Blind Nil" action buttons in place of the normal bid input; on "Reveal Hand", call `POST /api/tables/:tableId/reveal-hand` and display cards when `HAND_REVEALED` arrives; on "Bid Blind Nil", submit the bid directly — the hand is never displayed to the player
 - [x] `P0` Build hand display in Spread (fan) and Hand Diagram modes
 - [x] `P0` Game over screen: show final score and winner
 
 ### Testing
 
 - [x] `P0` End-to-end test: 4 players complete a full game from table creation to game over
+- [ ] `P0` Unit tests: blind nil eligible player does not receive `myHand` in `HAND_DEALT`; `HAND_REVEALED` is emitted only after `reveal-hand` is called; `reveal-hand` is rejected if the player has already placed a bid or is not eligible; ineligible team receives their full hand immediately
+- [ ] `P0` Integration test: blind nil eligible player's hand is withheld until reveal; both reveal-then-bid and bid-blind-nil-directly flows complete successfully
 
 ---
 

--- a/docs/spades_prd.md
+++ b/docs/spades_prd.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Version** | 1.4 — Visibility-Aware Lobby Events |
+| **Version** | 1.5 — Blind Nil Hand Visibility |
 | **Date** | April 2026 |
 | **Status** | For Review |
 | **Product** | Spades Online (Mobile & Web) |
@@ -149,6 +149,7 @@ v1.0 ships with a single standard ruleset. Rule customization is deferred to v1.
 | **Spades Breaking** | Spades are broken by the first Spade played (after the first trick). Once broken, Spades may be led. |
 | **Nil** | +50 if successful, -50 if failed. Available to any player at any time. |
 | **Blind Nil Eligibility** | A player may bid Blind Nil only if their team is at least 100 points behind the opposing team. |
+| **Blind Nil Hand Visibility** | When a team is eligible for Blind Nil at the start of a hand, the server withholds that team's cards from each eligible player until they explicitly act. Each eligible player is presented with two options: *Reveal Hand* — view cards and bid normally — or *Bid Blind Nil* — commit to a Blind Nil bid without viewing. The server must not transmit the player's cards in the initial `HAND_DEALT` event; cards are sent only after the player takes one of these two actions. This is a server-side enforcement and must not rely on client-side hiding alone. The ineligible team's players receive their hands immediately and may bid while eligible players are deciding. |
 | **Blind Nil Score** | +100 if successful, -100 if failed. |
 | **Blind Nil Limit** | Only one player per team may bid Blind Nil in a given hand. |
 | **Blind Nil Card Exchange** | The card exchange occurs after all four players have bid but before the opening lead. The Blind Nil player passes 2 cards face-down to their partner; the partner then passes 2 cards back. |
@@ -217,8 +218,9 @@ Events must not change shape in a backward-incompatible way without coordinating
 
 | Event | Audience | Key Payload Fields |
 |---|---|---|
-| `HAND_DEALT` | Per-player (4 individual sends) | `myHand`, `dealer`, `biddingOrder` |
+| `HAND_DEALT` | Per-player (4 individual sends) | `dealer`, `biddingOrder`, `blindNilEligible` (boolean); `myHand` is **omitted** when `blindNilEligible` is `true` — cards are withheld until the player reveals or bids Blind Nil |
 | `BID_PLACED` | All in room | `seat`, `bidType` (`nil` / `blindNil` / `number`); numeric value hidden until end-of-hand scoring |
+| `HAND_REVEALED` | Specific player | `myHand` — the player's full 13-card hand; sent only after the player calls *Reveal Hand* during the Blind Nil eligibility window |
 | `BLIND_NIL_EXCHANGE_PROMPT` | Specific player | `direction` (`send` / `receive`), `count` |
 | `CARD_PLAYED` | All in room | `seat`, `card` |
 | `TRICK_COMPLETE` | All in room | `winnerSeat`, `plays` |


### PR DESCRIPTION
Adds the Blind Nil hand visibility rule to the PRD and corresponding Slice 1 tasks to TASKS.md.

**PRD changes (v1.5):**
- New "Blind Nil Hand Visibility" rule row in Section 5.1 — server withholds cards from eligible players until they reveal or bid Blind Nil
- `HAND_DEALT` event updated: `myHand` omitted when `blindNilEligible: true`
- New `HAND_REVEALED` event added to Section 6.4.3

**TASKS.md changes (Slice 1):**
- Backend P0: `POST /api/tables/:tableId/reveal-hand` endpoint
- Web UI P0: face-down cards + Reveal / Bid Blind Nil buttons
- Testing P0: unit and integration tests for both flows

Closes #140

Generated with [Claude Code](https://claude.ai/code)