### PR TITLE
fix: bot bids partner's total when bidding second

### DIFF
--- a/server/game/bot.js
+++ b/server/game/bot.js
@@ -21,14 +21,23 @@ export function getBotPlayerId(seat) {
 }
 
 /**
- * Compute the bot's bid: count the number of spades in its hand.
- * This is a legal bid value (0–13) under all conditions.
+ * Compute the bot's bid.
+ *
+ * When bidding first (partnerBid is null), bids its spades count.
+ * When bidding second (partnerBid is a number), bids partner's bid + spades count
+ * so the team total equals partner's contribution plus the bot's individual spades.
+ * If the partner bid nil or blind_nil (individual bids), falls back to spades count only.
  *
  * @param {Array<{suit: string, rank: string}>} hand
+ * @param {number|'nil'|'blind_nil'|null} [partnerBid] - Partner's bid if bot is bidding second
  * @returns {number}
  */
-export function botBid(hand) {
-  return hand.filter((c) => c.suit === 'spades').length
+export function botBid(hand, partnerBid = null) {
+  const spades = hand.filter((c) => c.suit === 'spades').length
+  if (typeof partnerBid === 'number') {
+    return partnerBid + spades
+  }
+  return spades
 }
 
 /**

--- a/server/server.js
+++ b/server/server.js
@@ -41,7 +41,9 @@ function advanceBotTurns(state) {
     if (current.phase === 'bidding') {
       const seat = current.currentBidderSeat
       if (!seat || !isBot(current.players[seat])) break
-      const bid = botBid(current.hands[seat])
+      const partnerSeat = getPartnerSeat(seat)
+      const partnerBid = current.bids[partnerSeat]
+      const bid = botBid(current.hands[seat], partnerBid)
       console.log('Bot bid:', { seat, bid, tableId: current.tableId })
       current = placeBid(current, seat, bid)
     } else if (current.phase === 'playing') {

--- a/test/unit/game/bot.test.js
+++ b/test/unit/game/bot.test.js
@@ -65,6 +65,31 @@ describe('botBid', () => {
     ]
     assert.equal(botBid(hand), 13)
   })
+
+  describe('second bidder (partnerBid provided)', () => {
+    const hand = [
+      { suit: 'spades', rank: 'A' },
+      { suit: 'spades', rank: 'K' },
+      { suit: 'hearts', rank: 'Q' },
+      { suit: 'clubs', rank: '7' },
+    ] // 2 spades
+
+    it('returns partner bid + spades when partner bid a number', () => {
+      assert.equal(botBid(hand, 4), 6) // team total = 4 + 2
+    })
+
+    it('returns partner bid + spades when partner bid 0', () => {
+      assert.equal(botBid(hand, 0), 2) // team total = 0 + 2
+    })
+
+    it('returns just spades count when partner bid nil', () => {
+      assert.equal(botBid(hand, 'nil'), 2)
+    })
+
+    it('returns just spades count when partner bid blind_nil', () => {
+      assert.equal(botBid(hand, 'blind_nil'), 2)
+    })
+  })
 })
 
 describe('botPlay', () => {


### PR DESCRIPTION
When the simple bot bids second, it now bids partner's numeric bid + its own spades count, making the team total equal to the partner's contribution plus the bot's individual spades. If the partner bid nil or blind_nil, the bot falls back to its spades count only.

Closes #175

Generated with [Claude Code](https://claude.ai/code)