### PR TITLE
feat: show starting score at top of hand summary overlay

### DIFF
--- a/client/web/index.html
+++ b/client/web/index.html
@@ -1041,6 +1041,49 @@
         margin: 0;
       }
 
+      .hand-summary-scores-before {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 1rem;
+        width: 100%;
+        background: #0f1a0f;
+        border: 1px solid #2e4a2e;
+        border-radius: 7px;
+        padding: 0.6rem 1rem;
+      }
+
+      .scores-before-team {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.15rem;
+        flex: 1;
+      }
+
+      .scores-before-label {
+        font-size: 0.68rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        color: #81c784;
+      }
+
+      .scores-before-value {
+        font-size: 1.15rem;
+        font-weight: 700;
+        color: #e8e8e8;
+      }
+
+      .scores-before-sep {
+        font-size: 0.72rem;
+        color: #555;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        flex-shrink: 0;
+      }
+
       .hand-summary-cols {
         display: flex;
         gap: 0.75rem;

--- a/client/web/src/endOfHandSummary.js
+++ b/client/web/src/endOfHandSummary.js
@@ -115,10 +115,25 @@ export function endOfHandSummaryHtml(entry, mySeat) {
   const usLabel = `Us (${TEAM_LABEL[myTeam]})`
   const themLabel = `Them (${TEAM_LABEL[theirTeam]})`
 
+  const scoresBefore = entry.scoresBefore || { ns: 0, ew: 0 }
+  const myScoreBefore = scoresBefore[myTeam]
+  const theirScoreBefore = scoresBefore[theirTeam]
+
   return `
     <div class="hand-summary-overlay" id="hand-summary-overlay">
       <div class="hand-summary-modal" role="dialog" aria-label="Hand ${esc(String(entry.handNumber))} Summary">
         <h3 class="hand-summary-title">Hand ${esc(String(entry.handNumber))} Summary</h3>
+        <div class="hand-summary-scores-before">
+          <div class="scores-before-team">
+            <span class="scores-before-label">${esc(usLabel)}</span>
+            <span class="scores-before-value">${myScoreBefore}</span>
+          </div>
+          <div class="scores-before-sep">vs</div>
+          <div class="scores-before-team">
+            <span class="scores-before-label">${esc(themLabel)}</span>
+            <span class="scores-before-value">${theirScoreBefore}</span>
+          </div>
+        </div>
         <div class="hand-summary-cols">
           ${teamColHtml(myTeam, entry, usLabel)}
           ${teamColHtml(theirTeam, entry, themLabel)}

--- a/server/game/state.js
+++ b/server/game/state.js
@@ -415,6 +415,7 @@ function scoreCompletedHand(state) {
     scoreDelta,
     newBags,
     bagPenalty,
+    scoresBefore: { ...state.scores },
     scoresAfter: { ...scores },
     bagsAfter: { ...bags },
   }

--- a/test/unit/game/handHistory.test.js
+++ b/test/unit/game/handHistory.test.js
@@ -213,6 +213,23 @@ describe('handHistory — accumulates across multiple hands', () => {
   })
 })
 
+describe('handHistory — scoresBefore field', () => {
+  it('scoresBefore is { ns: 0, ew: 0 } for the first hand', () => {
+    const initial = createGame('table-1', PLAYER_IDS)
+    const state = completeOneHand(initial)
+    assert.deepEqual(state.handHistory[0].scoresBefore, { ns: 0, ew: 0 })
+  })
+
+  it('scoresBefore for hand 2 equals scoresAfter of hand 1', () => {
+    let state = createGame('table-1', PLAYER_IDS)
+    state = completeOneHand(state)
+    if (state.phase === 'game_over') return // skip if game ended in one hand
+    const scoresAfterHand1 = state.handHistory[0].scoresAfter
+    state = completeOneHand(state)
+    assert.deepEqual(state.handHistory[1].scoresBefore, scoresAfterHand1)
+  })
+})
+
 describe('handHistory — bag penalty detection', () => {
   it('bagPenalty.ns is 1 when ns crosses 10 bags in a hand', () => {
     // Construct a state with 9 bags for ns and force another bag this hand


### PR DESCRIPTION
Fixes #169

Adds a "score before this hand" banner below the title in the hand summary overlay, showing both teams' scores at the start of the hand side-by-side.

- `server/game/state.js`: add `scoresBefore` field to each hand history entry
- `client/web/src/endOfHandSummary.js`: render scores-before banner at top
- `client/web/index.html`: CSS for banner
- `test/unit/game/handHistory.test.js`: 2 regression tests for scoresBefore

Generated with [Claude Code](https://claude.ai/code)