### PR TITLE
fix: show tricks-only score in Bid X Took Y row; add pts to nil rows

### DIFF
--- a/client/web/src/endOfHandSummary.js
+++ b/client/web/src/endOfHandSummary.js
@@ -41,7 +41,7 @@ function nilBidderRowsHtml(team, entry) {
     const label = bid === 'blind_nil' ? 'Blind Nil' : 'Nil'
     const name = seat.charAt(0).toUpperCase() + seat.slice(1)
     const resultClass = made ? 'nil-made' : 'nil-failed'
-    const resultText = made ? `Made \u2713 +${points}` : `Failed \u2717 \u2212${points}`
+    const resultText = made ? `Made \u2713 +${points} pts` : `Failed \u2717 \u2212${points} pts`
 
     rows.push(`
       <div class="summary-row nil-row ${resultClass}">
@@ -64,7 +64,15 @@ function teamColHtml(team, entry, colLabel) {
   if (!isDoubleNil) {
     const teamBid = entry.teamBids[team]
     const teamTricks = seats.reduce((sum, s) => sum + entry.tricksWon[s], 0)
-    const delta = entry.scoreDelta[team]
+    // Compute tricks-only delta: exclude nil/blind nil contributions from the team score delta
+    let nilContribution = 0
+    for (const seat of seats) {
+      if (entry.bids[seat] === 'nil' || entry.bids[seat] === 'blind_nil') {
+        const nilPoints = entry.bids[seat] === 'blind_nil' ? 100 : 50
+        nilContribution += entry.tricksWon[seat] === 0 ? nilPoints : -nilPoints
+      }
+    }
+    const delta = entry.scoreDelta[team] - nilContribution
     const sign = delta >= 0 ? '+' : ''
     const bagsEarned = entry.newBags[team]
     const bagsSuffix = bagsEarned > 0 ? `, +${bagsEarned}${BAG_ICON}` : ''

--- a/test/unit/web/endOfHandSummary.test.js
+++ b/test/unit/web/endOfHandSummary.test.js
@@ -177,6 +177,55 @@ describe('endOfHandSummaryHtml — nil bid', () => {
       'should mention blind nil or 100 points',
     )
   })
+
+  it('shows tricks-only score in "Bid X, Took Y" row when team has a failed nil bidder', () => {
+    // Bid 3, Took 3 → +30 pts from tricks. Failed nil → -50. scoreDelta = -20.
+    // The "Bid X, Took Y" row must show +30, not the net -20.
+    const entry = makeEntry({
+      bids: { north: 'nil', east: 4, south: 3, west: 3 },
+      teamBids: { ns: 3, ew: 7 },
+      tricksWon: { north: 1, east: 4, south: 2, west: 3 },
+      scoreDelta: { ns: -20, ew: 70 },
+    })
+    const html = endOfHandSummaryHtml(entry, 'north')
+    assert.ok(html.includes('+30'), 'Bid X, Took Y row should show +30 (tricks only), not -20 (net)')
+    assert.ok(!html.includes('-20'), 'should not show the net score -20 in the team row')
+  })
+
+  it('shows tricks-only score in "Bid X, Took Y" row when team has a made nil bidder', () => {
+    // Bid 5, Took 5 → +50 pts from tricks. Made nil → +50. scoreDelta = 100.
+    // The "Bid X, Took Y" row must show +50, not +100.
+    const entry = makeEntry({
+      bids: { north: 'nil', east: 4, south: 5, west: 3 },
+      teamBids: { ns: 5, ew: 7 },
+      tricksWon: { north: 0, east: 4, south: 5, west: 3 },
+      scoreDelta: { ns: 100, ew: 70 },
+    })
+    const html = endOfHandSummaryHtml(entry, 'north')
+    assert.ok(html.includes('+50 pts'), 'Bid X, Took Y row should show +50 pts (tricks only)')
+  })
+
+  it('nil result rows include "pts" suffix', () => {
+    const entry = makeEntry({
+      bids: { north: 'nil', east: 4, south: 5, west: 3 },
+      teamBids: { ns: 5, ew: 7 },
+      tricksWon: { north: 2, east: 3, south: 5, west: 3 },
+      scoreDelta: { ns: 0, ew: 70 },
+    })
+    const html = endOfHandSummaryHtml(entry, 'north')
+    assert.ok(html.includes('−50 pts') || html.includes('-50 pts'), 'failed nil row should include "pts" suffix')
+  })
+
+  it('made nil result rows include "pts" suffix', () => {
+    const entry = makeEntry({
+      bids: { north: 'nil', east: 4, south: 5, west: 3 },
+      teamBids: { ns: 5, ew: 7 },
+      tricksWon: { north: 0, east: 4, south: 5, west: 3 },
+      scoreDelta: { ns: 100, ew: 70 },
+    })
+    const html = endOfHandSummaryHtml(entry, 'north')
+    assert.ok(html.includes('+50 pts'), 'made nil row should include "pts" suffix')
+  })
 })
 
 describe('endOfHandSummaryHtml — double nil (both players on a team bid nil)', () => {


### PR DESCRIPTION
Fixes #192

The "Bid X, Took Y" row was displaying the full team `scoreDelta` which includes nil/blind nil contributions. This caused it to show the net team score rather than just points earned from the bid. Fixed by subtracting nil contributions from `scoreDelta` before rendering the team row.

Also adds "pts" suffix to nil result rows for consistency with the team row format.

Generated with [Claude Code](https://claude.ai/code)