### PR TITLE
Bottom-align final score and divider in hand summary

### DIFF
--- a/client/web/index.html
+++ b/client/web/index.html
@@ -1156,8 +1156,8 @@
         flex-direction: column;
         align-items: center;
         text-align: center;
-        margin-top: 0.75rem;
-        padding-top: 0.6rem;
+        margin-top: auto;
+        padding-top: 0.75rem;
         border-top: 1px solid #2e4a2e;
         gap: 0.1rem;
       }


### PR DESCRIPTION
Fixes #184

- Use `margin-top: auto` on `.summary-total` so the final score and its divider line always sit at the bottom of each column, keeping them visually aligned even when one team has more score rows than the other

Generated with [Claude Code](https://claude.ai/code)