### PR TITLE
feat: end-of-trick hold — keep completed trick visible with winner highlight

### DIFF
--- a/client/web/index.html
+++ b/client/web/index.html
@@ -412,6 +412,11 @@
         background: #183018;
       }
 
+      .seat-info.seat-winner {
+        border-color: #ffd54f;
+        background: #2a2200;
+      }
+
       .seat-name {
         display: block;
         font-size: 0.7rem;
@@ -441,6 +446,19 @@
         border-radius: 8px;
         padding: 0.5rem;
         min-height: 130px;
+      }
+
+      /* Hold state — completed trick is kept visible while the hold timer runs */
+      .trick-area--hold {
+        border: 1px solid #ffd54f;
+      }
+
+      .trick-winner-banner {
+        font-size: 0.75rem;
+        font-weight: 700;
+        color: #ffd54f;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
       }
 
       .trick-row {

--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -8,6 +8,7 @@ import {
 import { navigate } from '../router.js'
 import { handSpreadHtml, handDiagramHtml, lastTrickHtml } from '../hand.js'
 import { relSeats } from '../seatUtils.js'
+import { HOLD_DURATIONS, detectCompletedTrick, trickHoldHtml } from '../trickHold.js'
 
 const SUIT_SYMBOL = { spades: '\u2660', hearts: '\u2665', diamonds: '\u2666', clubs: '\u2663' }
 const RED_SUIT = new Set(['hearts', 'diamonds'])
@@ -34,13 +35,14 @@ function bidLabel(bid) {
   return String(bid)
 }
 
-function seatInfoHtml(state, seat, label) {
+function seatInfoHtml(state, seat, label, isWinner = false) {
   const bid = state.bids[seat]
   const tricks = state.tricksWon[seat]
   const isActive = state.currentBidderSeat === seat || state.currentPlayerSeat === seat
   const activeCls = isActive ? ' seat-active' : ''
+  const winnerCls = isWinner ? ' seat-winner' : ''
   return `
-    <div class="seat-info${activeCls}">
+    <div class="seat-info${activeCls}${winnerCls}">
       <span class="seat-name">${esc(label)}</span>
       <div class="seat-stats">
         <span>Bid: ${esc(bidLabel(bid))}</span>
@@ -98,11 +100,33 @@ export function renderGameScreen(container) {
   let pollTimer = null
   let acting = false
   let mounted = true
+  let holdActive = false
+  let holdTrick = null
+  let holdTimer = null
+  let queuedState = null
 
   function cleanup() {
     mounted = false
     clearTimeout(pollTimer)
+    clearTimeout(holdTimer)
     if (appEl) appEl.classList.remove('app--game')
+  }
+
+  function startHold(trick) {
+    holdActive = true
+    holdTrick = trick
+    queuedState = null
+    clearTimeout(holdTimer)
+    render()
+    holdTimer = setTimeout(() => {
+      holdActive = false
+      holdTrick = null
+      if (queuedState !== null) {
+        state = queuedState
+        queuedState = null
+      }
+      render()
+    }, HOLD_DURATIONS.normal)
   }
   window.addEventListener('hashchange', cleanup, { once: true })
 
@@ -114,8 +138,13 @@ export function renderGameScreen(container) {
       try {
         const s = await getGameState({ tableId, sessionId, playerId })
         if (!mounted) return
-        state = s
-        render()
+        if (holdActive) {
+          // Queue the update — apply it after the hold window expires
+          queuedState = s
+        } else {
+          state = s
+          render()
+        }
       } catch (_) {
         // silent — retry on next poll
       }
@@ -270,24 +299,24 @@ export function renderGameScreen(container) {
 
         <div class="game-table">
           <div class="table-top">
-            ${seatInfoHtml(state, rel.across, rel.across.charAt(0).toUpperCase() + rel.across.slice(1))}
+            ${seatInfoHtml(state, rel.across, rel.across.charAt(0).toUpperCase() + rel.across.slice(1), holdActive && holdTrick?.winner === rel.across)}
           </div>
           <div class="table-middle">
             <div class="table-side table-left">
-              ${seatInfoHtml(state, rel.left, rel.left.charAt(0).toUpperCase() + rel.left.slice(1))}
+              ${seatInfoHtml(state, rel.left, rel.left.charAt(0).toUpperCase() + rel.left.slice(1), holdActive && holdTrick?.winner === rel.left)}
             </div>
             <div class="trick-wrap">
-              ${trickHtml(state, rel)}
-              ${state.phase === 'playing' && state.completedTricks.length > 0
+              ${holdActive ? trickHoldHtml(holdTrick, rel) : trickHtml(state, rel)}
+              ${!holdActive && state.phase === 'playing' && state.completedTricks.length > 0
                 ? '<button class="last-trick-btn" id="last-trick-btn">Last Trick</button>'
                 : ''}
             </div>
             <div class="table-side table-right">
-              ${seatInfoHtml(state, rel.right, rel.right.charAt(0).toUpperCase() + rel.right.slice(1))}
+              ${seatInfoHtml(state, rel.right, rel.right.charAt(0).toUpperCase() + rel.right.slice(1), holdActive && holdTrick?.winner === rel.right)}
             </div>
           </div>
           <div class="table-bottom">
-            ${seatInfoHtml(state, rel.me, 'You')}
+            ${seatInfoHtml(state, rel.me, 'You', holdActive && holdTrick?.winner === rel.me)}
           </div>
         </div>
 
@@ -372,11 +401,17 @@ export function renderGameScreen(container) {
             if (acting) return
             acting = true
             clearTimeout(pollTimer)
+            const prevState = state
             try {
               const s = await apiPlay({ tableId, card, sessionId, playerId })
               if (!mounted) return
+              const completedTrick = detectCompletedTrick(prevState, s)
               state = s
-              render()
+              if (completedTrick) {
+                startHold(completedTrick)
+              } else {
+                render()
+              }
             } catch (err) {
               if (!mounted) return
               const errEl = container.querySelector('.play-err')

--- a/client/web/src/trickHold.js
+++ b/client/web/src/trickHold.js
@@ -1,0 +1,76 @@
+const SUIT_SYMBOL = { spades: '\u2660', hearts: '\u2665', diamonds: '\u2666', clubs: '\u2663' }
+const RED_SUIT = new Set(['hearts', 'diamonds'])
+
+function esc(s) {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+/**
+ * Hold durations in milliseconds by animation speed setting.
+ * Hardcoded to `normal` (1500 ms) until the animation speed setting ships in Slice 5.
+ */
+export const HOLD_DURATIONS = { slow: 2500, normal: 1500, fast: 800 }
+
+/**
+ * Compare two successive game states and return the trick that was just
+ * completed, or null if no new trick completed between the two states.
+ *
+ * A trick is considered newly completed when nextState.completedTricks is
+ * longer than prevState.completedTricks.
+ *
+ * @param {object|null} prevState
+ * @param {object} nextState
+ * @returns {{ winner: string, plays: Array<{ seat: string, card: object }> } | null}
+ */
+export function detectCompletedTrick(prevState, nextState) {
+  if (!prevState || !nextState) return null
+  if (!Array.isArray(nextState.completedTricks)) return null
+  const prevLen = Array.isArray(prevState.completedTricks) ? prevState.completedTricks.length : 0
+  if (nextState.completedTricks.length > prevLen) {
+    return nextState.completedTricks[nextState.completedTricks.length - 1]
+  }
+  return null
+}
+
+/**
+ * Render a just-completed trick inline in the trick area during the hold window.
+ * Displays all four cards in the positional layout (same as the active trick area)
+ * with a winner banner above the cards.
+ *
+ * @param {{ winner: string, plays: Array<{ seat: string, card: object }> }} trick
+ * @param {{ me: string, right: string, across: string, left: string }} rel - seat positions from current player's perspective
+ * @returns {string} HTML string
+ */
+export function trickHoldHtml(trick, rel) {
+  const bySeats = {}
+  for (const { seat, card } of trick.plays) bySeats[seat] = card
+
+  function slot(seat) {
+    const card = bySeats[seat]
+    if (!card) return '<div class="trick-slot"></div>'
+    const s = SUIT_SYMBOL[card.suit]
+    const red = RED_SUIT.has(card.suit) ? ' trick-red' : ''
+    return `<div class="trick-slot"><div class="trick-card${red}">${esc(card.rank)}${s}</div></div>`
+  }
+
+  const winnerLabel = trick.winner === rel.me
+    ? 'You'
+    : esc(trick.winner.charAt(0).toUpperCase() + trick.winner.slice(1))
+
+  return `
+    <div class="trick-area trick-area--hold">
+      <div class="trick-winner-banner">Won by ${winnerLabel}</div>
+      <div class="trick-row">${slot(rel.across)}</div>
+      <div class="trick-row trick-middle">
+        ${slot(rel.left)}
+        <div class="trick-center"></div>
+        ${slot(rel.right)}
+      </div>
+      <div class="trick-row">${slot(rel.me)}</div>
+    </div>`
+}

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -57,7 +57,7 @@
 - [ ] `P0` Blind Nil hand hiding — web UI: when `HAND_DEALT` arrives with `blindNilEligible: true` and no `myHand`, render face-down card backs in the hand area and show "Reveal Hand" and "Bid Blind Nil" action buttons in place of the normal bid input; on "Reveal Hand", call `POST /api/tables/:tableId/reveal-hand` and display cards when `HAND_REVEALED` arrives; on "Bid Blind Nil", submit the bid directly — the hand is never displayed to the player
 - [x] `P0` Build hand display in Spread (fan) and Hand Diagram modes
 - [x] `P0` Game over screen: show final score and winner
-- [ ] `P1` End-of-trick hold: when the fourth card of a trick is played, keep the completed trick visible for 1500 ms (normal speed, hardcoded until the animation speed setting ships in Slice 5), highlight the winning seat, then clear — state updates that arrive during the hold window are queued and applied only after the hold expires
+- [x] `P1` End-of-trick hold: when the fourth card of a trick is played, keep the completed trick visible for 1500 ms (normal speed, hardcoded until the animation speed setting ships in Slice 5), highlight the winning seat, then clear — state updates that arrive during the hold window are queued and applied only after the hold expires
 - [ ] `P1` Input blocking: disable card play input for the active player from when they play a card until the card play animation (Slice 2) and end-of-trick hold have both fully completed — a `TURN_CHANGED` event arriving during this window must not re-enable input early
 
 ### Testing

--- a/test/unit/web/trickHold.test.js
+++ b/test/unit/web/trickHold.test.js
@@ -1,0 +1,175 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { HOLD_DURATIONS, detectCompletedTrick, trickHoldHtml } from '../../../client/web/src/trickHold.js'
+
+// ---------------------------------------------------------------------------
+// HOLD_DURATIONS
+// ---------------------------------------------------------------------------
+
+describe('HOLD_DURATIONS', () => {
+  it('exports slow duration of 2500 ms', () => {
+    assert.equal(HOLD_DURATIONS.slow, 2500)
+  })
+
+  it('exports normal duration of 1500 ms', () => {
+    assert.equal(HOLD_DURATIONS.normal, 1500)
+  })
+
+  it('exports fast duration of 800 ms', () => {
+    assert.equal(HOLD_DURATIONS.fast, 800)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// detectCompletedTrick
+// ---------------------------------------------------------------------------
+
+describe('detectCompletedTrick', () => {
+  const baseTrick = {
+    winner: 'north',
+    plays: [
+      { seat: 'north', card: { suit: 'spades',   rank: 'A' } },
+      { seat: 'east',  card: { suit: 'clubs',    rank: '2' } },
+      { seat: 'south', card: { suit: 'hearts',   rank: 'K' } },
+      { seat: 'west',  card: { suit: 'diamonds', rank: 'Q' } },
+    ],
+  }
+
+  it('returns null when prevState is null', () => {
+    const next = { completedTricks: [baseTrick], currentTrick: [] }
+    assert.equal(detectCompletedTrick(null, next), null)
+  })
+
+  it('returns null when nextState has no completedTricks array', () => {
+    const prev = { completedTricks: [] }
+    assert.equal(detectCompletedTrick(prev, {}), null)
+  })
+
+  it('returns null when the completedTricks length is unchanged', () => {
+    const prev = { completedTricks: [baseTrick] }
+    const next = { completedTricks: [baseTrick] }
+    assert.equal(detectCompletedTrick(prev, next), null)
+  })
+
+  it('returns null when prevState has no completedTricks and next also has none', () => {
+    const prev = { completedTricks: [] }
+    const next = { completedTricks: [] }
+    assert.equal(detectCompletedTrick(prev, next), null)
+  })
+
+  it('returns the newly completed trick when completedTricks grows by one', () => {
+    const prev = { completedTricks: [], currentTrick: [{ seat: 'north', card: baseTrick.plays[0].card }] }
+    const next = { completedTricks: [baseTrick], currentTrick: [] }
+    const result = detectCompletedTrick(prev, next)
+    assert.deepEqual(result, baseTrick)
+  })
+
+  it('returns the last trick when multiple tricks complete in one transition', () => {
+    const trick2 = { winner: 'south', plays: baseTrick.plays }
+    const prev = { completedTricks: [], currentTrick: [] }
+    const next = { completedTricks: [baseTrick, trick2], currentTrick: [] }
+    const result = detectCompletedTrick(prev, next)
+    assert.deepEqual(result, trick2)
+  })
+
+  it('handles prevState with missing completedTricks gracefully', () => {
+    const next = { completedTricks: [baseTrick] }
+    const result = detectCompletedTrick({}, next)
+    assert.deepEqual(result, baseTrick)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// trickHoldHtml
+// ---------------------------------------------------------------------------
+
+describe('trickHoldHtml', () => {
+  const rel = { me: 'south', right: 'east', across: 'north', left: 'west' }
+
+  const trick = {
+    winner: 'north',
+    plays: [
+      { seat: 'north', card: { suit: 'spades',   rank: 'A' } },
+      { seat: 'east',  card: { suit: 'clubs',    rank: '2' } },
+      { seat: 'south', card: { suit: 'hearts',   rank: 'K' } },
+      { seat: 'west',  card: { suit: 'diamonds', rank: 'Q' } },
+    ],
+  }
+
+  it('renders all 4 cards', () => {
+    const html = trickHoldHtml(trick, rel)
+    assert.ok(html.includes('A\u2660'), 'should contain A♠')
+    assert.ok(html.includes('2\u2663'), 'should contain 2♣')
+    assert.ok(html.includes('K\u2665'), 'should contain K♥')
+    assert.ok(html.includes('Q\u2666'), 'should contain Q♦')
+  })
+
+  it('shows "Won by You" when the current player is the winner', () => {
+    const t = { winner: 'south', plays: trick.plays }
+    const html = trickHoldHtml(t, rel)
+    assert.ok(html.includes('Won by You'), 'should say "Won by You"')
+  })
+
+  it('shows capitalized seat name when an opponent won', () => {
+    const html = trickHoldHtml(trick, rel)
+    assert.ok(html.includes('Won by North'), 'should say "Won by North"')
+  })
+
+  it('includes trick-area--hold modifier class to signal hold state', () => {
+    const html = trickHoldHtml(trick, rel)
+    assert.ok(html.includes('trick-area--hold'), 'should include hold modifier class')
+  })
+
+  it('includes the trick-winner-banner element', () => {
+    const html = trickHoldHtml(trick, rel)
+    assert.ok(html.includes('trick-winner-banner'), 'should include winner banner element')
+  })
+
+  it('applies trick-red to red-suit cards only', () => {
+    const html = trickHoldHtml(trick, rel)
+    // hearts (K) and diamonds (Q) should have trick-red — spades and clubs should not
+    const redCount = (html.match(/trick-red/g) || []).length
+    assert.equal(redCount, 2, 'exactly 2 red-suit cards should have trick-red')
+  })
+
+  it('does not apply trick-red to black-suit cards', () => {
+    const blackOnly = {
+      winner: 'north',
+      plays: [
+        { seat: 'north', card: { suit: 'spades', rank: 'A' } },
+        { seat: 'east',  card: { suit: 'clubs',  rank: '2' } },
+        { seat: 'south', card: { suit: 'spades', rank: '3' } },
+        { seat: 'west',  card: { suit: 'clubs',  rank: '4' } },
+      ],
+    }
+    const html = trickHoldHtml(blackOnly, rel)
+    assert.equal((html.match(/trick-red/g) || []).length, 0, 'no red class for black suits')
+  })
+
+  it('escapes HTML special characters in card ranks', () => {
+    const xssTrick = {
+      winner: 'north',
+      plays: [
+        { seat: 'north', card: { suit: 'spades',   rank: '<b>' } },
+        { seat: 'east',  card: { suit: 'clubs',    rank: '2' } },
+        { seat: 'south', card: { suit: 'hearts',   rank: '3' } },
+        { seat: 'west',  card: { suit: 'diamonds', rank: '4' } },
+      ],
+    }
+    const html = trickHoldHtml(xssTrick, rel)
+    assert.ok(!html.includes('<b>'), 'raw HTML should be escaped')
+    assert.ok(html.includes('&lt;b&gt;'), 'should contain escaped version')
+  })
+
+  it('renders the trick-area wrapper element', () => {
+    const html = trickHoldHtml(trick, rel)
+    assert.ok(html.includes('class="trick-area'), 'should include trick-area element')
+  })
+
+  it('renders positional rows for across, left, right, and me', () => {
+    const html = trickHoldHtml(trick, rel)
+    assert.ok((html.match(/trick-row/g) || []).length >= 2, 'should have at least two trick-row elements')
+    assert.ok(html.includes('trick-middle'), 'should include trick-middle row')
+    assert.ok(html.includes('trick-center'), 'should include trick-center spacing element')
+  })
+})


### PR DESCRIPTION
Implements the end-of-trick hold for the web client (Slice 1, issue #148).

## Changes

- New `client/web/src/trickHold.js` with pure functions: `HOLD_DURATIONS`, `detectCompletedTrick`, `trickHoldHtml`
- `game.js`: hold state machine, state-update queuing during hold, winner seat highlight
- `index.html`: CSS for `.seat-winner`, `.trick-area--hold`, `.trick-winner-banner`
- `docs/TASKS.md`: P1 end-of-trick hold task marked complete
- 20 new unit tests in `test/unit/web/trickHold.test.js`

Resolves #148

Generated with [Claude Code](https://claude.ai/code)