### PR TITLE
feat: host terminate game button

### DIFF
--- a/client/web/src/api.js
+++ b/client/web/src/api.js
@@ -311,6 +311,30 @@ export async function addBotToTable({ tableId, seat, sessionId, playerId }, fetc
 }
 
 /**
+ * Terminate a game (host only). Works in both waiting and playing phases.
+ * @param {{ tableId: string, sessionId: string, playerId: string }} data
+ * @param {typeof fetch} [fetchFn]
+ * @returns {Promise<{ message: string }>}
+ */
+export async function terminateGame({ tableId, sessionId, playerId }, fetchFn = globalThis.fetch) {
+  const res = await fetchFn(`/api/tables/${tableId}/terminate`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-session-id': sessionId,
+      'x-player-id': playerId,
+    },
+  })
+  const body = await res.json()
+  if (!res.ok) {
+    const err = new Error(body.error || 'Failed to terminate game.')
+    err.status = res.status
+    throw err
+  }
+  return body
+}
+
+/**
  * Log out the current session.
  * @param {{ sessionId: string }} data
  * @param {typeof fetch} [fetchFn]

--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -5,6 +5,7 @@ import {
   submitBlindNilExchange as apiExchange,
   addBotToTable as apiAddBot,
   revealHand as apiRevealHand,
+  terminateGame as apiTerminate,
 } from '../api.js'
 import { navigate } from '../router.js'
 import { handSpreadHtml, handDiagramHtml, lastTrickHtml } from '../hand.js'
@@ -273,7 +274,13 @@ export function renderGameScreen(container) {
           state = s
           render()
         }
-      } catch (_) {
+      } catch (err) {
+        if (err.status === 404) {
+          // Table was terminated — redirect to lobby
+          cleanup()
+          navigate('#/lobby')
+          return
+        }
         // silent — retry on next poll
       }
       schedulePoll()
@@ -296,6 +303,10 @@ export function renderGameScreen(container) {
       ? `<button class="btn-primary" id="fill-bots-btn">Fill with Bots (${emptySeats.length} seat${emptySeats.length !== 1 ? 's' : ''})</button>`
       : ''
 
+    const terminateBtn = state.isHost
+      ? `<button class="btn-danger" id="terminate-btn">Terminate Game</button>`
+      : ''
+
     container.innerHTML = `
       <div class="game-screen">
         <div class="waiting-screen">
@@ -303,6 +314,7 @@ export function renderGameScreen(container) {
           <div class="waiting-seats">${rows}</div>
           <div class="form-error waiting-err" role="alert" aria-live="polite"></div>
           ${fillBotsBtn}
+          ${terminateBtn}
           <p class="auth-link"><a href="#/lobby">Leave table</a></p>
         </div>
       </div>`
@@ -325,6 +337,21 @@ export function renderGameScreen(container) {
         errEl.textContent = err.message || 'Failed to add bots.'
         btn.disabled = false
         btn.textContent = `Fill with Bots (${emptySeats.length} seat${emptySeats.length !== 1 ? 's' : ''})`
+      }
+    })
+
+    container.querySelector('#terminate-btn')?.addEventListener('click', async () => {
+      if (!confirm('Are you sure you want to terminate this game? This cannot be undone.')) return
+      const btn = container.querySelector('#terminate-btn')
+      const errEl = container.querySelector('.waiting-err')
+      btn.disabled = true
+      try {
+        await apiTerminate({ tableId, sessionId, playerId })
+        cleanup()
+        navigate('#/lobby')
+      } catch (err) {
+        errEl.textContent = err.message || 'Failed to terminate game.'
+        btn.disabled = false
       }
     })
   }
@@ -526,6 +553,8 @@ export function renderGameScreen(container) {
         ${showLastTrick && state.completedTricks.length > 0
           ? lastTrickHtml(state.completedTricks[state.completedTricks.length - 1], rel)
           : ''}
+
+        ${state.isHost ? '<div class="host-controls"><button class="btn-danger btn-sm" id="terminate-btn">Terminate Game</button></div>' : ''}
       </div>`
 
     // Mode toggle
@@ -547,6 +576,21 @@ export function renderGameScreen(container) {
       if (e.target.id === 'last-trick-overlay' || e.target.id === 'last-trick-close') {
         showLastTrick = false
         render()
+      }
+    })
+
+    // Terminate game button (host only, in-game)
+    container.querySelector('#terminate-btn')?.addEventListener('click', async () => {
+      if (!confirm('Are you sure you want to terminate this game? This cannot be undone.')) return
+      const btn = container.querySelector('#terminate-btn')
+      btn.disabled = true
+      try {
+        await apiTerminate({ tableId, sessionId, playerId })
+        cleanup()
+        navigate('#/lobby')
+      } catch (err) {
+        btn.disabled = false
+        console.log('Terminate failed:', { error: err.message })
       }
     })
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -21,6 +21,7 @@
 - [x] `P0` Apply rate limiting on all authentication endpoints
 - [x] `P1` Build player profile page (username, avatar, career win/loss record, recent 20 games, cosmetics)
 - [x] `P1` Add logout button to the lobby screen (`client/web/src/screens/lobby.js`): calls `POST /api/auth/logout`, clears `sessionStorage`, and redirects to the login screen
+- [x] `DEV` Host terminate game — `POST /api/tables/:tableId/terminate` lets the table host immediately end a game at any point (waiting or in progress). Deletes the table and game state from Redis. All seated players are redirected to the lobby on their next poll (404 from state endpoint). A "Terminate Game" button with a browser confirm prompt is shown to the host on both the waiting screen and during active play (`server/lobby/table.js`, `server/server.js`, `client/web/src/api.js`, `client/web/src/screens/game.js`).
 
 ---
 

--- a/server/lobby/table.js
+++ b/server/lobby/table.js
@@ -201,6 +201,20 @@ export async function removePlayerFromTables(redis, playerId) {
 }
 
 /**
+ * Terminate a table and its associated game state, removing all Redis keys.
+ * Used by the host to forcibly end a game at any point (waiting or in progress).
+ *
+ * @param {import('redis').RedisClientType} redis
+ * @param {string} tableId
+ */
+export async function terminateTable(redis, tableId) {
+  await redis.del(`table:${tableId}`)
+  await redis.del(`game:${tableId}`)
+  await redis.hDel('lobby:tables', tableId)
+  console.log('Table terminated:', { tableId })
+}
+
+/**
  * List all open (waiting) tables from the lobby index.
  * Fetches full table state for each waiting entry to include seat info.
  *

--- a/server/server.js
+++ b/server/server.js
@@ -18,6 +18,7 @@ import {
   listTables,
   addBotToTable,
   removePlayerFromTables,
+  terminateTable,
 } from './lobby/table.js'
 import { createGame, placeBid, playCard, submitBlindNilExchange, revealHand, getPlayerView } from './game/state.js'
 import { getPartnerSeat } from './game/bid.js'
@@ -329,6 +330,27 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
     }
   })
 
+  // POST /api/tables/:tableId/terminate — host terminates the game (any phase)
+  app.post('/api/tables/:tableId/terminate', async (req, res) => {
+    const { tableId } = req.params
+    try {
+      const redisClient = await getRedis()
+      const session = await validateAuthHeaders(redisClient, req)
+      const table = await getTable(redisClient, tableId)
+      if (!table) return sendJSON(res, 404, { error: 'Table not found' })
+      if (table.hostPlayerId !== session.playerId) {
+        return sendJSON(res, 403, { error: 'Only the host can terminate the game' })
+      }
+      await terminateTable(redisClient, tableId)
+      console.log('Game terminated by host:', { tableId, playerId: session.playerId })
+      sendJSON(res, 200, { message: 'Game terminated.' })
+    } catch (err) {
+      if (err.code === 'UNAUTHORIZED') return sendJSON(res, 401, { error: err.message })
+      console.error('Terminate game error:', { tableId, error: err.message })
+      sendJSON(res, 500, { error: 'Internal server error' })
+    }
+  })
+
   // GET /api/tables/:tableId/state — get game state (filtered for this player)
   app.get('/api/tables/:tableId/state', async (req, res) => {
     const { tableId } = req.params
@@ -344,7 +366,7 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
       const gameState = await getGameState(redisClient, tableId)
       if (!gameState) return sendJSON(res, 200, { status: 'waiting', seats: table.seats, isHost: table.hostPlayerId === session.playerId })
 
-      sendJSON(res, 200, getPlayerView(gameState, seat))
+      sendJSON(res, 200, { ...getPlayerView(gameState, seat), isHost: table.hostPlayerId === session.playerId })
     } catch (err) {
       if (err.code === 'UNAUTHORIZED') return sendJSON(res, 401, { error: err.message })
       console.error('Get game state error:', { tableId, error: err.message })

--- a/test/integration/game/terminate.test.js
+++ b/test/integration/game/terminate.test.js
@@ -1,0 +1,187 @@
+/**
+ * Integration tests for POST /api/tables/:tableId/terminate.
+ * Requires a real Redis instance (REDIS_URL).
+ * Tests are skipped when REDIS_URL or DATABASE_URL is not set.
+ */
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import express from 'express'
+import bcrypt from 'bcryptjs'
+import { handler } from '../../../server/server.js'
+import { getDb, closeDb } from '../../../server/db.js'
+import { getRedis, closeRedis } from '../../../server/redis.js'
+
+const skip =
+  !process.env.DATABASE_URL || !process.env.REDIS_URL
+    ? 'DATABASE_URL and REDIS_URL must both be set'
+    : false
+
+async function startTestServer() {
+  const app = express()
+  app.use(express.json())
+  handler(app)
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address()
+      resolve({
+        baseUrl: `http://127.0.0.1:${port}`,
+        close: () => new Promise((res) => server.close(res)),
+      })
+    })
+  })
+}
+
+async function ensurePlayersTable(db) {
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS players (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      email VARCHAR(255) UNIQUE NOT NULL,
+      username VARCHAR(50) UNIQUE NOT NULL,
+      password_hash VARCHAR(255) NOT NULL,
+      is_verified BOOLEAN NOT NULL DEFAULT FALSE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `)
+  await db.query(`DELETE FROM players WHERE email LIKE '%@term.spades.invalid'`)
+}
+
+async function insertVerifiedPlayer(db, { email, username, password }) {
+  const hash = await bcrypt.hash(password, 4)
+  const result = await db.query(
+    `INSERT INTO players (email, username, password_hash, is_verified)
+     VALUES ($1, $2, $3, TRUE) RETURNING id`,
+    [email, username, hash],
+  )
+  return result.rows[0].id
+}
+
+async function loginPlayer(baseUrl, email, password) {
+  const res = await fetch(`${baseUrl}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  })
+  return res.json()
+}
+
+describe('POST /api/tables/:tableId/terminate', { skip }, () => {
+  let server, db, redis
+  const players = []
+
+  before(async () => {
+    db = getDb()
+    redis = await getRedis()
+    await ensurePlayersTable(db)
+    for (let i = 1; i <= 2; i++) {
+      await insertVerifiedPlayer(db, {
+        email: `termplayer${i}@term.spades.invalid`,
+        username: `term_player${i}`,
+        password: 'password123',
+      })
+    }
+    server = await startTestServer()
+    for (let i = 1; i <= 2; i++) {
+      const data = await loginPlayer(
+        server.baseUrl,
+        `termplayer${i}@term.spades.invalid`,
+        'password123',
+      )
+      players.push(data)
+    }
+  })
+
+  after(async () => {
+    await server.close()
+    await closeDb()
+    await closeRedis()
+  })
+
+  it('host can terminate a waiting table', async () => {
+    const host = players[0]
+    const createRes = await fetch(`${server.baseUrl}/api/tables`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+    })
+    assert.equal(createRes.status, 201)
+    const { tableId } = await createRes.json()
+
+    // Sit host at a seat so auth check passes on state endpoint
+    await fetch(`${server.baseUrl}/api/tables/${tableId}/sit`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+      body: JSON.stringify({ seat: 'north' }),
+    })
+
+    const termRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/terminate`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+    })
+    assert.equal(termRes.status, 200)
+    const body = await termRes.json()
+    assert.ok(body.message, 'should return a message')
+
+    // Table should no longer be found
+    const stateRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
+      headers: { 'x-session-id': host.sessionId, 'x-player-id': host.playerId },
+    })
+    assert.equal(stateRes.status, 404, 'table should be gone after termination')
+  })
+
+  it('non-host player gets 403', async () => {
+    const host = players[0]
+    const other = players[1]
+
+    const createRes = await fetch(`${server.baseUrl}/api/tables`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+    })
+    const { tableId } = await createRes.json()
+
+    const termRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/terminate`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': other.sessionId,
+        'x-player-id': other.playerId,
+      },
+    })
+    assert.equal(termRes.status, 403)
+  })
+
+  it('returns 404 for unknown tableId', async () => {
+    const host = players[0]
+    const fakeId = '00000000-0000-0000-0000-000000000000'
+    const termRes = await fetch(`${server.baseUrl}/api/tables/${fakeId}/terminate`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+    })
+    assert.equal(termRes.status, 404)
+  })
+
+  it('returns 401 without auth headers', async () => {
+    const res = await fetch(`${server.baseUrl}/api/tables/some-id/terminate`, {
+      method: 'POST',
+    })
+    assert.equal(res.status, 401)
+  })
+})


### PR DESCRIPTION
Adds a host-only "Terminate Game" button with a confirm prompt that works in both the waiting screen and during active play.

## Changes
- `POST /api/tables/:tableId/terminate` — host-only endpoint that deletes table and game state from Redis
- `isHost` now included in in-game state response
- Terminate button + confirm dialog in waiting & active game screens
- Poll loop redirects all players to lobby on 40 (game terminated)
- Integration tests for host/non-host/404/401 cases

Closes #186

Generated with [Claude Code](https://claude.ai/code)