### PR TITLE
fix: show individual bid in seat cards for second bidder (issue #151)

### DIFF
--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -125,8 +125,37 @@ export function teamBidSummaryHtml(state) {
   return `<div class="bid-summary">${bars.join('')}</div>`
 }
 
-function seatInfoHtml(state, seat, label, isWinner = false) {
+/**
+ * Returns the bid to display for a seat, taking partnership bidding into account.
+ * For the second bidder in a numeric partnership, state.bids[seat] holds the team
+ * total, not the player's individual contribution. This function converts it back.
+ * @param {{ bids: object, biddingOrder: string[] }} state
+ * @param {string} seat
+ * @returns {number|string|null}
+ */
+export function getDisplayBid(state, seat) {
   const bid = state.bids[seat]
+  if (typeof bid !== 'number') return bid
+
+  const partner = PARTNER[seat]
+  const partnerBid = state.bids[partner]
+  if (typeof partnerBid !== 'number') return bid
+
+  const biddingOrder = state.biddingOrder || []
+  const teamPair = new Set([seat, partner])
+  const orderedTeam = biddingOrder.filter((s) => teamPair.has(s))
+
+  if (orderedTeam.length === 2 && orderedTeam[1] === seat) {
+    // Second bidder stores the team total as their bid value.
+    // Show individual contribution instead.
+    return bid - partnerBid
+  }
+
+  return bid
+}
+
+function seatInfoHtml(state, seat, label, isWinner = false) {
+  const bid = getDisplayBid(state, seat)
   const tricks = state.tricksWon[seat]
   const isActive = state.currentBidderSeat === seat || state.currentPlayerSeat === seat
   const activeCls = isActive ? ' seat-active' : ''

--- a/test/unit/web/seatBidDisplay.test.js
+++ b/test/unit/web/seatBidDisplay.test.js
@@ -1,0 +1,111 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { getDisplayBid } from '../../../client/web/src/screens/game.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeState(bids, { biddingOrder = ['north', 'east', 'south', 'west'], teamBids = {} } = {}) {
+  return {
+    bids,
+    biddingOrder,
+    teamBids: { ns: null, ew: null, ...teamBids },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// getDisplayBid
+// ---------------------------------------------------------------------------
+
+describe('getDisplayBid', () => {
+  it('returns raw bid for first bidder in a numeric partnership', () => {
+    // North bids 4 first. South enters 7 as team total.
+    // North is the first bidder — should show 4 (their advisory individual bid).
+    const state = makeState(
+      { north: 4, south: 7, east: null, west: null },
+      { biddingOrder: ['north', 'east', 'south', 'west'] },
+    )
+    assert.equal(getDisplayBid(state, 'north'), 4)
+  })
+
+  it('returns individual contribution for second bidder in a numeric partnership', () => {
+    // South is the second NS bidder, stored bid is team total 7, partner bid 4.
+    // Individual contribution = 7 - 4 = 3.
+    const state = makeState(
+      { north: 4, south: 7, east: null, west: null },
+      { biddingOrder: ['north', 'east', 'south', 'west'] },
+    )
+    assert.equal(getDisplayBid(state, 'south'), 3)
+  })
+
+  it('handles zero first bid (second bidder contribution equals team total)', () => {
+    // North bids 0. South enters 4 as team total. South individual = 4 - 0 = 4.
+    const state = makeState(
+      { north: 0, south: 4, east: null, west: null },
+    )
+    assert.equal(getDisplayBid(state, 'south'), 4)
+    assert.equal(getDisplayBid(state, 'north'), 0)
+  })
+
+  it('returns null for un-bid seat', () => {
+    const state = makeState({ north: 4, south: null, east: null, west: null })
+    assert.equal(getDisplayBid(state, 'south'), null)
+  })
+
+  it('returns nil string unchanged', () => {
+    const state = makeState({ north: 'nil', south: 4, east: null, west: null })
+    assert.equal(getDisplayBid(state, 'north'), 'nil')
+  })
+
+  it('returns blind_nil string unchanged', () => {
+    const state = makeState({ north: 'blind_nil', south: 4, east: null, west: null })
+    assert.equal(getDisplayBid(state, 'north'), 'blind_nil')
+  })
+
+  it('second bidder with nil partner bid returns raw bid (not subtracted)', () => {
+    // Partner bid is Nil (not numeric) — no contribution math applies.
+    const state = makeState(
+      { north: 'nil', south: 4, east: null, west: null },
+      { biddingOrder: ['north', 'east', 'south', 'west'] },
+    )
+    assert.equal(getDisplayBid(state, 'south'), 4)
+  })
+
+  it('works for E/W team — East is first bidder', () => {
+    const state = makeState(
+      { north: null, south: null, east: 5, west: 8 },
+      { biddingOrder: ['north', 'east', 'south', 'west'] },
+    )
+    assert.equal(getDisplayBid(state, 'east'), 5)
+    assert.equal(getDisplayBid(state, 'west'), 3) // 8 - 5
+  })
+
+  it('handles biddingOrder where South bids before North', () => {
+    // Dealer = East, so order is south, west, north, east.
+    // South bids first for NS (advisory 3). North enters 7 as team total. North individual = 4.
+    const state = makeState(
+      { north: 7, south: 3, east: null, west: null },
+      { biddingOrder: ['south', 'west', 'north', 'east'] },
+    )
+    assert.equal(getDisplayBid(state, 'south'), 3)  // first bidder — unchanged
+    assert.equal(getDisplayBid(state, 'north'), 4)  // second bidder: 7 - 3 = 4
+  })
+
+  it('returns raw bid when partner has not yet bid (no biddingOrder context)', () => {
+    // Only one player on team has bid — no individual calculation possible.
+    const state = makeState(
+      { north: 4, south: null, east: null, west: null },
+    )
+    assert.equal(getDisplayBid(state, 'north'), 4)
+  })
+
+  it('maximum total (13): second bidder shows correct individual', () => {
+    // North bids 7, South enters 13 as team total. South individual = 6.
+    const state = makeState(
+      { north: 7, south: 13, east: null, west: null },
+    )
+    assert.equal(getDisplayBid(state, 'south'), 6)
+    assert.equal(getDisplayBid(state, 'north'), 7)
+  })
+})


### PR DESCRIPTION
The second bidder's stored bid value is the team total, not their individual contribution. seatInfoHtml was displaying state.bids[seat] raw, causing a mismatch with the top summary bar (which correctly showed the individual split).

Introduced getDisplayBid() to convert the second bidder's team total back to their individual contribution, and wired it into seatInfoHtml. Added 10-case regression test in test/unit/web/seatBidDisplay.test.js.

Closes #151

Generated with [Claude Code](https://claude.ai/code)