### PR TITLE
Replace bag emoji with colored SVG money bag icon

### DIFF
--- a/client/web/src/endOfHandSummary.js
+++ b/client/web/src/endOfHandSummary.js
@@ -12,6 +12,8 @@
  * The caller renders this as an overlay and wires up the Continue button.
  */
 
+import { BAG_ICON } from './icons.js'
+
 const TEAM = { north: 'ns', south: 'ns', east: 'ew', west: 'ew' }
 const TEAM_SEATS = { ns: ['north', 'south'], ew: ['east', 'west'] }
 const TEAM_LABEL = { ns: 'N/S', ew: 'E/W' }
@@ -65,11 +67,11 @@ function teamColHtml(team, entry, colLabel) {
     const delta = entry.scoreDelta[team]
     const sign = delta >= 0 ? '+' : ''
     const bagsEarned = entry.newBags[team]
-    const bagsText = bagsEarned > 0 ? `, +${bagsEarned}\u{1F45D}` : ''
+    const bagsSuffix = bagsEarned > 0 ? `, +${bagsEarned}${BAG_ICON}` : ''
     teamRowHtml = `
       <div class="summary-row team-row">
         <span class="summary-row-label">Bid ${esc(String(teamBid))}, Took ${teamTricks}</span>
-        <span class="summary-row-value">${sign}${delta} pts${esc(bagsText)}</span>
+        <span class="summary-row-value">${sign}${delta} pts${bagsSuffix}</span>
       </div>`
   }
 
