### PR TITLE
fix: display bid buttons 7 per row

### DIFF
--- a/client/web/index.html
+++ b/client/web/index.html
@@ -534,8 +534,8 @@
       }
 
       .bid-grid {
-        display: flex;
-        flex-wrap: wrap;
+        display: grid;
+        grid-template-columns: repeat(7, 38px);
         gap: 0.35rem;
         margin-bottom: 0.5rem;
       }


### PR DESCRIPTION
Changed .bid-grid from flex-wrap to CSS grid with 7 columns so the 14 bid buttons (0-13) render as two uniform rows of 7 instead of 8 and 6.

Closes #168

Generated with [Claude Code](https://claude.ai/code)