### PR TITLE
fix: bags are worth +1 point each (PRD §5.1)

### DIFF
--- a/client/web/src/endOfHandSummary.js
+++ b/client/web/src/endOfHandSummary.js
@@ -65,7 +65,7 @@ function teamColHtml(team, entry, colLabel) {
     const delta = entry.scoreDelta[team]
     const sign = delta >= 0 ? '+' : ''
     const bagsEarned = entry.newBags[team]
-    const bagsText = bagsEarned > 0 ? `, +${bagsEarned} bag${bagsEarned !== 1 ? 's' : ''}` : ''
+    const bagsText = bagsEarned > 0 ? `, +${bagsEarned}\u{1F45D}` : ''
     teamRowHtml = `
       <div class="summary-row team-row">
         <span class="summary-row-label">Bid ${esc(String(teamBid))}, Took ${teamTricks}</span>
@@ -96,7 +96,7 @@ function teamColHtml(team, entry, colLabel) {
       ${penaltyHtml}
       <div class="summary-total">
         <span class="summary-score">${scoreAfter} pts</span>
-        <span class="summary-bags">${bagsAfter} bag${bagsAfter !== 1 ? 's' : ''}</span>
+        <span class="summary-bags">${bagsAfter}\u{1F45D}</span>
       </div>
     </div>`
 }

--- a/server/game/score.js
+++ b/server/game/score.js
@@ -66,6 +66,11 @@ export function scoreHand({ bids, teamBids, tricksWon }) {
     }
   }
 
+  // Each bag is worth +1 point (PRD §5.1)
+  for (const team of TEAMS) {
+    scoreDelta[team] += newBags[team]
+  }
+
   return { scoreDelta, newBags }
 }
 

--- a/test/unit/game/score.test.js
+++ b/test/unit/game/score.test.js
@@ -21,11 +21,11 @@ describe('scoreHand — basic team bid', () => {
       teamBids: { ns: 7, ew: 7 },
       tricksWon: { north: 4, east: 5, south: 4, west: 3 },
     })
-    // NS: 8 tricks vs bid 7 → +70 + 1 bag
-    assert.equal(scoreDelta.ns, 70)
+    // NS: 8 tricks vs bid 7 → +70 + 1 bag (+1 pt) = 71
+    assert.equal(scoreDelta.ns, 71)
     assert.equal(newBags.ns, 1)
-    // EW: 8 tricks vs bid 7 → +70 + 1 bag
-    assert.equal(scoreDelta.ew, 70)
+    // EW: 8 tricks vs bid 7 → +70 + 1 bag (+1 pt) = 71
+    assert.equal(scoreDelta.ew, 71)
     assert.equal(newBags.ew, 1)
   })
 
@@ -75,8 +75,8 @@ describe('scoreHand — nil bid', () => {
       tricksWon: { north: 3, east: 4, south: 5, west: 3 },
     })
     // North failed nil: -50
-    // NS: 8 tricks vs bid 5 → +50 + 3 bags
-    assert.equal(scoreDelta.ns, -50 + 50)
+    // NS: 8 tricks vs bid 5 → +50 + 3 bags (+3 pts) = 3
+    assert.equal(scoreDelta.ns, -50 + 50 + 3)
     assert.equal(newBags.ns, 3)
   })
 })
@@ -121,8 +121,8 @@ describe('scoreHand — double nil', () => {
       teamBids: { ns: null, ew: 7 },
       tricksWon: { north: 2, east: 4, south: 0, west: 3 },
     })
-    // North failed nil (-50); south made nil (+50); north's 2 tricks = 2 bags
-    assert.equal(scoreDelta.ns, -50 + 50)
+    // North failed nil (-50); south made nil (+50); north's 2 tricks = 2 bags (+2 pts)
+    assert.equal(scoreDelta.ns, -50 + 50 + 2)
     assert.equal(newBags.ns, 2)
   })
 })
@@ -134,8 +134,8 @@ describe('scoreHand — team bid of 0', () => {
       teamBids: { ns: 0, ew: 7 },
       tricksWon: { north: 2, east: 4, south: 1, west: 3 },
     })
