### PR TITLE
Show bags before hand in score header and move bags inline with final score

### DIFF
--- a/client/web/index.html
+++ b/client/web/index.html
@@ -1153,13 +1153,14 @@
 
       .summary-total {
         display: flex;
-        flex-direction: column;
-        align-items: center;
+        flex-direction: row;
+        align-items: baseline;
+        justify-content: center;
         text-align: center;
         margin-top: 0.75rem;
         padding-top: 0.6rem;
         border-top: 1px solid #2e4a2e;
-        gap: 0.1rem;
+        gap: 0.4rem;
       }
 
       .summary-score {
@@ -1172,6 +1173,12 @@
       .summary-bags {
         font-size: 0.72rem;
         color: #777;
+      }
+
+      .scores-before-bags {
+        font-size: 0.72rem;
+        color: #777;
+        font-weight: 400;
       }
 
       .hand-summary-continue {

--- a/client/web/src/endOfHandSummary.js
+++ b/client/web/src/endOfHandSummary.js
@@ -95,8 +95,7 @@ function teamColHtml(team, entry, colLabel) {
       ${nilRows}
       ${penaltyHtml}
       <div class="summary-total">
-        <span class="summary-score">${scoreAfter} pts</span>
-        <span class="summary-bags">${bagsAfter}\u{1F45D}</span>
+        <span class="summary-score">${scoreAfter} pts</span> <span class="summary-bags">${bagsAfter}\u{1F45D}</span>
       </div>
     </div>`
 }
@@ -119,8 +118,11 @@ export function endOfHandSummaryHtml(entry, mySeat, gameOverInfo = null) {
   const themLabel = `Them (${TEAM_LABEL[theirTeam]})`
 
   const scoresBefore = entry.scoresBefore || { ns: 0, ew: 0 }
+  const bagsBefore = entry.bagsBefore || { ns: 0, ew: 0 }
   const myScoreBefore = scoresBefore[myTeam]
   const theirScoreBefore = scoresBefore[theirTeam]
+  const myBagsBefore = bagsBefore[myTeam]
+  const theirBagsBefore = bagsBefore[theirTeam]
 
   const titleSuffix = gameOverInfo ? ' \u00b7 GAME OVER' : ''
 
@@ -144,12 +146,12 @@ export function endOfHandSummaryHtml(entry, mySeat, gameOverInfo = null) {
         <div class="hand-summary-scores-before">
           <div class="scores-before-team">
             <span class="scores-before-label">${esc(usLabel)}</span>
-            <span class="scores-before-value">${myScoreBefore}</span>
+            <span class="scores-before-value">${myScoreBefore} <span class="scores-before-bags">${myBagsBefore}\u{1F45D}</span></span>
           </div>
           <div class="scores-before-sep">vs</div>
           <div class="scores-before-team">
             <span class="scores-before-label">${esc(themLabel)}</span>
-            <span class="scores-before-value">${theirScoreBefore}</span>
+            <span class="scores-before-value">${theirScoreBefore} <span class="scores-before-bags">${theirBagsBefore}\u{1F45D}</span></span>
           </div>
         </div>
         <div class="hand-summary-cols">

--- a/server/game/state.js
+++ b/server/game/state.js
@@ -416,6 +416,7 @@ function scoreCompletedHand(state) {
     newBags,
     bagPenalty,
     scoresBefore: { ...state.scores },
+    bagsBefore: { ...state.bags },
     scoresAfter: { ...scores },
     bagsAfter: { ...bags },
   }

--- a/test/unit/game/handHistory.test.js
+++ b/test/unit/game/handHistory.test.js
@@ -230,6 +230,23 @@ describe('handHistory — scoresBefore field', () => {
   })
 })
 
+describe('handHistory — bagsBefore field', () => {
+  it('bagsBefore is { ns: 0, ew: 0 } for the first hand', () => {
+    const initial = createGame('table-1', PLAYER_IDS)
+    const state = completeOneHand(initial)
+    assert.deepEqual(state.handHistory[0].bagsBefore, { ns: 0, ew: 0 })
+  })
+
+  it('bagsBefore for hand 2 equals bagsAfter of hand 1', () => {
+    let state = createGame('table-1', PLAYER_IDS)
+    state = completeOneHand(state)
+    if (state.phase === 'game_over') return // skip if game ended in one hand
+    const bagsAfterHand1 = state.handHistory[0].bagsAfter
+    state = completeOneHand(state)
+    assert.deepEqual(state.handHistory[1].bagsBefore, bagsAfterHand1)
+  })
+})
+
 describe('handHistory — bag penalty detection', () => {
   it('bagPenalty.ns is 1 when ns crosses 10 bags in a hand', () => {
     // Construct a state with 9 bags for ns and force another bag this hand

--- a/test/unit/web/endOfHandSummary.test.js
+++ b/test/unit/web/endOfHandSummary.test.js
@@ -20,6 +20,8 @@ function makeEntry(overrides = {}) {
     scoreDelta: { ns: 70, ew: 70 },
     newBags: { ns: 0, ew: 0 },
     bagPenalty: { ns: 0, ew: 0 },
+    scoresBefore: { ns: 0, ew: 0 },
+    bagsBefore: { ns: 0, ew: 0 },
     scoresAfter: { ns: 70, ew: 70 },
     bagsAfter: { ns: 0, ew: 0 },
     ...overrides,
@@ -265,6 +267,30 @@ describe('endOfHandSummaryHtml — running totals', () => {
     const entry = makeEntry({ bagsAfter: { ns: 3, ew: 1 } })
     const html = endOfHandSummaryHtml(entry, 'north')
     assert.ok(html.includes('3'), 'should show ns bags 3')
+  })
+
+  it('shows bagsBefore next to the scores at the top', () => {
+    const entry = makeEntry({
+      scoresBefore: { ns: 100, ew: 50 },
+      bagsBefore: { ns: 4, ew: 2 },
+    })
+    const html = endOfHandSummaryHtml(entry, 'north')
+    // bags-before values should appear in the scores-before section
+    const scoresBefore = html.match(/hand-summary-scores-before[\s\S]*?hand-summary-cols/)?.[0] ?? html
+    assert.ok(scoresBefore.includes('4') || html.includes('4'), 'should display us bags before (4)')
+    assert.ok(scoresBefore.includes('2') || html.includes('2'), 'should display them bags before (2)')
+  })
+
+  it('bagsAfter appear on the same line as the final score (not below)', () => {
+    const entry = makeEntry({ bagsAfter: { ns: 5, ew: 0 }, scoresAfter: { ns: 127, ew: 49 } })
+    const html = endOfHandSummaryHtml(entry, 'north')
+    // summary-bags should be inside summary-total but not in its own separate block
+    const totalSection = html.match(/summary-total[\s\S]*?<\/div>/)?.[0] ?? ''
+    assert.ok(html.includes('summary-bags'), 'bags element should exist')
+    // The bags span should follow the score span without a line-break wrapper in between
+    const scoreIdx = html.indexOf('summary-score')
+    const bagsIdx = html.indexOf('summary-bags')
+    assert.ok(bagsIdx > scoreIdx, 'summary-bags should appear after summary-score in the DOM')
   })
 })
 


### PR DESCRIPTION
Fixes #184

- Display bags at start of hand next to each team score at the top of the hand summary
- Move bags after from below the final score to the right of it (inline)
- Add `bagsBefore` field to hand history entries in server/game/state.js

Generated with [Claude Code](https://claude.ai/code)