### PR TITLE
test: bidding UI partnership clarity unit tests (issue #151)

### DIFF
--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -35,6 +35,59 @@ function bidLabel(bid) {
   return String(bid)
 }
 
+/**
+ * Computes the bid contribution hint for the second bidder.
+ * @param {number} teamTotal - The combined team target being considered
+ * @param {number} partnerBid - The first bidder's already-placed numeric bid
+ * @returns {{ yourBid: number, isWarning: boolean }}
+ */
+export function bidContributionHint(teamTotal, partnerBid) {
+  return {
+    yourBid: teamTotal - partnerBid,
+    isWarning: teamTotal < partnerBid,
+  }
+}
+
+/**
+ * Renders the post-bid team summary bar once both players on a team have bid.
+ * Nil and Blind Nil bids are excluded from the combined team total.
+ * Returns an empty string if bidding is not yet complete for either team.
+ * @param {{ bids: object }} state
+ * @returns {string}
+ */
+export function teamBidSummaryHtml(state) {
+  const teams = [
+    { label: 'N/S', seats: ['north', 'south'] },
+    { label: 'E/W', seats: ['east', 'west'] },
+  ]
+
+  const bars = []
+  for (const { label, seats } of teams) {
+    const [a, b] = seats
+    const bidA = state.bids[a]
+    const bidB = state.bids[b]
+    if (bidA === null || bidA === undefined || bidB === null || bidB === undefined) continue
+
+    const isSpecialA = bidA === 'nil' || bidA === 'blind_nil'
+    const isSpecialB = bidB === 'nil' || bidB === 'blind_nil'
+    const nameA = a.charAt(0).toUpperCase() + a.slice(1)
+    const nameB = b.charAt(0).toUpperCase() + b.slice(1)
+
+    let summary
+    if (!isSpecialA && !isSpecialB) {
+      const total = bidA + bidB
+      summary = `${esc(label)}: ${total} \u2014 ${esc(nameA)} ${bidA}, ${esc(nameB)} ${bidB}`
+    } else {
+      summary = `${esc(label)}: ${esc(nameA)} ${esc(bidLabel(bidA))}, ${esc(nameB)} ${esc(bidLabel(bidB))}`
+    }
+
+    bars.push(`<div class="bid-summary-team">${summary}</div>`)
+  }
+
+  if (bars.length === 0) return ''
+  return `<div class="bid-summary">${bars.join('')}</div>`
+}
+
 function seatInfoHtml(state, seat, label, isWinner = false) {
   const bid = state.bids[seat]
   const tricks = state.tricksWon[seat]

--- a/test/unit/web/bidHint.test.js
+++ b/test/unit/web/bidHint.test.js
@@ -1,0 +1,55 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { bidContributionHint } from '../../../client/web/src/screens/game.js'
+
+describe('bidContributionHint', () => {
+  it('computes yourBid as teamTotal minus partnerBid', () => {
+    const result = bidContributionHint(7, 4)
+    assert.equal(result.yourBid, 3)
+  })
+
+  it('isWarning is false when teamTotal equals partnerBid (zero contribution)', () => {
+    const result = bidContributionHint(4, 4)
+    assert.equal(result.yourBid, 0)
+    assert.equal(result.isWarning, false)
+  })
+
+  it('isWarning is false when teamTotal is above partnerBid', () => {
+    const result = bidContributionHint(7, 4)
+    assert.equal(result.isWarning, false)
+  })
+
+  it('isWarning is true when teamTotal is below partnerBid', () => {
+    const result = bidContributionHint(2, 4)
+    assert.equal(result.isWarning, true)
+  })
+
+  it('yourBid is negative when teamTotal is below partnerBid (warns, does not clamp)', () => {
+    const result = bidContributionHint(2, 4)
+    assert.equal(result.yourBid, -2)
+  })
+
+  it('works when partnerBid is 0', () => {
+    const result = bidContributionHint(5, 0)
+    assert.equal(result.yourBid, 5)
+    assert.equal(result.isWarning, false)
+  })
+
+  it('works when teamTotal is 0 and partnerBid is 0', () => {
+    const result = bidContributionHint(0, 0)
+    assert.equal(result.yourBid, 0)
+    assert.equal(result.isWarning, false)
+  })
+
+  it('returns both fields as an object', () => {
+    const result = bidContributionHint(6, 3)
+    assert.ok(Object.hasOwn(result, 'yourBid'), 'result must have yourBid')
+    assert.ok(Object.hasOwn(result, 'isWarning'), 'result must have isWarning')
+  })
+
+  it('handles large team total', () => {
+    const result = bidContributionHint(13, 6)
+    assert.equal(result.yourBid, 7)
+    assert.equal(result.isWarning, false)
+  })
+})

--- a/test/unit/web/bidSummary.test.js
+++ b/test/unit/web/bidSummary.test.js
@@ -1,0 +1,105 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { teamBidSummaryHtml } from '../../../client/web/src/screens/game.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeState(bids) {
+  return { bids }
+}
+
+// ---------------------------------------------------------------------------
+// teamBidSummaryHtml
+// ---------------------------------------------------------------------------
+
+describe('teamBidSummaryHtml', () => {
+  it('returns empty string when no team has finished bidding', () => {
+    const state = makeState({ north: null, south: null, east: null, west: null })
+    assert.equal(teamBidSummaryHtml(state), '')
+  })
+
+  it('returns empty string when only one player on a team has bid', () => {
+    const state = makeState({ north: 4, south: null, east: null, west: null })
+    assert.equal(teamBidSummaryHtml(state), '')
+  })
+
+  it('renders N/S summary once both N/S players have bid', () => {
+    const state = makeState({ north: 4, south: 3, east: null, west: null })
+    const html = teamBidSummaryHtml(state)
+    assert.ok(html.includes('N/S'), 'should include team label N/S')
+    assert.ok(html.includes('7'), 'should show combined total 7')
+    assert.ok(html.includes('North'), 'should show North seat name')
+    assert.ok(html.includes('South'), 'should show South seat name')
+  })
+
+  it('renders E/W summary once both E/W players have bid', () => {
+    const state = makeState({ north: null, south: null, east: 5, west: 3 })
+    const html = teamBidSummaryHtml(state)
+    assert.ok(html.includes('E/W'), 'should include team label E/W')
+    assert.ok(html.includes('8'), 'should show combined total 8')
+    assert.ok(html.includes('East'), 'should show East seat name')
+    assert.ok(html.includes('West'), 'should show West seat name')
+  })
+
+  it('renders both team summaries when all four players have bid', () => {
+    const state = makeState({ north: 4, south: 3, east: 5, west: 2 })
+    const html = teamBidSummaryHtml(state)
+    assert.ok(html.includes('N/S'), 'should include N/S')
+    assert.ok(html.includes('E/W'), 'should include E/W')
+    assert.ok(html.includes('7'), 'N/S total should be 7')
+    assert.ok(html.includes('bid-summary-team'), 'should use bid-summary-team class')
+  })
+
+  it('wraps output in a bid-summary container', () => {
+    const state = makeState({ north: 4, south: 3, east: null, west: null })
+    const html = teamBidSummaryHtml(state)
+    assert.ok(html.includes('bid-summary'), 'should include bid-summary class')
+  })
+
+  it('shows Nil bid individually and excludes it from team total', () => {
+    const state = makeState({ north: 'nil', south: 4, east: null, west: null })
+    const html = teamBidSummaryHtml(state)
+    assert.ok(html.includes('N/S'), 'should include team label')
+    assert.ok(html.includes('Nil'), 'should show Nil label')
+    // Should not show a combined numeric total like "4" as a standalone total
+    // The summary should just show individual bids
+    assert.ok(!html.match(/N\/S: \d+ —/), 'should not show a combined numeric total when one bid is Nil')
+  })
+
+  it('shows Blind Nil bid individually and excludes it from team total', () => {
+    const state = makeState({ north: 'blind_nil', south: 4, east: null, west: null })
+    const html = teamBidSummaryHtml(state)
+    assert.ok(html.includes('Blind Nil'), 'should show Blind Nil label')
+    assert.ok(!html.match(/N\/S: \d+ —/), 'should not show a combined numeric total when one bid is Blind Nil')
+  })
+
+  it('shows both Nil bids individually with no combined total', () => {
+    const state = makeState({ north: 'nil', south: 'nil', east: null, west: null })
+    const html = teamBidSummaryHtml(state)
+    assert.ok(html.includes('N/S'), 'should include team label')
+    assert.ok(!html.match(/N\/S: \d+ —/), 'should not show a combined total for two Nil bids')
+  })
+
+  it('handles a zero bid in the team total', () => {
+    const state = makeState({ north: 0, south: 4, east: null, west: null })
+    const html = teamBidSummaryHtml(state)
+    assert.ok(html.includes('4'), 'should show combined total of 4')
+    assert.ok(html.includes('North 0'), 'should show North 0')
+  })
+
+  it('handles maximum possible team total (13 tricks split across two players)', () => {
+    const state = makeState({ north: 7, south: 6, east: null, west: null })
+    const html = teamBidSummaryHtml(state)
+    assert.ok(html.includes('13'), 'should show combined total 13')
+  })
+
+  it('E/W summary with one Nil bid excludes Nil from team total', () => {
+    const state = makeState({ north: null, south: null, east: 'nil', west: 5 })
+    const html = teamBidSummaryHtml(state)
+    assert.ok(html.includes('E/W'), 'should include E/W label')
+    assert.ok(html.includes('Nil'), 'should show Nil')
+    assert.ok(!html.match(/E\/W: \d+ —/), 'should not show a combined numeric total')
+  })
+})


### PR DESCRIPTION
Adds unit tests for the two pure helpers introduced for the partnership bidding UI clarity feature (issue #151).

**Changes:**
- `bidContributionHint` and `teamBidSummaryHtml` exported as named exports from `game.js`
- `test/unit/web/bidHint.test.js` — 9 tests for hint arithmetic and warning logic
- `test/unit/web/bidSummary.test.js` — 11 tests for team summary rendering (including Nil/Blind Nil exclusion)

Relates to #151

Generated with [Claude Code](https://claude.ai/code)