### PR TITLE
test: blind nil hand hiding — server enforcement + unit/integration tests

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -35,7 +35,7 @@
 - [x] `P0` Implement partnership bidding: first bidder bids individually, second bidder sets team total (first bidder's number is advisory only)
 - [x] `P0` Implement Nil bid (+50 / -50)
 - [x] `P0` Implement Blind Nil bid (+100 / -100): eligibility check (≥100 pts behind), one-per-team limit, card exchange after all bids but before opening lead
-- [ ] `P0` Blind Nil hand hiding — server-side enforcement: when a team is eligible for Blind Nil at deal time, omit `myHand` from `HAND_DEALT` for those players and set `blindNilEligible: true`; add `POST /api/tables/:tableId/reveal-hand` that validates bidding phase, player eligibility, and no bid yet placed — then emits `HAND_REVEALED` with `myHand` to that player only; bidding Blind Nil also triggers the hand reveal to the server's game state as normal
+- [x] `P0` Blind Nil hand hiding — server-side enforcement: when a team is eligible for Blind Nil at deal time, omit `myHand` from `HAND_DEALT` for those players and set `blindNilEligible: true`; add `POST /api/tables/:tableId/reveal-hand` that validates bidding phase, player eligibility, and no bid yet placed — then emits `HAND_REVEALED` with `myHand` to that player only; bidding Blind Nil also triggers the hand reveal to the server's game state as normal
 - [x] `P0` Implement team bid of 0: legal, not treated as Nil; every trick taken is a bag
 - [x] `P0` Enforce no Spade lead on first trick rule
 - [x] `P0` Implement Spades-breaking logic
@@ -64,8 +64,8 @@
 ### Testing
 
 - [x] `P0` End-to-end test: 4 players complete a full game from table creation to game over
-- [ ] `P0` Unit tests: blind nil eligible player does not receive `myHand` in `HAND_DEALT`; `HAND_REVEALED` is emitted only after `reveal-hand` is called; `reveal-hand` is rejected if the player has already placed a bid or is not eligible; ineligible team receives their full hand immediately
-- [ ] `P0` Integration test: blind nil eligible player's hand is withheld until reveal; both reveal-then-bid and bid-blind-nil-directly flows complete successfully
+- [x] `P0` Unit tests: blind nil eligible player does not receive `myHand` in `HAND_DEALT`; `HAND_REVEALED` is emitted only after `reveal-hand` is called; `reveal-hand` is rejected if the player has already placed a bid or is not eligible; ineligible team receives their full hand immediately
+- [x] `P0` Integration test: blind nil eligible player's hand is withheld until reveal; both reveal-then-bid and bid-blind-nil-directly flows complete successfully
 
 ---
 

--- a/server/game/state.js
+++ b/server/game/state.js
@@ -43,6 +43,7 @@ function dealHand(dealerSeat) {
     biddingOrder,
     currentBidderSeat: biddingOrder[0],
     blindNilExchange: null,
+    handRevealedSeats: [],
     currentTrick: [],
     completedTricks: [],
     tricksWon: { north: 0, east: 0, south: 0, west: 0 },
@@ -433,8 +434,36 @@ function scoreCompletedHand(state) {
 }
 
 /**
+ * Reveal the hand for a Blind Nil eligible player before they have bid.
+ * After calling this, getPlayerView will include myHand for this player.
+ *
+ * @param {object} state
+ * @param {string} seat
+ * @returns {object} New state
+ * @throws {Error} If ineligible, already bid, or wrong phase
+ */
+export function revealHand(state, seat) {
+  if (state.phase !== 'bidding') {
+    throw Object.assign(new Error('Game is not in bidding phase'), { code: 'INVALID_ACTION' })
+  }
+  if (!isEligibleForBlindNil(state.scores, seat)) {
+    throw Object.assign(new Error('Not eligible for Blind Nil'), { code: 'NOT_ELIGIBLE' })
+  }
+  if (state.bids[seat] !== null) {
+    throw Object.assign(new Error('Cannot reveal hand after placing a bid'), { code: 'BID_ALREADY_PLACED' })
+  }
+  return {
+    ...state,
+    handRevealedSeats: [...(state.handRevealedSeats || []), seat],
+  }
+}
+
+/**
  * Return a player-specific view of the game state that does not expose other
  * players' hands. This is what gets sent to the client.
+ *
+ * For Blind Nil eligible players who have not yet revealed their hand,
+ * myHand is omitted and blindNilEligible is set to true.
  *
  * @param {object} state - Full server game state
  * @param {string} seat - The requesting player's seat
@@ -442,6 +471,18 @@ function scoreCompletedHand(state) {
  */
 export function getPlayerView(state, seat) {
   const { hands, ...rest } = state
+  const isEligible = isEligibleForBlindNil(state.scores, seat)
+  const hasRevealed = (state.handRevealedSeats || []).includes(seat)
+
+  // Withhold hand from eligible players who have not yet revealed during bidding
+  if (state.phase === 'bidding' && isEligible && !hasRevealed) {
+    return {
+      ...rest,
+      blindNilEligible: true,
+      // myHand intentionally omitted until player calls reveal-hand or bids Blind Nil
+    }
+  }
+
   return {
     ...rest,
     myHand: hands[seat],

--- a/server/server.js
+++ b/server/server.js
@@ -19,7 +19,7 @@ import {
   addBotToTable,
   removePlayerFromTables,
 } from './lobby/table.js'
-import { createGame, placeBid, playCard, submitBlindNilExchange, getPlayerView } from './game/state.js'
+import { createGame, placeBid, playCard, submitBlindNilExchange, revealHand, getPlayerView } from './game/state.js'
 import { getPartnerSeat } from './game/bid.js'
 import { getSeatForPlayer, validateCardPlay, validateBidTurn } from './anticheat/validate.js'
 import { isBot, botBid, botPlay, botBlindNilExchange } from './game/bot.js'
@@ -411,6 +411,34 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
       if (err.code === 'INVALID_EXCHANGE') return sendJSON(res, 400, { error: err.message })
       if (err.code === 'CARD_NOT_IN_HAND') return sendJSON(res, 400, { error: err.message })
       console.error('Blind nil exchange error:', { tableId, error: err.message })
+      sendJSON(res, 500, { error: 'Internal server error' })
+    }
+  })
+
+  // POST /api/tables/:tableId/reveal-hand — reveal hand for a Blind Nil eligible player
+  app.post('/api/tables/:tableId/reveal-hand', async (req, res) => {
+    const { tableId } = req.params
+    try {
+      const redisClient = await getRedis()
+      const session = await validateAuthHeaders(redisClient, req)
+      const table = await getTable(redisClient, tableId)
+      if (!table) return sendJSON(res, 404, { error: 'Table not found' })
+
+      const seat = getSeatForPlayer(table.seats, session.playerId)
+      if (!seat) return sendJSON(res, 403, { error: 'You are not seated at this table' })
+
+      const gameState = await getGameState(redisClient, tableId)
+      if (!gameState) return sendJSON(res, 409, { error: 'Game has not started' })
+
+      const newState = revealHand(gameState, seat)
+      await saveGameState(redisClient, tableId, newState)
+      sendJSON(res, 200, getPlayerView(newState, seat))
+    } catch (err) {
+      if (err.code === 'UNAUTHORIZED') return sendJSON(res, 401, { error: err.message })
+      if (err.code === 'INVALID_ACTION') return sendJSON(res, 409, { error: err.message })
+      if (err.code === 'NOT_ELIGIBLE') return sendJSON(res, 400, { error: err.message })
+      if (err.code === 'BID_ALREADY_PLACED') return sendJSON(res, 409, { error: err.message })
+      console.error('Reveal hand error:', { tableId, error: err.message })
       sendJSON(res, 500, { error: 'Internal server error' })
     }
   })

--- a/test/integration/game/blindNilHiding.test.js
+++ b/test/integration/game/blindNilHiding.test.js
@@ -1,0 +1,381 @@
+/**
+ * Integration tests: Blind Nil hand hiding flows.
+ *
+ * Requires a real Redis + DB instance (DATABASE_URL and REDIS_URL).
+ * Tests are skipped when those env vars are absent.
+ *
+ * Setup: create a 4-player table, then inject game state with scores that
+ * make the NS team eligible for Blind Nil (NS is 100+ points behind).
+ */
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import express from 'express'
+import bcrypt from 'bcryptjs'
+import { handler } from '../../../server/server.js'
+import { getDb, closeDb } from '../../../server/db.js'
+import { getRedis, closeRedis } from '../../../server/redis.js'
+import { getGameState, saveGameState } from '../../../server/lobby/table.js'
+
+const skip =
+  !process.env.DATABASE_URL || !process.env.REDIS_URL
+    ? 'DATABASE_URL and REDIS_URL must both be set'
+    : false
+
+// ── Test server ───────────────────────────────────────────────────────────────
+
+async function startTestServer() {
+  const app = express()
+  app.use(express.json())
+  handler(app)
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address()
+      resolve({
+        baseUrl: `http://127.0.0.1:${port}`,
+        close: () => new Promise((res) => server.close(res)),
+      })
+    })
+  })
+}
+
+// ── DB helpers ────────────────────────────────────────────────────────────────
+
+async function ensurePlayersTable(db) {
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS players (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      email VARCHAR(255) UNIQUE NOT NULL,
+      username VARCHAR(50) UNIQUE NOT NULL,
+      password_hash VARCHAR(255) NOT NULL,
+      is_verified BOOLEAN NOT NULL DEFAULT FALSE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `)
+  await db.query(`DELETE FROM players WHERE email LIKE '%@bnh-itest.spades.invalid'`)
+}
+
+async function insertVerifiedPlayer(db, { email, username, password }) {
+  const hash = await bcrypt.hash(password, 4)
+  const result = await db.query(
+    `INSERT INTO players (email, username, password_hash, is_verified)
+     VALUES ($1, $2, $3, TRUE) RETURNING id`,
+    [email, username, hash],
+  )
+  return result.rows[0].id
+}
+
+// ── HTTP helpers ──────────────────────────────────────────────────────────────
+
+async function loginViaHttp(baseUrl, email, password) {
+  const res = await fetch(`${baseUrl}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  })
+  return res.json()
+}
+
+// ── Game setup helper ─────────────────────────────────────────────────────────
+
+/**
+ * Create a table, seat all 4 players (north→south→east→west), and inject game
+ * state so NS is eligible for Blind Nil (EW score = 100, NS score = 0).
+ *
+ * Returns { tableId, seatMap } where seatMap is seat → player credentials.
+ */
+async function setupEligibleGame(baseUrl, players) {
+  const seats = ['north', 'east', 'south', 'west']
+  const seatMap = {}
+  for (let i = 0; i < 4; i++) {
+    seatMap[seats[i]] = players[i]
+  }
+
+  const authHdrs = (player) => ({
+    'Content-Type': 'application/json',
+    'x-session-id': player.sessionId,
+    'x-player-id': player.playerId,
+  })
+
+  // Create table
+  const createRes = await fetch(`${baseUrl}/api/tables`, {
+    method: 'POST',
+    headers: authHdrs(players[0]),
+  })
+  assert.equal(createRes.status, 201)
+  const { tableId } = await createRes.json()
+
+  // Seat all players
+  for (let i = 0; i < 4; i++) {
+    const sitRes = await fetch(`${baseUrl}/api/tables/${tableId}/sit`, {
+      method: 'POST',
+      headers: authHdrs(players[i]),
+      body: JSON.stringify({ seat: seats[i] }),
+    })
+    assert.equal(sitRes.status, 200, `player ${i + 1} (${seats[i]}) failed to sit`)
+  }
+
+  // Override game state so NS is eligible: EW = 100, NS = 0
+  const redis = await getRedis()
+  const gameState = await getGameState(redis, tableId)
+  assert.ok(gameState, 'game state should exist after all 4 players sit')
+  await saveGameState(redis, tableId, { ...gameState, scores: { ns: 0, ew: 100 } })
+
+  return { tableId, seatMap }
+}
+
+// ── Test suite ────────────────────────────────────────────────────────────────
+
+describe('Blind Nil hand hiding — integration', { skip }, () => {
+  let server, db
+  const players = []
+
+  before(async () => {
+    db = getDb()
+    await getRedis()
+    await ensurePlayersTable(db)
+
+    for (let i = 1; i <= 4; i++) {
+      await insertVerifiedPlayer(db, {
+        email: `bnh${i}@bnh-itest.spades.invalid`,
+        username: `bnh_player${i}`,
+        password: 'Password123!',
+      })
+    }
+
+    server = await startTestServer()
+
+    for (let i = 1; i <= 4; i++) {
+      const data = await loginViaHttp(
+        server.baseUrl,
+        `bnh${i}@bnh-itest.spades.invalid`,
+        'Password123!',
+      )
+      players.push(data)
+    }
+  })
+
+  after(async () => {
+    await server.close()
+    await closeDb()
+    await closeRedis()
+  })
+
+  it('eligible player hand is withheld on initial state fetch', async () => {
+    const { tableId, seatMap } = await setupEligibleGame(server.baseUrl, players)
+
+    const northRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
+      headers: {
+        'x-session-id': seatMap.north.sessionId,
+        'x-player-id': seatMap.north.playerId,
+      },
+    })
+    assert.equal(northRes.status, 200)
+    const northState = await northRes.json()
+
+    assert.equal(northState.blindNilEligible, true, 'north should have blindNilEligible: true')
+    assert.equal(northState.myHand, undefined, 'north myHand should be withheld')
+  })
+
+  it('ineligible team (EW) receives full hand immediately', async () => {
+    const { tableId, seatMap } = await setupEligibleGame(server.baseUrl, players)
+
+    const eastRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
+      headers: {
+        'x-session-id': seatMap.east.sessionId,
+        'x-player-id': seatMap.east.playerId,
+      },
+    })
+    assert.equal(eastRes.status, 200)
+    const eastState = await eastRes.json()
+
+    assert.ok(Array.isArray(eastState.myHand), 'east should receive myHand')
+    assert.equal(eastState.myHand.length, 13)
+  })
+
+  it('reveal-then-bid: eligible player reveals hand then bids normally', async () => {
+    const { tableId, seatMap } = await setupEligibleGame(server.baseUrl, players)
+
+    const northHdrs = {
+      'Content-Type': 'application/json',
+      'x-session-id': seatMap.north.sessionId,
+      'x-player-id': seatMap.north.playerId,
+    }
+
+    // Before reveal: hand is hidden
+    const beforeRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
+      headers: northHdrs,
+    })
+    const beforeState = await beforeRes.json()
+    assert.equal(beforeState.myHand, undefined, 'hand must be hidden before reveal')
+
+    // Call reveal-hand
+    const revealRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/reveal-hand`, {
+      method: 'POST',
+      headers: northHdrs,
+    })
+    assert.equal(revealRes.status, 200, 'reveal-hand should succeed')
+    const revealState = await revealRes.json()
+
+    // HAND_REVEALED: myHand is now present
+    assert.ok(Array.isArray(revealState.myHand), 'myHand should be present after reveal')
+    assert.equal(revealState.myHand.length, 13)
+
+    // Now north can bid normally — north is the last bidder (bidding order: east, south, west, north)
+    // Need to drive the other three bids first
+    const seats = ['east', 'south', 'west']
+    let lastState = revealState
+    for (const seat of seats) {
+      const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/bid`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-session-id': seatMap[seat].sessionId,
+          'x-player-id': seatMap[seat].playerId,
+        },
+        body: JSON.stringify({ bid: 3 }),
+      })
+      assert.equal(res.status, 200, `${seat} bid should succeed`)
+      lastState = await res.json()
+    }
+
+    // North bids a normal number (not blind nil)
+    const northBidRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/bid`, {
+      method: 'POST',
+      headers: northHdrs,
+      body: JSON.stringify({ bid: 4 }),
+    })
+    assert.equal(northBidRes.status, 200, 'north normal bid should succeed after reveal')
+    const afterBid = await northBidRes.json()
+    assert.ok(
+      afterBid.phase === 'playing' || afterBid.phase === 'blind_nil_exchange',
+      `expected playing or blind_nil_exchange phase, got ${afterBid.phase}`,
+    )
+  })
+
+  it('bid-blind-nil-directly: eligible player bids Blind Nil without revealing', async () => {
+    const { tableId, seatMap } = await setupEligibleGame(server.baseUrl, players)
+
+    // Bidding order with north dealer: east, south, west, north
+    // south is on NS (eligible). Bid east first, then south can bid blind_nil
+    const eastBidRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/bid`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': seatMap.east.sessionId,
+        'x-player-id': seatMap.east.playerId,
+      },
+      body: JSON.stringify({ bid: 4 }),
+    })
+    assert.equal(eastBidRes.status, 200, 'east bid should succeed')
+
+    // South bids blind_nil directly (no reveal-hand call)
+    const southBidRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/bid`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': seatMap.south.sessionId,
+        'x-player-id': seatMap.south.playerId,
+      },
+      body: JSON.stringify({ bid: 'blind_nil' }),
+    })
+    assert.equal(southBidRes.status, 200, 'south blind nil bid should succeed')
+    const southState = await southBidRes.json()
+    // After bidding, south's view should NOT include myHand (they bid without seeing it)
+    assert.equal(southState.myHand, undefined, 'south myHand should not be sent after blind nil bid')
+
+    // Complete bidding: west and north still need to bid
+    const westBidRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/bid`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': seatMap.west.sessionId,
+        'x-player-id': seatMap.west.playerId,
+      },
+      body: JSON.stringify({ bid: 3 }),
+    })
+    assert.equal(westBidRes.status, 200, 'west bid should succeed')
+
+    const northBidRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/bid`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': seatMap.north.sessionId,
+        'x-player-id': seatMap.north.playerId,
+      },
+      body: JSON.stringify({ bid: 4 }),
+    })
+    assert.equal(northBidRes.status, 200, 'north bid should succeed')
+    const finalState = await northBidRes.json()
+    assert.equal(
+      finalState.phase,
+      'blind_nil_exchange',
+      'game should enter blind_nil_exchange phase after blind nil bid',
+    )
+  })
+
+  it('reveal-hand is rejected if player has already placed a bid', async () => {
+    const { tableId, seatMap } = await setupEligibleGame(server.baseUrl, players)
+
+    // Inject a state where north has already bid (non-null) but phase is still 'bidding'
+    // (simulates a scenario where north placed a bid before trying to reveal)
+    const redis = await getRedis()
+    const gameState = await getGameState(redis, tableId)
+    const stateWithNorthBid = {
+      ...gameState,
+      bids: { ...gameState.bids, north: 4 },
+      // Keep phase as 'bidding' — other players haven't bid yet
+    }
+    await saveGameState(redis, tableId, stateWithNorthBid)
+
+    const revealRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/reveal-hand`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': seatMap.north.sessionId,
+        'x-player-id': seatMap.north.playerId,
+      },
+    })
+    assert.equal(revealRes.status, 409, 'reveal-hand should be rejected after bid placed')
+    const body = await revealRes.json()
+    assert.ok(body.error, 'error message should be present')
+  })
+
+  it('reveal-hand is rejected if player is not eligible', async () => {
+    // Create a fresh game with default scores (nobody eligible)
+    const seats = ['north', 'east', 'south', 'west']
+    const seatMap = {}
+    for (let i = 0; i < 4; i++) {
+      seatMap[seats[i]] = players[i]
+    }
+    const authHdrs = (player) => ({
+      'Content-Type': 'application/json',
+      'x-session-id': player.sessionId,
+      'x-player-id': player.playerId,
+    })
+
+    const createRes = await fetch(`${server.baseUrl}/api/tables`, {
+      method: 'POST',
+      headers: authHdrs(players[0]),
+    })
+    assert.equal(createRes.status, 201)
+    const { tableId } = await createRes.json()
+
+    for (let i = 0; i < 4; i++) {
+      const sitRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/sit`, {
+        method: 'POST',
+        headers: authHdrs(players[i]),
+        body: JSON.stringify({ seat: seats[i] }),
+      })
+      assert.equal(sitRes.status, 200)
+    }
+
+    // Scores are 0/0 — no one is eligible
+    const revealRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/reveal-hand`, {
+      method: 'POST',
+      headers: authHdrs(seatMap.north),
+    })
+    assert.equal(revealRes.status, 400, 'reveal-hand should be rejected when player is not eligible')
+    const body = await revealRes.json()
+    assert.ok(body.error, 'error message should be present')
+  })
+})

