### PR TITLE
feat: Bidding UI — partnership clarity (issue #151)

### DIFF
--- a/client/web/index.html
+++ b/client/web/index.html
@@ -951,6 +951,42 @@
         color: #ccc;
         border-color: #666;
       }
+
+      /* Bid panel — partnership clarity */
+      .bid-partner-info {
+        font-size: 0.8rem;
+        color: #90caf9;
+        margin-bottom: 0.5rem;
+      }
+
+      .bid-hint {
+        min-height: 1.25rem;
+        font-size: 0.78rem;
+        color: #b0b0b0;
+        margin-top: 0.25rem;
+        margin-bottom: 0.25rem;
+      }
+
+      .bid-hint--warning {
+        color: #ffa726;
+      }
+
+      /* Post-bid team summary */
+      .bid-summary {
+        background: #111;
+        border-bottom: 1px solid #333;
+        padding: 0.3rem 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.15rem;
+        flex-shrink: 0;
+      }
+
+      .bid-summary-team {
+        font-size: 0.78rem;
+        color: #b0b0b0;
+        text-align: center;
+      }
     </style>
   </head>
   <body>

--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -316,9 +316,28 @@ export function renderGameScreen(container) {
     const oppTeam = myTeam === 'ns' ? 'ew' : 'ns'
     const blindNilEligible = (state.scores[oppTeam] - state.scores[myTeam]) >= 100
 
+    const partnerSeat = PARTNER[seat]
+    const partnerBid = state.bids[partnerSeat]
+    const partnerHasBid = partnerBid !== null && partnerBid !== undefined
+    const partnerHasNumericBid = partnerHasBid && typeof partnerBid === 'number'
+
+    let bidPanelTitle = 'Choose your bid:'
+    let bidPartnerInfoHtml = ''
+    let bidHintHtml = ''
+    if (partnerHasBid) {
+      if (partnerHasNumericBid) {
+        bidPanelTitle = 'Team Total'
+        bidPartnerInfoHtml = `<p class="bid-partner-info">Partner bid ${partnerBid} \u2014 enter team total:</p>`
+        bidHintHtml = '<div class="bid-hint" id="bid-hint" aria-live="polite"></div>'
+      } else {
+        bidPartnerInfoHtml = `<p class="bid-partner-info">Partner: ${esc(bidLabel(partnerBid))}</p>`
+      }
+    }
+
     const bidPanelHtml = isMyBidTurn ? `
       <div class="bid-panel">
-        <p class="bid-title">Choose your bid:</p>
+        <p class="bid-title">${esc(bidPanelTitle)}</p>
+        ${bidPartnerInfoHtml}
         <div class="bid-grid">
           ${Array.from({ length: 14 }, (_, i) => `<button class="bid-num-btn" data-bid="${i}">${i}</button>`).join('')}
         </div>
@@ -326,6 +345,7 @@ export function renderGameScreen(container) {
           <button class="bid-special-btn" data-bid="nil">Nil</button>
           ${blindNilEligible ? '<button class="bid-special-btn bid-blind-nil-btn" data-bid="blind_nil">Blind Nil</button>' : ''}
         </div>
+        ${bidHintHtml}
         <div class="form-error bid-err" role="alert" aria-live="polite"></div>
       </div>` : ''
 
@@ -354,6 +374,7 @@ export function renderGameScreen(container) {
             <span class="score-bags">${state.bags.ew} bag${state.bags.ew !== 1 ? 's' : ''}</span>
           </div>
         </div>
+        ${teamBidSummaryHtml(state)}
 
         <div class="game-table">
           <div class="table-top">
@@ -446,6 +467,34 @@ export function renderGameScreen(container) {
           }
         })
       })
+    }
+
+    // Bid hint for second bidder with numeric partner bid
+    if (isMyBidTurn && partnerHasNumericBid) {
+      const hintEl = container.querySelector('#bid-hint')
+      if (hintEl) {
+        container.querySelectorAll('.bid-num-btn').forEach((btn) => {
+          const showHint = () => {
+            const teamTotal = Number(btn.dataset.bid)
+            const { yourBid, isWarning } = bidContributionHint(teamTotal, partnerBid)
+            if (isWarning) {
+              hintEl.className = 'bid-hint bid-hint--warning'
+              hintEl.textContent = `\u26a0 Team target (${teamTotal}) is below partner\u2019s bid (${partnerBid}) \u2014 every trick above ${teamTotal} is a bag`
+            } else {
+              hintEl.className = 'bid-hint'
+              hintEl.textContent = `You are bidding ${yourBid} (team total ${teamTotal} \u2212 partner\u2019s bid ${partnerBid})`
+            }
+          }
+          const clearHint = () => {
+            hintEl.textContent = ''
+            hintEl.className = 'bid-hint'
+          }
+          btn.addEventListener('mouseenter', showHint)
+          btn.addEventListener('focus', showHint)
+          btn.addEventListener('mouseleave', clearHint)
+          btn.addEventListener('blur', clearHint)
+        })
+      }
     }
 
     // Hand card interactions (play or exchange)


### PR DESCRIPTION
Implements PRD Section 5.3 bidding UI requirements on top of the exported helpers already merged in PR #154.

**Changes:**
- Second bidder sees "Team Total" label (when partner has numeric bid)
- Partner's placed bid shown adjacent to input for all second bidders
- Live contribution hint on mouseenter/focus of numeric bid buttons; warning variant (orange) when team total < partner's bid
- Post-bid team summary bar below scoreboard (Nil/Blind Nil excluded from combined total)
- CSS for .bid-partner-info, .bid-hint, .bid-hint--warning, .bid-summary, .bid-summary-team in index.html

Closes #151

Generated with [Claude Code](https://claude.ai/code)