@@ -95,7 +97,7 @@ function teamColHtml(team, entry, colLabel) {
       ${nilRows}
       ${penaltyHtml}
       <div class="summary-total">
-        <span class="summary-score">${scoreAfter} pts</span> <span class="summary-bags">${bagsAfter}\u{1F45D}</span>
+        <span class="summary-score">${scoreAfter} pts</span> <span class="summary-bags">${bagsAfter}${BAG_ICON}</span>
       </div>
     </div>`
 }
@@ -146,12 +148,12 @@ export function endOfHandSummaryHtml(entry, mySeat, gameOverInfo = null) {
         <div class="hand-summary-scores-before">
           <div class="scores-before-team">
             <span class="scores-before-label">${esc(usLabel)}</span>
-            <span class="scores-before-value">${myScoreBefore} <span class="scores-before-bags">${myBagsBefore}\u{1F45D}</span></span>
+            <span class="scores-before-value">${myScoreBefore} <span class="scores-before-bags">${myBagsBefore}${BAG_ICON}</span></span>
           </div>
           <div class="scores-before-sep">vs</div>
           <div class="scores-before-team">
             <span class="scores-before-label">${esc(themLabel)}</span>
-            <span class="scores-before-value">${theirScoreBefore} <span class="scores-before-bags">${theirBagsBefore}\u{1F45D}</span></span>
+            <span class="scores-before-value">${theirScoreBefore} <span class="scores-before-bags">${theirBagsBefore}${BAG_ICON}</span></span>
           </div>
         </div>
         <div class="hand-summary-cols">

--- a/client/web/src/icons.js
+++ b/client/web/src/icons.js
@@ -1,0 +1,34 @@
+/**
+ * Shared SVG icon constants for use in HTML template strings.
+ *
+ * All icons use viewBox="0 0 24 24" and inherit surrounding text color via
+ * currentColor where applicable. Colored icons use inline fill/stroke values.
+ *
+ * Note: when the same icon appears multiple times on a page, gradient <defs>
+ * IDs are duplicated in the DOM — browsers use the first definition, which is
+ * fine because all instances are visually identical.
+ */
+
+export const BAG_ICON = [
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" style="vertical-align:-2px">',
+  '<defs>',
+  '<linearGradient id="bagG" x1="0" y1="0" x2="0" y2="1">',
+  '<stop offset="0%" stop-color="#FFE55C"/>',
+  '<stop offset="50%" stop-color="#FFC200"/>',
+  '<stop offset="100%" stop-color="#B35A00"/>',
+  '</linearGradient>',
+  '</defs>',
+  // Bag body — wide rounded teardrop
+  '<path d="M4.5 16.5 C4.5 21 7.5 23 12 23 C16.5 23 19.5 21 19.5 16.5 C19.5 12 16.5 10 12 10 C7.5 10 4.5 12 4.5 16.5 Z" fill="url(#bagG)" stroke="#8B5E00" stroke-width="1"/>',
+  // Neck — narrow band sitting above the body
+  '<path d="M10.5 10 L10.5 8.5 Q10.5 7.5 12 7.5 Q13.5 7.5 13.5 8.5 L13.5 10" fill="#E6A800" stroke="#8B5E00" stroke-width="0.8"/>',
+  // Cinch string tied around the neck
+  '<line x1="10" y1="9" x2="14" y2="9" stroke="#6B4400" stroke-width="1.5" stroke-linecap="round"/>',
+  // Knot — small arch above the cinch
+  '<path d="M10.5 8.2 Q12 6 13.5 8.2" fill="none" stroke="#8B5E00" stroke-width="1.5" stroke-linecap="round"/>',
+  // Dollar sign — vertical bar
+  '<line x1="12" y1="11.5" x2="12" y2="21.5" stroke="#6B4400" stroke-width="1.5" stroke-linecap="round"/>',
+  // Dollar sign — S curve
+  '<path d="M14.5 13.8 Q14.5 11.5 12 11.5 Q9.5 11.5 9.5 13.8 Q9.5 16 12 16 Q14.5 16 14.5 18.2 Q14.5 20.5 12 20.5 Q9.5 20.5 9.5 18.2" fill="none" stroke="#6B4400" stroke-width="1.4" stroke-linecap="round"/>',
+  '</svg>',
+].join('')

--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -12,6 +12,7 @@ import { relSeats } from '../seatUtils.js'
 import { HOLD_DURATIONS, detectCompletedTrick, trickHoldHtml } from '../trickHold.js'
 import { createInputBlocker } from '../inputBlock.js'
 import { endOfHandSummaryHtml } from '../endOfHandSummary.js'
+import { BAG_ICON } from '../icons.js'
 
 const SUIT_SYMBOL = { spades: '\u2660', hearts: '\u2665', diamonds: '\u2666', clubs: '\u2663' }
 const RED_SUIT = new Set(['hearts', 'diamonds'])
@@ -473,13 +474,13 @@ export function renderGameScreen(container) {
           <div class="score-team score-ns">
             <span class="score-team-label">N/S</span>
             <span class="score-pts">${state.scores.ns}</span>
-            <span class="score-bags">\u{1F45D} ${state.bags.ns} bag${state.bags.ns !== 1 ? 's' : ''}</span>
+            <span class="score-bags">${BAG_ICON} ${state.bags.ns} bag${state.bags.ns !== 1 ? 's' : ''}</span>
           </div>
           <div class="score-meta">Hand #${state.handNumber}${state.spadesbroken ? ' \u00b7 \u2660 broken' : ''}</div>
           <div class="score-team score-ew">
             <span class="score-team-label">E/W</span>
             <span class="score-pts">${state.scores.ew}</span>
-            <span class="score-bags">\u{1F45D} ${state.bags.ew} bag${state.bags.ew !== 1 ? 's' : ''}</span>
+            <span class="score-bags">${BAG_ICON} ${state.bags.ew} bag${state.bags.ew !== 1 ? 's' : ''}</span>
           </div>
         </div>
         ${teamBidSummaryHtml(state)}


### PR DESCRIPTION
Adds `client/web/src/icons.js` with a `BAG_ICON` constant — an inline SVG money bag with a vertical gold gradient, cinch string around the neck, a tied knot at the top, and a dollar sign on the body.

Replaces the clutch bag emoji (👝) at all 6 call sites in `endOfHandSummary.js` and `screens/game.js`.

Closes #185

Generated with [Claude Code](https://claude.ai/code)