### PR TITLE
feat(game): Blind Nil hand hiding — server-side enforcement (#144)

### DIFF
--- a/server/game/state.js
+++ b/server/game/state.js
@@ -485,6 +485,7 @@ export function getPlayerView(state, seat) {
 
   return {
     ...rest,
+    blindNilEligible: false,
     myHand: hands[seat],
     // Include played cards from the current trick (visible to all)
     // Do NOT include other players' unplayed hands

--- a/test/unit/game/blindNilHiding.test.js
+++ b/test/unit/game/blindNilHiding.test.js
@@ -61,6 +61,12 @@ describe('getPlayerView — Blind Nil hand hiding', () => {
     assert.equal(westView.myHand.length, 13)
   })
 
+  it('ineligible player has blindNilEligible: false', () => {
+    const state = makeNsEligibleState()
+    const eastView = getPlayerView(state, 'east')
+    assert.equal(eastView.blindNilEligible, false, 'blindNilEligible must be false for ineligible player')
+  })
+
   it('eligible player receives myHand after reveal-hand', () => {
     const state = makeNsEligibleState()
     const revealed = revealHand(state, 'north')


### PR DESCRIPTION
Closes #144

## Summary

The server-side Blind Nil hand hiding feature was already fully implemented:

- `getPlayerView()` omits `myHand` and sets `blindNilEligible: true` for eligible players during bidding
- `revealHand()` validates phase, eligibility, and no-bid-yet before revealing
- `POST /api/tables/:tableId/reveal-hand` with full validation
- Blind Nil bid without reveal works correctly
- Unit and integration tests in place

This PR fixes one PRD compliance gap: PRD §6.4.3 defines `blindNilEligible` as a boolean field for all players; ineligible players previously received it as `undefined` instead of `false`. Added `blindNilEligible: false` to the fallthrough return in `getPlayerView` and a covering unit test.

Generated with [Claude Code](https://claude.ai/code)