### PR TITLE
fix: teamBidSummaryHtml uses authoritative teamBids, not raw bid addition

### DIFF
--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -79,17 +79,17 @@ export function bidContributionHint(teamTotal, partnerBid) {
  * Renders the post-bid team summary bar once both players on a team have bid.
  * Nil and Blind Nil bids are excluded from the combined team total.
  * Returns an empty string if bidding is not yet complete for either team.
- * @param {{ bids: object }} state
+ * @param {{ bids: object, teamBids: object, biddingOrder: string[] }} state
  * @returns {string}
  */
 export function teamBidSummaryHtml(state) {
   const teams = [
-    { label: 'N/S', seats: ['north', 'south'] },
-    { label: 'E/W', seats: ['east', 'west'] },
+    { label: 'N/S', seats: ['north', 'south'], teamKey: 'ns' },
+    { label: 'E/W', seats: ['east', 'west'], teamKey: 'ew' },
   ]
 
   const bars = []
-  for (const { label, seats } of teams) {
+  for (const { label, seats, teamKey } of teams) {
     const [a, b] = seats
     const bidA = state.bids[a]
     const bidB = state.bids[b]
@@ -102,8 +102,18 @@ export function teamBidSummaryHtml(state) {
 
     let summary
     if (!isSpecialA && !isSpecialB) {
-      const total = bidA + bidB
-      summary = `${esc(label)}: ${total} \u2014 ${esc(nameA)} ${bidA}, ${esc(nameB)} ${bidB}`
+      // Use the authoritative team total from the server; the second bidder's stored
+      // bid value is the team total, not their individual contribution.
+      const teamTotal = state.teamBids[teamKey]
+      const biddingOrder = state.biddingOrder || []
+      const [firstSeat, secondSeat] = biddingOrder.filter((s) => s === a || s === b)
+      const resolvedFirst = firstSeat ?? a
+      const resolvedSecond = secondSeat ?? b
+      const firstName = resolvedFirst.charAt(0).toUpperCase() + resolvedFirst.slice(1)
+      const secondName = resolvedSecond.charAt(0).toUpperCase() + resolvedSecond.slice(1)
+      const firstBid = state.bids[resolvedFirst]
+      const secondIndividual = teamTotal - firstBid
+      summary = `${esc(label)}: ${teamTotal} \u2014 ${esc(firstName)} ${firstBid}, ${esc(secondName)} ${secondIndividual}`
     } else {
       summary = `${esc(label)}: ${esc(nameA)} ${esc(bidLabel(bidA))}, ${esc(nameB)} ${esc(bidLabel(bidB))}`
     }
@@ -341,9 +351,7 @@ export function renderGameScreen(container) {
       statusMsg = isMyPlayTurn ? 'Your turn \u2014 click a card to play' : `Waiting for ${esc(state.currentPlayerSeat)} to play\u2026`
     }
 
-    const myTeam = TEAM[seat]
-    const oppTeam = myTeam === 'ns' ? 'ew' : 'ns'
-    const blindNilEligible = (state.scores[oppTeam] - state.scores[myTeam]) >= 100
+    const blindNilEligible = state.blindNilEligible === true
 
     const partnerSeat = PARTNER[seat]
     const partnerBid = state.bids[partnerSeat]

--- a/test/unit/web/bidSummary.test.js
+++ b/test/unit/web/bidSummary.test.js
@@ -6,8 +6,15 @@ import { teamBidSummaryHtml } from '../../../client/web/src/screens/game.js'
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeState(bids) {
-  return { bids }
+/**
+ * Build a minimal game state for teamBidSummaryHtml.
+ *
+ * bids: raw stored bid per seat (second bidder's numeric value = team total).
+ * teamBids: authoritative team totals (computed server-side by computeTeamBids).
+ * biddingOrder: seat order clockwise from left of dealer.
+ */
+function makeState(bids, { teamBids = {}, biddingOrder = ['north', 'east', 'south', 'west'] } = {}) {
+  return { bids, teamBids: { ns: null, ew: null, ...teamBids }, biddingOrder }
 }
 
 // ---------------------------------------------------------------------------
@@ -25,81 +32,153 @@ describe('teamBidSummaryHtml', () => {
     assert.equal(teamBidSummaryHtml(state), '')
   })
 
-  it('renders N/S summary once both N/S players have bid', () => {
-    const state = makeState({ north: 4, south: 3, east: null, west: null })
+  it('renders N/S summary with correct team total and individual contributions', () => {
+    // North bids 4 (first, advisory). South enters 7 as team total (second bidder).
+    // state.bids.south = 7 (team total), teamBids.ns = 7, South individual = 7 - 4 = 3.
+    const state = makeState(
+      { north: 4, south: 7, east: null, west: null },
+      { teamBids: { ns: 7 } },
+    )
     const html = teamBidSummaryHtml(state)
     assert.ok(html.includes('N/S'), 'should include team label N/S')
-    assert.ok(html.includes('7'), 'should show combined total 7')
-    assert.ok(html.includes('North'), 'should show North seat name')
-    assert.ok(html.includes('South'), 'should show South seat name')
+    assert.ok(html.includes('7'), 'should show team total 7')
+    assert.ok(html.includes('North 4'), 'should show North individual bid 4')
+    assert.ok(html.includes('South 3'), 'should show South individual contribution 3')
+    assert.ok(!html.match(/N\/S: 11/), 'should not show wrong total 11 (4+7)')
+  })
+
+  it('renders N/S summary when South is the first bidder', () => {
+    // With dealer = west, biddingOrder = ['north', 'east', 'south', 'west'].
+    // Use a dealer = south so biddingOrder = ['west', 'north', 'east', 'south'].
+    // Here South bids last for NS — North bids first: North 5, South enters 8 as team total.
+    // South individual = 8 - 5 = 3.
+    const state = makeState(
+      { north: 5, south: 8, east: null, west: null },
+      { teamBids: { ns: 8 } },
+      // default biddingOrder: north first, south second for NS
+    )
+    const html = teamBidSummaryHtml(state)
+    assert.ok(html.includes('N/S: 8'), 'should show team total 8')
+    assert.ok(html.includes('North 5'), 'should show first bidder North 5')
+    assert.ok(html.includes('South 3'), 'should show second bidder South individual 3')
   })
 
   it('renders E/W summary once both E/W players have bid', () => {
-    const state = makeState({ north: null, south: null, east: 5, west: 3 })
+    // East bids 5 (first for EW). West enters 8 as team total (second for EW).
+    // West individual = 8 - 5 = 3.
+    const state = makeState(
+      { north: null, south: null, east: 5, west: 8 },
+      { teamBids: { ew: 8 } },
+    )
     const html = teamBidSummaryHtml(state)
     assert.ok(html.includes('E/W'), 'should include team label E/W')
-    assert.ok(html.includes('8'), 'should show combined total 8')
-    assert.ok(html.includes('East'), 'should show East seat name')
-    assert.ok(html.includes('West'), 'should show West seat name')
+    assert.ok(html.includes('8'), 'should show team total 8')
+    assert.ok(html.includes('East 5'), 'should show East individual bid 5')
+    assert.ok(html.includes('West 3'), 'should show West individual contribution 3')
   })
 
   it('renders both team summaries when all four players have bid', () => {
-    const state = makeState({ north: 4, south: 3, east: 5, west: 2 })
+    // NS: North 4, South enters 7 (team total). EW: East 5, West enters 7 (team total).
+    const state = makeState(
+      { north: 4, south: 7, east: 5, west: 7 },
+      { teamBids: { ns: 7, ew: 7 } },
+    )
     const html = teamBidSummaryHtml(state)
     assert.ok(html.includes('N/S'), 'should include N/S')
     assert.ok(html.includes('E/W'), 'should include E/W')
-    assert.ok(html.includes('7'), 'N/S total should be 7')
     assert.ok(html.includes('bid-summary-team'), 'should use bid-summary-team class')
   })
 
   it('wraps output in a bid-summary container', () => {
-    const state = makeState({ north: 4, south: 3, east: null, west: null })
+    const state = makeState(
+      { north: 4, south: 7, east: null, west: null },
+      { teamBids: { ns: 7 } },
+    )
     const html = teamBidSummaryHtml(state)
     assert.ok(html.includes('bid-summary'), 'should include bid-summary class')
   })
 
   it('shows Nil bid individually and excludes it from team total', () => {
-    const state = makeState({ north: 'nil', south: 4, east: null, west: null })
+    // North bids nil (first). South bids 4 (second, team total = 4).
+    const state = makeState(
+      { north: 'nil', south: 4, east: null, west: null },
+      { teamBids: { ns: 4 } },
+    )
     const html = teamBidSummaryHtml(state)
     assert.ok(html.includes('N/S'), 'should include team label')
     assert.ok(html.includes('Nil'), 'should show Nil label')
-    // Should not show a combined numeric total like "4" as a standalone total
-    // The summary should just show individual bids
     assert.ok(!html.match(/N\/S: \d+ —/), 'should not show a combined numeric total when one bid is Nil')
   })
 
   it('shows Blind Nil bid individually and excludes it from team total', () => {
-    const state = makeState({ north: 'blind_nil', south: 4, east: null, west: null })
+    const state = makeState(
+      { north: 'blind_nil', south: 4, east: null, west: null },
+      { teamBids: { ns: 4 } },
+    )
     const html = teamBidSummaryHtml(state)
     assert.ok(html.includes('Blind Nil'), 'should show Blind Nil label')
     assert.ok(!html.match(/N\/S: \d+ —/), 'should not show a combined numeric total when one bid is Blind Nil')
   })
 
   it('shows both Nil bids individually with no combined total', () => {
-    const state = makeState({ north: 'nil', south: 'nil', east: null, west: null })
+    const state = makeState(
+      { north: 'nil', south: 'nil', east: null, west: null },
+      { teamBids: { ns: null } },
+    )
     const html = teamBidSummaryHtml(state)
     assert.ok(html.includes('N/S'), 'should include team label')
     assert.ok(!html.match(/N\/S: \d+ —/), 'should not show a combined total for two Nil bids')
   })
 
-  it('handles a zero bid in the team total', () => {
-    const state = makeState({ north: 0, south: 4, east: null, west: null })
+  it('handles a zero first bid in the team total', () => {
+    // North bids 0 (first). South enters 4 as team total. South individual = 4.
+    const state = makeState(
+      { north: 0, south: 4, east: null, west: null },
+      { teamBids: { ns: 4 } },
+    )
     const html = teamBidSummaryHtml(state)
-    assert.ok(html.includes('4'), 'should show combined total of 4')
+    assert.ok(html.includes('4'), 'should show team total of 4')
     assert.ok(html.includes('North 0'), 'should show North 0')
+    assert.ok(html.includes('South 4'), 'should show South individual of 4')
   })
 
-  it('handles maximum possible team total (13 tricks split across two players)', () => {
-    const state = makeState({ north: 7, south: 6, east: null, west: null })
+  it('handles maximum possible team total (13 tricks)', () => {
+    // North bids 7 (first). South enters 13 as team total. South individual = 6.
+    const state = makeState(
+      { north: 7, south: 13, east: null, west: null },
+      { teamBids: { ns: 13 } },
+    )
     const html = teamBidSummaryHtml(state)
-    assert.ok(html.includes('13'), 'should show combined total 13')
+    assert.ok(html.includes('13'), 'should show team total 13')
+    assert.ok(html.includes('North 7'), 'should show North 7')
+    assert.ok(html.includes('South 6'), 'should show South individual 6')
   })
 
   it('E/W summary with one Nil bid excludes Nil from team total', () => {
-    const state = makeState({ north: null, south: null, east: 'nil', west: 5 })
+    const state = makeState(
+      { north: null, south: null, east: 'nil', west: 5 },
+      { teamBids: { ew: 5 } },
+    )
     const html = teamBidSummaryHtml(state)
     assert.ok(html.includes('E/W'), 'should include E/W label')
     assert.ok(html.includes('Nil'), 'should show Nil')
     assert.ok(!html.match(/E\/W: \d+ —/), 'should not show a combined numeric total')
+  })
+
+  it('true partnership case: second bidder value is team total, not individual', () => {
+    // This is the core partnership bug scenario.
+    // North bids 4. South enters 7 meaning "our team bids 7 total".
+    // state.bids.south = 7, but South's individual contribution is only 3.
+    // The summary must show "N/S: 7 — North 4, South 3", NOT "N/S: 11 — North 4, South 7".
+    const state = makeState(
+      { north: 4, south: 7, east: null, west: null },
+      { teamBids: { ns: 7 } },
+    )
+    const html = teamBidSummaryHtml(state)
+    assert.ok(html.includes('N/S: 7'), 'team total must be 7 (the authoritative teamBids value)')
+    assert.ok(html.includes('North 4'), 'first bidder shows their advisory number')
+    assert.ok(html.includes('South 3'), 'second bidder shows individual contribution (7 − 4 = 3)')
+    assert.ok(!html.includes('11'), 'must not incorrectly add raw bids (4 + 7 = 11)')
+    assert.ok(!html.includes('South 7'), 'must not show second bidder raw team total as their individual bid')
   })
 })


### PR DESCRIPTION
Fixes the partnership bid summary bug identified in issue #159.

- `teamBidSummaryHtml` now reads `state.teamBids` for the authoritative team total and derives the second bidder's individual contribution as `teamTotal − firstBid`, using `state.biddingOrder` to identify which seat bid first.
- `blindNilEligible` now reads the server-supplied `state.blindNilEligible` field directly instead of re-deriving it client-side.
- Tests updated to use realistic state shapes and a new explicit partnership case test is added.

Generated with [Claude Code](https://claude.ai/code)