### PR TITLE
feat: fix second-play vulnerability during hold window (#149)

### DIFF
--- a/client/web/src/inputBlock.js
+++ b/client/web/src/inputBlock.js
@@ -1,0 +1,19 @@
+/**
+ * Creates an input blocker instance that tracks whether card-play input
+ * should be disabled. The blocker is owned by a single game-screen mount.
+ *
+ * Slice 2 hook: when animation support ships, move the `unblock()` call
+ * inside the animation-complete promise inside `startHold` in game.js.
+ */
+export function createInputBlocker() {
+  let blocked = false
+
+  return {
+    /** Disable card-play input. Safe to call when already blocked. */
+    block() { blocked = true },
+    /** Re-enable card-play input. Safe to call when already unblocked. */
+    unblock() { blocked = false },
+    /** Returns true if card-play input is currently disabled. */
+    isBlocked() { return blocked },
+  }
+}

--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -9,6 +9,7 @@ import { navigate } from '../router.js'
 import { handSpreadHtml, handDiagramHtml, lastTrickHtml } from '../hand.js'
 import { relSeats } from '../seatUtils.js'
 import { HOLD_DURATIONS, detectCompletedTrick, trickHoldHtml } from '../trickHold.js'
+import { createInputBlocker } from '../inputBlock.js'
 
 const SUIT_SYMBOL = { spades: '\u2660', hearts: '\u2665', diamonds: '\u2666', clubs: '\u2663' }
 const RED_SUIT = new Set(['hearts', 'diamonds'])
@@ -104,6 +105,7 @@ export function renderGameScreen(container) {
   let holdTrick = null
   let holdTimer = null
   let queuedState = null
+  const inputBlocker = createInputBlocker()
 
   function cleanup() {
     mounted = false
@@ -121,6 +123,9 @@ export function renderGameScreen(container) {
     holdTimer = setTimeout(() => {
       holdActive = false
       holdTrick = null
+      // Slice 2 hook: move inputBlocker.unblock() inside the animation-complete
+      // promise when card-play animations ship.
+      inputBlocker.unblock()
       if (queuedState !== null) {
         state = queuedState
         queuedState = null
@@ -234,7 +239,7 @@ export function renderGameScreen(container) {
 
     function cardExtraCls(card) {
       const key = `${card.suit}-${card.rank}`
-      if (isMyPlayTurn) return 'card-play'
+      if (isMyPlayTurn && !inputBlocker.isBlocked()) return 'card-play'
       if (isMyExchangeTurn) return selectedSet.has(key) ? 'card-sel' : 'card-exch'
       return ''
     }
@@ -391,15 +396,16 @@ export function renderGameScreen(container) {
     }
 
     // Hand card interactions (play or exchange)
-    const handIsInteractive = isMyPlayTurn || isMyExchangeTurn
+    const handIsInteractive = (isMyPlayTurn && !inputBlocker.isBlocked()) || isMyExchangeTurn
     if (handIsInteractive) {
       container.querySelectorAll('#hand-cards [data-suit]').forEach((el) => {
         el.addEventListener('click', async () => {
           const card = { suit: el.dataset.suit, rank: el.dataset.rank }
 
           if (isMyPlayTurn) {
-            if (acting) return
+            if (acting || inputBlocker.isBlocked()) return
             acting = true
+            inputBlocker.block()
             clearTimeout(pollTimer)
             const prevState = state
             try {
@@ -409,10 +415,13 @@ export function renderGameScreen(container) {
               state = s
               if (completedTrick) {
                 startHold(completedTrick)
+                // inputBlocker stays blocked until the hold timer fires
               } else {
+                inputBlocker.unblock()
                 render()
               }
             } catch (err) {
+              inputBlocker.unblock()
               if (!mounted) return
               const errEl = container.querySelector('.play-err')
               if (errEl) errEl.textContent = err.message || 'Cannot play that card.'

--- a/test/unit/web/inputBlock.test.js
+++ b/test/unit/web/inputBlock.test.js
@@ -1,0 +1,54 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createInputBlocker } from '../../../client/web/src/inputBlock.js'
+
+describe('createInputBlocker', () => {
+  it('starts unblocked', () => {
+    const blocker = createInputBlocker()
+    assert.equal(blocker.isBlocked(), false)
+  })
+
+  it('is blocked after block()', () => {
+    const blocker = createInputBlocker()
+    blocker.block()
+    assert.equal(blocker.isBlocked(), true)
+  })
+
+  it('is unblocked after unblock()', () => {
+    const blocker = createInputBlocker()
+    blocker.block()
+    blocker.unblock()
+    assert.equal(blocker.isBlocked(), false)
+  })
+
+  it('unblock() is idempotent when already unblocked', () => {
+    const blocker = createInputBlocker()
+    blocker.unblock()
+    blocker.unblock()
+    assert.equal(blocker.isBlocked(), false)
+  })
+
+  it('block() does not stack — a single unblock() clears it', () => {
+    const blocker = createInputBlocker()
+    blocker.block()
+    blocker.block()
+    blocker.unblock()
+    assert.equal(blocker.isBlocked(), false)
+  })
+
+  it('can be re-blocked after unblocking', () => {
+    const blocker = createInputBlocker()
+    blocker.block()
+    blocker.unblock()
+    blocker.block()
+    assert.equal(blocker.isBlocked(), true)
+  })
+
+  it('two instances are independent', () => {
+    const a = createInputBlocker()
+    const b = createInputBlocker()
+    a.block()
+    assert.equal(a.isBlocked(), true)
+    assert.equal(b.isBlocked(), false)
+  })
+})


### PR DESCRIPTION
Closes #149

Fix the second-play vulnerability where a player could play a second card during the end-of-trick hold window. The root cause was `acting` being reset to `false` in `finally` even after `startHold()` was called.

Introduces `client/web/src/inputBlock.js` — a factory owning a persistent `blocked` flag that is set on click and only cleared by the hold timer (or on API error). Adds 7 unit tests.

Generated with [Claude Code](https://claude.ai/code)