### PR TITLE
fix: convert bid warning from inline hint to CSS tooltip

### DIFF
--- a/client/web/index.html
+++ b/client/web/index.html
@@ -551,10 +551,38 @@
         font-weight: 600;
         cursor: pointer;
         transition: background 0.15s;
+        position: relative;
       }
 
       .bid-num-btn:hover {
         background: #388e3c;
+      }
+
+      .bid-num-btn[data-tooltip]:hover::after,
+      .bid-num-btn[data-tooltip]:focus::after {
+        content: attr(data-tooltip);
+        position: absolute;
+        bottom: calc(100% + 6px);
+        left: 50%;
+        transform: translateX(-50%);
+        background: #222;
+        color: #b0b0b0;
+        font-size: 0.75rem;
+        font-weight: 400;
+        padding: 5px 8px;
+        border-radius: 4px;
+        white-space: normal;
+        width: max-content;
+        max-width: 220px;
+        z-index: 100;
+        pointer-events: none;
+        border: 1px solid #444;
+        text-align: left;
+      }
+
+      .bid-num-btn--warn[data-tooltip]:hover::after,
+      .bid-num-btn--warn[data-tooltip]:focus::after {
+        color: #ffa726;
       }
 
       .bid-special-row {
@@ -957,18 +985,6 @@
         font-size: 0.8rem;
         color: #90caf9;
         margin-bottom: 0.5rem;
-      }
-
-      .bid-hint {
-        min-height: 1.25rem;
-        font-size: 0.78rem;
-        color: #b0b0b0;
-        margin-top: 0.25rem;
-        margin-bottom: 0.25rem;
-      }
-
-      .bid-hint--warning {
-        color: #ffa726;
       }
 
       /* Post-bid team summary */

--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -409,12 +409,10 @@ export function renderGameScreen(container) {
 
     let bidPanelTitle = 'Choose your bid:'
     let bidPartnerInfoHtml = ''
-    let bidHintHtml = ''
     if (partnerHasBid) {
       if (partnerHasNumericBid) {
         bidPanelTitle = 'Team Total'
         bidPartnerInfoHtml = `<p class="bid-partner-info">Partner bid ${partnerBid} \u2014 enter team total:</p>`
-        bidHintHtml = '<div class="bid-hint" id="bid-hint" aria-live="polite"></div>'
       } else {
         bidPartnerInfoHtml = `<p class="bid-partner-info">Partner: ${esc(bidLabel(partnerBid))}</p>`
       }
@@ -428,13 +426,19 @@ export function renderGameScreen(container) {
         <p class="bid-title">${esc(bidPanelTitle)}</p>
         ${bidPartnerInfoHtml}
         <div class="bid-grid">
-          ${Array.from({ length: 14 }, (_, i) => `<button class="bid-num-btn" data-bid="${i}">${i}</button>`).join('')}
+          ${Array.from({ length: 14 }, (_, i) => {
+            if (!partnerHasNumericBid) return `<button class="bid-num-btn" data-bid="${i}">${i}</button>`
+            const { yourBid, isWarning } = bidContributionHint(i, partnerBid)
+            const tip = isWarning
+              ? `\u26a0 Team target (${i}) is below partner\u2019s bid (${partnerBid}) \u2014 every trick above ${i} is a bag`
+              : `You are bidding ${yourBid} (team total ${i} \u2212 partner\u2019s bid ${partnerBid})`
+            return `<button class="bid-num-btn${isWarning ? ' bid-num-btn--warn' : ''}" data-bid="${i}" data-tooltip="${tip}">${i}</button>`
+          }).join('')}
         </div>
         <div class="bid-special-row">
           <button class="bid-special-btn" data-bid="nil">Nil</button>
           ${blindNilEligible ? '<button class="bid-special-btn bid-blind-nil-btn" data-bid="blind_nil">Blind Nil</button>' : ''}
         </div>
-        ${bidHintHtml}
         <div class="form-error bid-err" role="alert" aria-live="polite"></div>
       </div>`)
       : ''
@@ -557,34 +561,6 @@ export function renderGameScreen(container) {
           }
         })
       })
-    }
-
-    // Bid hint for second bidder with numeric partner bid
-    if (isMyBidTurn && partnerHasNumericBid) {
-      const hintEl = container.querySelector('#bid-hint')
-      if (hintEl) {
-        container.querySelectorAll('.bid-num-btn').forEach((btn) => {
-          const showHint = () => {
-            const teamTotal = Number(btn.dataset.bid)
-            const { yourBid, isWarning } = bidContributionHint(teamTotal, partnerBid)
-            if (isWarning) {
-              hintEl.className = 'bid-hint bid-hint--warning'
-              hintEl.textContent = `\u26a0 Team target (${teamTotal}) is below partner\u2019s bid (${partnerBid}) \u2014 every trick above ${teamTotal} is a bag`
-            } else {
-              hintEl.className = 'bid-hint'
-              hintEl.textContent = `You are bidding ${yourBid} (team total ${teamTotal} \u2212 partner\u2019s bid ${partnerBid})`
-            }
-          }
-          const clearHint = () => {
-            hintEl.textContent = ''
-            hintEl.className = 'bid-hint'
-          }
-          btn.addEventListener('mouseenter', showHint)
-          btn.addEventListener('focus', showHint)
-          btn.addEventListener('mouseleave', clearHint)
-          btn.addEventListener('blur', clearHint)
-        })
-      }
     }
 
     // Hand card interactions (play or exchange)


### PR DESCRIPTION
Fixes #167

The .bid-hint element below the bid grid caused layout shift when hovering a bid lower than the partner's because the longer warning text expanded the reserved space. Replace with a CSS ::after tooltip that is absolutely positioned and has no effect on document flow.

Generated with [Claude Code](https://claude.ai/code)