-    // NS team bid 0: every trick is a bag, no positive/negative score
-    assert.equal(scoreDelta.ns, 0)
+    // NS team bid 0: every trick is a bag (+1 pt each)
+    assert.equal(scoreDelta.ns, 3) // 3 bags = +3 pts
     assert.equal(newBags.ns, 3) // 2 + 1
   })
 })

--- a/test/unit/game/state.test.js
+++ b/test/unit/game/state.test.js
@@ -512,7 +512,7 @@ describe('bag tracking — state level', () => {
 
     assert.equal(state.bags.ns, 2, 'NS should have 2 bags from 2 overtricks')
     assert.equal(state.bags.ew, 0, 'EW missed bid — no bags')
-    assert.equal(state.scores.ns, 70, 'NS: bid 7 made 9 → +70')
+    assert.equal(state.scores.ns, 72, 'NS: bid 7 made 9 → +70 + 2 bags (+2 pts) = 72')
     assert.equal(state.scores.ew, -60, 'EW: bid 6 made 4 → -60')
   })
 
@@ -524,8 +524,8 @@ describe('bag tracking — state level', () => {
       { north: 4, east: 2, south: 5, west: 1 },
     )
 
-    // NS: 100 + 70 (bid made) - 100 (bag penalty) = 70; bags: (9+2) % 10 = 1
-    assert.equal(state.scores.ns, 70, 'NS score after bag penalty')
+    // NS: 100 + 72 (bid made + 2 bags) - 100 (bag penalty) = 72; bags: (9+2) % 10 = 1
+    assert.equal(state.scores.ns, 72, 'NS score after bag penalty')
     assert.equal(state.bags.ns, 1, 'NS bags reset to 1 after penalty')
     // EW: 100 - 60 = 40; bags unchanged
     assert.equal(state.scores.ew, 40, 'EW score unaffected by NS bag penalty')
@@ -545,7 +545,7 @@ describe('bag tracking — state level', () => {
 
     // Verify hand 1 results
     assert.equal(bagsAfterHand1.ns, 2)
-    assert.equal(scoresAfterHand1.ns, 70)
+    assert.equal(scoresAfterHand1.ns, 72)
 
     // Hand 2: same setup — NS gets 2 more bags, total 4 (no penalty yet)
     // Bidding order for hand 2: south (east was dealer), west, north, east
@@ -739,7 +739,7 @@ describe('game over — phase transition', () => {
   }
 
   it('transitions to game_over with winner=ns when NS score reaches 250', () => {
-    // After hand: NS=9 tricks (north:4+south:5) vs bid 7 → +70 → 200+70=270 ≥ 250
+    // After hand: NS=9 tricks (north:4+south:5) vs bid 7 → +70 + 2 bags (+2 pts) = 72 → 200+72=272 ≥ 250
     //             EW=4 tricks (east:3+west:1) vs bid 6 → -60 → 100-60=40
     const state = buildNearEndState({
       initialScores: { ns: 200, ew: 100 },
@@ -748,7 +748,7 @@ describe('game over — phase transition', () => {
     assert.equal(state.phase, 'game_over')
     assert.equal(state.winner, 'ns')
     assert.equal(state.gameOver, true)
-    assert.equal(state.scores.ns, 270)
+    assert.equal(state.scores.ns, 272)
   })
 
   it('starts next hand in bidding phase when neither team reaches a threshold', () => {


### PR DESCRIPTION
Fixes #180

**Bug:** `scoreHand` tracked bag counts but never added the +1 point bonus per bag to `scoreDelta`. All bag cases were affected: normal overtricks, team bid of 0, and double nil.

**Changes:**
- `server/game/score.js` — after computing `newBags` for all teams, adds `newBags[team]` to `scoreDelta[team]`
- `client/web/src/endOfHandSummary.js` — replaced the word "bag(s)" with 👝 icon in both the per-hand earned line and the running total
- `test/unit/game/score.test.js` — updated expected `scoreDelta` values to include bag points

Generated with [Claude Code](https://claude.ai/code)