### PR TITLE
feat: bot passes 2 random cards during blind nil exchange

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -13,6 +13,7 @@
 
 - [x] `DEV` `DEV_AUTO_VERIFY` env var — when set to `true`, registration skips email verification and marks the player as verified immediately. Enables registering multiple test accounts without an email server. Never set in production.
 - [x] `DEV` Simple bot players — `POST /api/tables/:tableId/add-bot` lets the table host add a bot to any empty seat. Bots bid the number of spades in their hand and play a random legal card. Bot turns advance automatically server-side after each human action; no client round-trips needed. Bot IDs follow the pattern `bot:<seat>` and are scoped to dev/test use — they do not affect the production bot design in v1.1.
+- [x] `DEV` Bot blind nil card exchange — when a human bids blind nil and their partner is a bot, the bot automatically passes 2 random cards during the `partner_to_blind` exchange step, allowing games with bot partners to proceed through the blind nil exchange without stalling.
 - [x] `P0` Implement email/password registration with required email verification
 - [x] `P0` Resend verification email flow: `POST /api/auth/resend-verification` + UI prompt on login 403 and registration success screen
 - [x] `P0` Forgot password flow: `POST /api/auth/forgot-password`, `POST /api/auth/reset-password`, forgot/reset password screens with proper success/error landing pages

--- a/server/game/bot.js
+++ b/server/game/bot.js
@@ -32,6 +32,18 @@ export function botBid(hand) {
 }
 
 /**
+ * Choose 2 random cards for the bot to pass during a blind nil card exchange.
+ * Used when the bot is the partner of a blind nil bidder.
+ *
+ * @param {Array<{suit: string, rank: string}>} hand
+ * @returns {Array<{suit: string, rank: string}>} Exactly 2 cards
+ */
+export function botBlindNilExchange(hand) {
+  const shuffled = [...hand].sort(() => Math.random() - 0.5)
+  return shuffled.slice(0, 2)
+}
+
+/**
  * Choose a card for the bot to play.
  * Picks uniformly at random from the set of legal plays.
  *

--- a/server/server.js
+++ b/server/server.js
@@ -20,8 +20,9 @@ import {
   removePlayerFromTables,
 } from './lobby/table.js'
 import { createGame, placeBid, playCard, submitBlindNilExchange, getPlayerView } from './game/state.js'
+import { getPartnerSeat } from './game/bid.js'
 import { getSeatForPlayer, validateCardPlay, validateBidTurn } from './anticheat/validate.js'
-import { isBot, botBid, botPlay } from './game/bot.js'
+import { isBot, botBid, botPlay, botBlindNilExchange } from './game/bot.js'
 
 function sendJSON(res, statusCode, data) {
   res.status(statusCode).json(data)
@@ -49,8 +50,17 @@ function advanceBotTurns(state) {
       const card = botPlay(current.hands[seat], current.currentTrick, current.spadesbroken, current.isFirstTrick)
       console.log('Bot play:', { seat, card, tableId: current.tableId })
       current = playCard(current, seat, card)
+    } else if (current.phase === 'blind_nil_exchange') {
+      const { currentBlindNilSeat, step } = current.blindNilExchange
+      // Bots never bid blind nil, so they can only act as the partner (step: partner_to_blind)
+      if (step !== 'partner_to_blind') break
+      const partnerSeat = getPartnerSeat(currentBlindNilSeat)
+      if (!isBot(current.players[partnerSeat])) break
+      const cards = botBlindNilExchange(current.hands[partnerSeat])
+      console.log('Bot blind nil exchange:', { seat: partnerSeat, cards, tableId: current.tableId })
+      current = submitBlindNilExchange(current, partnerSeat, cards)
     } else {
-      // blind_nil_exchange or game_over — bots never bid blind nil, nothing to auto-advance
+      // game_over — nothing to auto-advance
       break
     }
   }

--- a/test/unit/game/bot.test.js
+++ b/test/unit/game/bot.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { isBot, getBotPlayerId, botBid, botPlay } from '../../../server/game/bot.js'
+import { isBot, getBotPlayerId, botBid, botPlay, botBlindNilExchange } from '../../../server/game/bot.js'
 
 describe('isBot', () => {
   it('returns true for bot player IDs', () => {
@@ -112,5 +112,38 @@ describe('botPlay', () => {
     const card = botPlay(hand, [], false, false)
     assert.equal(card.suit, 'clubs')
     assert.equal(card.rank, '2')
+  })
+})
+
+describe('botBlindNilExchange', () => {
+  const hand = [
+    { suit: 'spades', rank: 'A' },
+    { suit: 'spades', rank: 'K' },
+    { suit: 'hearts', rank: 'Q' },
+    { suit: 'clubs', rank: '7' },
+    { suit: 'diamonds', rank: '3' },
+  ]
+
+  it('returns exactly 2 cards', () => {
+    const cards = botBlindNilExchange(hand)
+    assert.equal(cards.length, 2)
+  })
+
+  it('returns cards that are in the hand', () => {
+    const cards = botBlindNilExchange(hand)
+    for (const card of cards) {
+      assert.ok(hand.some((c) => c.suit === card.suit && c.rank === card.rank))
+    }
+  })
+
+  it('returns 2 distinct cards (no duplicate)', () => {
+    const cards = botBlindNilExchange(hand)
+    assert.notDeepEqual(cards[0], cards[1])
+  })
+
+  it('does not mutate the original hand', () => {
+    const originalLength = hand.length
+    botBlindNilExchange(hand)
+    assert.equal(hand.length, originalLength)
   })
 })


### PR DESCRIPTION
When a human bids blind nil and their partner is a bot, the game was stalling because `advanceBotTurns` had no handler for the `blind_nil_exchange` phase.

Adds `botBlindNilExchange(hand)` to `bot.js` and wires it into `advanceBotTurns` so the bot automatically passes 2 random cards when it is the partner of a blind nil bidder.

Closes #139

Generated with [Claude Code](https://claude.ai/code)