### PR TITLE
fix: resolve null team total in bid summary when teamBids not yet populated

### DIFF
--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -105,11 +105,13 @@ export function teamBidSummaryHtml(state) {
     if (!isSpecialA && !isSpecialB) {
       // Use the authoritative team total from the server; the second bidder's stored
       // bid value is the team total, not their individual contribution.
-      const teamTotal = state.teamBids[teamKey]
+      // Fall back to the second bidder's stored bid when teamBids hasn't been
+      // populated yet (i.e. the other team hasn't finished bidding).
       const biddingOrder = state.biddingOrder || []
       const [firstSeat, secondSeat] = biddingOrder.filter((s) => s === a || s === b)
       const resolvedFirst = firstSeat ?? a
       const resolvedSecond = secondSeat ?? b
+      const teamTotal = state.teamBids[teamKey] ?? state.bids[resolvedSecond]
       const firstName = resolvedFirst.charAt(0).toUpperCase() + resolvedFirst.slice(1)
       const secondName = resolvedSecond.charAt(0).toUpperCase() + resolvedSecond.slice(1)
       const firstBid = state.bids[resolvedFirst]

--- a/test/unit/web/bidSummary.test.js
+++ b/test/unit/web/bidSummary.test.js
@@ -165,6 +165,23 @@ describe('teamBidSummaryHtml', () => {
     assert.ok(!html.match(/E\/W: \d+ —/), 'should not show a combined numeric total')
   })
 
+  it('renders correctly when teamBids is null but both players on a team have bid (mid-bidding)', () => {
+    // E/W finished bidding but N/S has not, so state.teamBids.ew is still null.
+    // East bids 2 (first for EW), West enters 3 as team total (second for EW).
+    // state.bids.west = 3 (team total stored as second bidder's value).
+    // teamBids.ew is null because the server only populates it after all 4 players bid.
+    const state = makeState(
+      { north: null, south: null, east: 2, west: 3 },
+      // teamBids.ew stays null (default from makeState)
+    )
+    const html = teamBidSummaryHtml(state)
+    assert.ok(html.includes('E/W'), 'should include E/W label')
+    assert.ok(html.includes('E/W: 3'), 'should show team total 3 from fallback bids[resolvedSecond]')
+    assert.ok(html.includes('East 2'), 'should show first bidder East 2')
+    assert.ok(html.includes('West 1'), 'should show second bidder West individual (3 − 2 = 1)')
+    assert.ok(!html.includes('null'), 'must not render the word null')
+  })
+
   it('true partnership case: second bidder value is team total, not individual', () => {
     // This is the core partnership bug scenario.
     // North bids 4. South enters 7 meaning "our team bids 7 total".


### PR DESCRIPTION
Fixes the "E/W: null" bug in the bid summary bar that appeared when one team finished bidding before the other.

## Root cause
`state.teamBids[teamKey]` is null until all 4 players have bid. The previous fix attempted to use `state.bids[resolvedSecond]` as a fallback, but `resolvedSecond` was declared after `teamTotal`, so the fallback was never applied.

## Fix
Moved the `biddingOrder`/seat resolution block before `teamTotal`, then applied `state.teamBids[teamKey] ?? state.bids[resolvedSecond]`. The fallback is safe: the line 97 guard ensures both seats have bid before this code runs, and the second bidder always stores the team total per partnership rules.

Adds a regression test for the mid-bidding null scenario.

Closes #166

Generated with [Claude Code](https://claude.ai/code)