--- a/test/unit/game/blindNilHiding.test.js
+++ b/test/unit/game/blindNilHiding.test.js
@@ -1,0 +1,160 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createGame, getPlayerView, revealHand, placeBid } from '../../../server/game/state.js'
+
+const PLAYER_IDS = {
+  north: 'player-north',
+  east: 'player-east',
+  south: 'player-south',
+  west: 'player-west',
+}
+
+/**
+ * Build a game state where NS team is eligible for Blind Nil (100+ behind).
+ * NS has 0, EW has 100 → NS is exactly 100 behind.
+ */
+function makeNsEligibleState() {
+  const state = createGame('table-bnh-test', PLAYER_IDS)
+  return { ...state, scores: { ns: 0, ew: 100 } }
+}
+
+/**
+ * Build a game state where neither team is eligible (scores even).
+ */
+function makeNoEligibleState() {
+  return createGame('table-bnh-test', PLAYER_IDS)
+  // scores start at {ns: 0, ew: 0} — neither team is 100+ behind
+}
+
+// ── getPlayerView: hand hiding ──────────────────────────────────────────────
+
+describe('getPlayerView — Blind Nil hand hiding', () => {
+  it('eligible player does not receive myHand before revealing', () => {
+    const state = makeNsEligibleState()
+    const view = getPlayerView(state, 'north')
+    assert.equal(view.myHand, undefined, 'myHand should be omitted for eligible player')
+  })
+
+  it('eligible player has blindNilEligible: true before revealing', () => {
+    const state = makeNsEligibleState()
+    const view = getPlayerView(state, 'north')
+    assert.equal(view.blindNilEligible, true)
+  })
+
+  it('both NS players are eligible when NS is 100+ behind', () => {
+    const state = makeNsEligibleState()
+    const northView = getPlayerView(state, 'north')
+    const southView = getPlayerView(state, 'south')
+    assert.equal(northView.myHand, undefined, 'north hand should be hidden')
+    assert.equal(northView.blindNilEligible, true)
+    assert.equal(southView.myHand, undefined, 'south hand should be hidden')
+    assert.equal(southView.blindNilEligible, true)
+  })
+
+  it('ineligible team (EW) receives full hand immediately', () => {
+    const state = makeNsEligibleState()
+    const eastView = getPlayerView(state, 'east')
+    const westView = getPlayerView(state, 'west')
+    assert.ok(Array.isArray(eastView.myHand), 'east should receive myHand')
+    assert.equal(eastView.myHand.length, 13)
+    assert.ok(Array.isArray(westView.myHand), 'west should receive myHand')
+    assert.equal(westView.myHand.length, 13)
+  })
+
+  it('eligible player receives myHand after reveal-hand', () => {
+    const state = makeNsEligibleState()
+    const revealed = revealHand(state, 'north')
+    const view = getPlayerView(revealed, 'north')
+    assert.ok(Array.isArray(view.myHand), 'myHand should be present after reveal')
+    assert.equal(view.myHand.length, 13)
+  })
+
+  it('HAND_REVEALED is not sent before reveal-hand — south still hidden after north reveals', () => {
+    const state = makeNsEligibleState()
+    const revealedNorth = revealHand(state, 'north')
+    const southView = getPlayerView(revealedNorth, 'south')
+    assert.equal(southView.myHand, undefined, 'south hand should still be hidden')
+  })
+
+  it('when no team is eligible all players receive their hand immediately', () => {
+    const state = makeNoEligibleState()
+    for (const seat of ['north', 'east', 'south', 'west']) {
+      const view = getPlayerView(state, seat)
+      assert.ok(Array.isArray(view.myHand), `${seat} should receive myHand`)
+      assert.equal(view.myHand.length, 13)
+    }
+  })
+})
+
+// ── revealHand: validation ──────────────────────────────────────────────────
+
+describe('revealHand — validation', () => {
+  it('rejects if player is not eligible for Blind Nil', () => {
+    const state = makeNsEligibleState() // EW is not eligible
+    assert.throws(
+      () => revealHand(state, 'east'),
+      (err) => {
+        assert.equal(err.code, 'NOT_ELIGIBLE')
+        return true
+      },
+    )
+  })
+
+  it('rejects if player has already placed a bid', () => {
+    const state = makeNsEligibleState()
+    // Directly set a bid for north (last in bidding order for north dealer)
+    const stateWithBid = { ...state, bids: { ...state.bids, north: 4 } }
+    assert.throws(
+      () => revealHand(stateWithBid, 'north'),
+      (err) => {
+        assert.equal(err.code, 'BID_ALREADY_PLACED')
+        return true
+      },
+    )
+  })
+
+  it('rejects if game is not in bidding phase', () => {
+    const state = makeNsEligibleState()
+    const playingState = { ...state, phase: 'playing' }
+    assert.throws(
+      () => revealHand(playingState, 'north'),
+      (err) => {
+        assert.equal(err.code, 'INVALID_ACTION')
+        return true
+      },
+    )
+  })
+
+  it('succeeds and returns state with seat in handRevealedSeats', () => {
+    const state = makeNsEligibleState()
+    const newState = revealHand(state, 'north')
+    assert.ok(newState.handRevealedSeats.includes('north'))
+  })
+
+  it('does not mutate original state', () => {
+    const state = makeNsEligibleState()
+    revealHand(state, 'north')
+    assert.deepEqual(state.handRevealedSeats, [])
+  })
+})
+
+// ── Bid Blind Nil directly — hand never revealed ────────────────────────────
+
+describe('Blind Nil bid without reveal — hand remains hidden during bidding', () => {
+  it('eligible player who bids Blind Nil directly never reveals their hand during bidding', () => {
+    // North dealer → bidding order: east, south, west, north
+    // NS is eligible; east bids first (EW), south bids second (NS)
+    // Have east bid, then south bid blind_nil directly (without calling reveal-hand)
+    const state = makeNsEligibleState()
+
+    // east bids first
+    const afterEast = placeBid(state, 'east', 4)
+    // south bids blind_nil directly (NS is eligible)
+    const afterSouth = placeBid(afterEast, 'south', 'blind_nil')
+
+    // south's view should still not include myHand during bidding phase
+    // (they chose not to reveal; their hand is withheld)
+    const southView = getPlayerView(afterSouth, 'south')
+    assert.equal(southView.myHand, undefined, 'south chose blind nil — hand must not be sent during bidding')
+  })
+})


### PR DESCRIPTION
Closes #146

## Summary

Implements server-side Blind Nil hand hiding (Slice 1 P0, #144 depency) and adds full unit + integration test coverage.

### Server-side enforcement

- `server/game/state.js`: add `handRevealedSeats` field; add `revealHand(state, seat)`; update `getPlayerView` to omit `myHand` for eligible players who haven't revealed
- `server/server.js`: add `POST /api/tables/:tableId/reveal-hand`

### Tests

- `test/unit/game/blindNilHiding.test.js`: unit tests for getPlayerView hiding, revealHand validation
- `test/integration/game/blindNilHiding.test.js`: reveal-then-bid and bid-blind-nil-directly flows

Generated with [Claude Code](https://claude.ai/code)