### PR TITLE
docs: add PRD Section 5.3 bidding UI requirements (#138)

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -54,6 +54,7 @@
 - [x] `P0` Create table screen: name only (no visibility/join policy yet)
 - [x] `P0` Join table screen: list of open tables, click to join and choose a seat
 - [x] `P0` Game screen: display hand, bid input, card play, current trick, scoreboard
+- [ ] `P0` Bidding UI — partnership clarity: label the second bidder's input as "Team Total", show the partner's bid adjacent to the input, display a live individual-contribution hint that switches to a bag warning (e.g. *"⚠ Team target (2) is below partner's bid (4) — every trick above 2 is a bag"*) when the team total falls below the partner's bid, and show the team's combined bid in the post-bid summary (see PRD Section 5.3)
 - [ ] `P0` Blind Nil hand hiding — web UI: when `HAND_DEALT` arrives with `blindNilEligible: true` and no `myHand`, render face-down card backs in the hand area and show "Reveal Hand" and "Bid Blind Nil" action buttons in place of the normal bid input; on "Reveal Hand", call `POST /api/tables/:tableId/reveal-hand` and display cards when `HAND_REVEALED` arrives; on "Bid Blind Nil", submit the bid directly — the hand is never displayed to the player
 - [x] `P0` Build hand display in Spread (fan) and Hand Diagram modes
 - [x] `P0` Game over screen: show final score and winner

--- a/docs/spades_prd.md
+++ b/docs/spades_prd.md
@@ -168,6 +168,20 @@ The bidding sequence follows a partnership model designed to allow informed team
 
 > **Example:** North bids 4. South (second bidder) sees the 4 and bids a team total of 7. The team target is 7 (South has effectively bid 3 for themselves). If North had instead bid Nil, North's Nil bid stands and South bids only their own hand.
 
+### 5.3 Bidding UI Requirements
+
+The second-bidder's role as team-total setter must be made explicit in the UI. The following requirements apply to all clients (web and mobile).
+
+1. **"Team Total" label** — the second bidder's input must be labelled **"Team Total"**, not "Your Bid", so it is immediately clear they are setting the combined team target.
+
+2. **Partner's bid visible** — the first bidder's already-placed bid must be shown adjacent to the second bidder's input (e.g. *"Partner bid 4 — enter team total:"*).
+
+3. **Live individual-contribution hint** — as the second bidder adjusts the input, show a live hint below it:
+   - When team total ≥ partner's bid: *"You are bidding X (team total Y − partner's bid Z)"*
+   - When team total < partner's bid: *"⚠ Team target (Y) is below partner's bid (Z) — every trick above Y is a bag"* — this surfaces the bag consequence of setting a target lower than the partner's individual bid, which is a valid strategic choice.
+
+4. **Post-bid team summary** — once both bids are placed, the bid summary shows the team's combined total alongside individual bids (e.g. *"N/S: 7 — North 4, South 3"*). Nil and Blind Nil bids are shown individually and are not combined into the team total.
+
 ---
 
 ## 6. Technical Requirements


### PR DESCRIPTION
Adds PRD Section 5.3 specifying UX requirements for the bidding phase to make the partnership model clear to all players, and a corresponding Slice 1 P0 task in TASKS.md.

Uses "bid" throughout (not "pledge"). When the second bidder sets a team total below their partner's bid, the live hint switches to a warning surfacing the bag consequence.

Closes #138

Generated with [Claude Code](https://claude.ai/code)