### PR TITLE
feat: rename "Bag penalty" to "Bagged out", add embarrassed face for double bag-out

### DIFF
--- a/client/web/src/endOfHandSummary.js
+++ b/client/web/src/endOfHandSummary.js
@@ -12,7 +12,7 @@
  * The caller renders this as an overlay and wires up the Continue button.
  */
 
-import { BAG_ICON } from './icons.js'
+import { BAG_ICON, EMBARRASSED_FACE_ICON } from './icons.js'
 
 const TEAM = { north: 'ns', south: 'ns', east: 'ew', west: 'ew' }
 const TEAM_SEATS = { ns: ['north', 'south'], ew: ['east', 'west'] }
@@ -80,9 +80,13 @@ function teamColHtml(team, entry, colLabel) {
   let penaltyHtml = ''
   if (entry.bagPenalty[team] > 0) {
     const penaltyPts = entry.bagPenalty[team] * 100
+    const isDouble = entry.bagPenalty[team] > 1
+    const penaltyLabel = isDouble
+      ? `Bagged out TWICE ${EMBARRASSED_FACE_ICON}`
+      : 'Bagged out'
     penaltyHtml = `
       <div class="summary-row penalty-row">
-        <span class="summary-row-label">Bag penalty${entry.bagPenalty[team] > 1 ? ` \u00d7${entry.bagPenalty[team]}` : ''}</span>
+        <span class="summary-row-label">${penaltyLabel}</span>
         <span class="summary-row-value">\u2212${penaltyPts} pts</span>
       </div>`
   }

--- a/client/web/src/icons.js
+++ b/client/web/src/icons.js
@@ -32,3 +32,33 @@ export const BAG_ICON = [
   '<path d="M14.5 13.8 Q14.5 11.5 12 11.5 Q9.5 11.5 9.5 13.8 Q9.5 16 12 16 Q14.5 16 14.5 18.2 Q14.5 20.5 12 20.5 Q9.5 20.5 9.5 18.2" fill="none" stroke="#6B4400" stroke-width="1.4" stroke-linecap="round"/>',
   '</svg>',
 ].join('')
+
+export const DUNCE_CAP_ICON = [
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" style="vertical-align:-2px">',
+  // Hat body — red cone
+  '<path d="M12 2 L3 20 L21 20 Z" fill="#CC2200" stroke="#991100" stroke-width="0.8"/>',
+  // Brim — yellow band
+  '<ellipse cx="12" cy="20" rx="9" ry="2" fill="#FFD700" stroke="#CC9900" stroke-width="0.8"/>',
+  // Pompom — yellow circle at tip
+  '<circle cx="12" cy="3" r="1.8" fill="#FFD700" stroke="#CC9900" stroke-width="0.6"/>',
+  '</svg>',
+].join('')
+
+export const EMBARRASSED_FACE_ICON = [
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" style="vertical-align:-2px">',
+  // Face
+  '<circle cx="12" cy="12" r="10" fill="#FFD700" stroke="#CC9900" stroke-width="1"/>',
+  // Left eye — X
+  '<line x1="7" y1="8" x2="10" y2="11" stroke="#333" stroke-width="1.5" stroke-linecap="round"/>',
+  '<line x1="10" y1="8" x2="7" y2="11" stroke="#333" stroke-width="1.5" stroke-linecap="round"/>',
+  // Right eye — X
+  '<line x1="14" y1="8" x2="17" y2="11" stroke="#333" stroke-width="1.5" stroke-linecap="round"/>',
+  '<line x1="17" y1="8" x2="14" y2="11" stroke="#333" stroke-width="1.5" stroke-linecap="round"/>',
+  // Left blush
+  '<ellipse cx="7.5" cy="14.5" rx="2.5" ry="1.5" fill="#FF8080" opacity="0.7"/>',
+  // Right blush
+  '<ellipse cx="16.5" cy="14.5" rx="2.5" ry="1.5" fill="#FF8080" opacity="0.7"/>',
+  // Worried mouth
+  '<path d="M9 18 Q12 16 15 18" fill="none" stroke="#333" stroke-width="1.5" stroke-linecap="round"/>',
+  '</svg>',
+].join('')

--- a/test/unit/web/endOfHandSummary.test.js
+++ b/test/unit/web/endOfHandSummary.test.js
@@ -249,8 +249,8 @@ describe('endOfHandSummaryHtml — bag penalty', () => {
     const html = endOfHandSummaryHtml(entry, 'north')
     assert.ok(html.includes('200'), 'should show 200 for double bag penalty')
     assert.ok(
-      html.toLowerCase().includes('penalty'),
-      'should show penalty label',
+      html.toLowerCase().includes('twice'),
+      'should show "twice" label for double bag-out',
     )
   })
 })


### PR DESCRIPTION
Closes #189

- "Bag penalty" → "Bagged out" for single bag-out
- "Bagged out TWICE" + embarrassed face SVG for double bag-out
- Adds EMBARRASSED_FACE_ICON and DUNCE_CAP_ICON to client/web/src/icons.js
- Updates end-of-hand summary test to match new label text

Generated with [Claude Code](https://claude.ai/code)