### PR TITLE
fix: add bag emoji icon to scoreboard header

### DIFF
--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -473,13 +473,13 @@ export function renderGameScreen(container) {
           <div class="score-team score-ns">
             <span class="score-team-label">N/S</span>
             <span class="score-pts">${state.scores.ns}</span>
-            <span class="score-bags">${state.bags.ns} bag${state.bags.ns !== 1 ? 's' : ''}</span>
+            <span class="score-bags">\u{1F45D} ${state.bags.ns} bag${state.bags.ns !== 1 ? 's' : ''}</span>
           </div>
           <div class="score-meta">Hand #${state.handNumber}${state.spadesbroken ? ' \u00b7 \u2660 broken' : ''}</div>
           <div class="score-team score-ew">
             <span class="score-team-label">E/W</span>
             <span class="score-pts">${state.scores.ew}</span>
-            <span class="score-bags">${state.bags.ew} bag${state.bags.ew !== 1 ? 's' : ''}</span>
+            <span class="score-bags">\u{1F45D} ${state.bags.ew} bag${state.bags.ew !== 1 ? 's' : ''}</span>
           </div>
         </div>
         ${teamBidSummaryHtml(state)}


### PR DESCRIPTION
The bag count in the scoreboard header was displaying as plain text without the bag icon. Added the 👝 emoji to both N/S and E/W score-bags spans.

Fixes #182

Generated with [Claude Code](https://claude.ai/code)