### PR TITLE
Add leave table button for seated players

### DIFF
--- a/client/web/src/api.js
+++ b/client/web/src/api.js
@@ -311,6 +311,30 @@ export async function addBotToTable({ tableId, seat, sessionId, playerId }, fetc
 }
 
 /**
+ * Leave a waiting table, removing the player from their seat.
+ * @param {{ tableId: string, sessionId: string, playerId: string }} data
+ * @param {typeof fetch} [fetchFn]
+ * @returns {Promise<{ message: string }>}
+ */
+export async function leaveTable({ tableId, sessionId, playerId }, fetchFn = globalThis.fetch) {
+  const res = await fetchFn(`/api/tables/${tableId}/leave`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-session-id': sessionId,
+      'x-player-id': playerId,
+    },
+  })
+  const body = await res.json()
+  if (!res.ok) {
+    const err = new Error(body.error || 'Failed to leave table.')
+    err.status = res.status
+    throw err
+  }
+  return body
+}
+
+/**
  * Terminate a game (host only). Works in both waiting and playing phases.
  * @param {{ tableId: string, sessionId: string, playerId: string }} data
  * @param {typeof fetch} [fetchFn]

--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -6,6 +6,7 @@ import {
   addBotToTable as apiAddBot,
   revealHand as apiRevealHand,
   terminateGame as apiTerminate,
+  leaveTable as apiLeaveTable,
 } from '../api.js'
 import { navigate } from '../router.js'
 import { handSpreadHtml, handDiagramHtml, lastTrickHtml } from '../hand.js'
@@ -316,7 +317,7 @@ export function renderGameScreen(container) {
           <div class="form-error waiting-err" role="alert" aria-live="polite"></div>
           ${fillBotsBtn}
           ${terminateBtn}
-          <p class="auth-link"><a href="#/lobby">Leave table</a></p>
+          <button class="btn-secondary" id="leave-table-btn">Leave Table</button>
         </div>
       </div>`
 
@@ -353,6 +354,23 @@ export function renderGameScreen(container) {
       } catch (err) {
         errEl.textContent = err.message || 'Failed to terminate game.'
         btn.disabled = false
+      }
+    })
+
+    container.querySelector('#leave-table-btn')?.addEventListener('click', async () => {
+      const btn = container.querySelector('#leave-table-btn')
+      const errEl = container.querySelector('.waiting-err')
+      btn.disabled = true
+      btn.textContent = 'Leaving\u2026'
+      errEl.textContent = ''
+      try {
+        await apiLeaveTable({ tableId, sessionId, playerId })
+        cleanup()
+        navigate('#/lobby')
+      } catch (err) {
+        errEl.textContent = err.message || 'Failed to leave table.'
+        btn.disabled = false
+        btn.textContent = 'Leave Table'
       }
     })
   }

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -22,6 +22,7 @@
 - [x] `P1` Build player profile page (username, avatar, career win/loss record, recent 20 games, cosmetics)
 - [x] `P1` Add logout button to the lobby screen (`client/web/src/screens/lobby.js`): calls `POST /api/auth/logout`, clears `sessionStorage`, and redirects to the login screen
 - [x] `DEV` Host terminate game — `POST /api/tables/:tableId/terminate` lets the table host immediately end a game at any point (waiting or in progress). Deletes the table and game state from Redis. All seated players are redirected to the lobby on their next poll (404 from state endpoint). A "Terminate Game" button with a browser confirm prompt is shown to the host on both the waiting screen and during active play (`server/lobby/table.js`, `server/server.js`, `client/web/src/api.js`, `client/web/src/screens/game.js`).
+- [x] `P1` Leave table — `POST /api/tables/:tableId/leave` removes the requesting player from their seat at a waiting table. Only allowed while the table status is 'waiting'; returns 409 if a game is in progress. A "Leave Table" button on the waiting screen calls this endpoint and redirects the player to the lobby on success (`server/lobby/table.js`, `server/server.js`, `client/web/src/api.js`, `client/web/src/screens/game.js`).
 
 ---
 

--- a/server/lobby/table.js
+++ b/server/lobby/table.js
@@ -201,6 +201,36 @@ export async function removePlayerFromTables(redis, playerId) {
 }
 
 /**
+ * Remove the requesting player from a waiting table's seat.
+ * Only allowed while the table is in 'waiting' status — in-progress games
+ * require separate disconnect handling.
+ *
+ * @param {import('redis').RedisClientType} redis
+ * @param {string} tableId
+ * @param {string} playerId
+ * @returns {Promise<TableState>}
+ * @throws {Error} If the table is not found, game is in progress, or player is not seated
+ */
+export async function leaveTable(redis, tableId, playerId) {
+  const table = await getTable(redis, tableId)
+  if (!table) {
+    throw Object.assign(new Error('Table not found'), { code: 'NOT_FOUND' })
+  }
+  if (table.status === 'playing') {
+    throw Object.assign(new Error('Cannot leave a game in progress'), { code: 'GAME_IN_PROGRESS' })
+  }
+  const seatEntry = Object.entries(table.seats).find(([, id]) => id === playerId)
+  if (!seatEntry) {
+    throw Object.assign(new Error('You are not seated at this table'), { code: 'NOT_SEATED' })
+  }
+  const [seat] = seatEntry
+  const updated = { ...table, seats: { ...table.seats, [seat]: null } }
+  await saveTable(redis, updated)
+  console.log('Player left table:', { tableId, playerId, seat })
+  return updated
+}
+
+/**
  * Terminate a table and its associated game state, removing all Redis keys.
  * Used by the host to forcibly end a game at any point (waiting or in progress).
  *

--- a/server/server.js
+++ b/server/server.js
@@ -19,6 +19,7 @@ import {
   addBotToTable,
   removePlayerFromTables,
   terminateTable,
+  leaveTable,
 } from './lobby/table.js'
 import { createGame, placeBid, playCard, submitBlindNilExchange, revealHand, getPlayerView } from './game/state.js'
 import { getPartnerSeat } from './game/bid.js'
@@ -347,6 +348,25 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
     } catch (err) {
       if (err.code === 'UNAUTHORIZED') return sendJSON(res, 401, { error: err.message })
       console.error('Terminate game error:', { tableId, error: err.message })
+      sendJSON(res, 500, { error: 'Internal server error' })
+    }
+  })
+
+  // POST /api/tables/:tableId/leave — leave a waiting table (removes player from their seat)
+  app.post('/api/tables/:tableId/leave', async (req, res) => {
+    const { tableId } = req.params
+    try {
+      const redisClient = await getRedis()
+      const session = await validateAuthHeaders(redisClient, req)
+      await leaveTable(redisClient, tableId, session.playerId)
+      console.log('Player left table:', { tableId, playerId: session.playerId })
+      sendJSON(res, 200, { message: 'Left table.' })
+    } catch (err) {
+      if (err.code === 'UNAUTHORIZED') return sendJSON(res, 401, { error: err.message })
+      if (err.code === 'NOT_FOUND') return sendJSON(res, 404, { error: err.message })
+      if (err.code === 'GAME_IN_PROGRESS') return sendJSON(res, 409, { error: err.message })
+      if (err.code === 'NOT_SEATED') return sendJSON(res, 409, { error: err.message })
+      console.error('Leave table error:', { tableId, error: err.message })
       sendJSON(res, 500, { error: 'Internal server error' })
     }
   })

--- a/test/integration/game/leaveTable.test.js
+++ b/test/integration/game/leaveTable.test.js
@@ -1,0 +1,263 @@
+/**
+ * Integration tests for POST /api/tables/:tableId/leave.
+ * Requires a real Redis instance (REDIS_URL).
+ * Tests are skipped when REDIS_URL or DATABASE_URL is not set.
+ */
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import express from 'express'
+import bcrypt from 'bcryptjs'
+import { handler } from '../../../server/server.js'
+import { getDb, closeDb } from '../../../server/db.js'
+import { getRedis, closeRedis } from '../../../server/redis.js'
+
+const skip =
+  !process.env.DATABASE_URL || !process.env.REDIS_URL
+    ? 'DATABASE_URL and REDIS_URL must both be set'
+    : false
+
+async function startTestServer() {
+  const app = express()
+  app.use(express.json())
+  handler(app)
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address()
+      resolve({
+        baseUrl: `http://127.0.0.1:${port}`,
+        close: () => new Promise((res) => server.close(res)),
+      })
+    })
+  })
+}
+
+async function ensurePlayersTable(db) {
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS players (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      email VARCHAR(255) UNIQUE NOT NULL,
+      username VARCHAR(50) UNIQUE NOT NULL,
+      password_hash VARCHAR(255) NOT NULL,
+      is_verified BOOLEAN NOT NULL DEFAULT FALSE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `)
+  await db.query(`DELETE FROM players WHERE email LIKE '%@leave.spades.invalid'`)
+}
+
+async function insertVerifiedPlayer(db, { email, username, password }) {
+  const hash = await bcrypt.hash(password, 4)
+  const result = await db.query(
+    `INSERT INTO players (email, username, password_hash, is_verified)
+     VALUES ($1, $2, $3, TRUE) RETURNING id`,
+    [email, username, hash],
+  )
+  return result.rows[0].id
+}
+
+async function loginPlayer(baseUrl, email, password) {
+  const res = await fetch(`${baseUrl}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  })
+  return res.json()
+}
+
+describe('POST /api/tables/:tableId/leave', { skip }, () => {
+  let server, db, redis
+  const players = []
+
+  before(async () => {
+    db = getDb()
+    redis = await getRedis()
+    await ensurePlayersTable(db)
+    for (let i = 1; i <= 3; i++) {
+      await insertVerifiedPlayer(db, {
+        email: `leaveplayer${i}@leave.spades.invalid`,
+        username: `leave_player${i}`,
+        password: 'password123',
+      })
+    }
+    server = await startTestServer()
+    for (let i = 1; i <= 3; i++) {
+      const data = await loginPlayer(
+        server.baseUrl,
+        `leaveplayer${i}@leave.spades.invalid`,
+        'password123',
+      )
+      players.push(data)
+    }
+  })
+
+  after(async () => {
+    await server.close()
+    await closeDb()
+    await closeRedis()
+  })
+
+  it('seated player can leave a waiting table', async () => {
+    const host = players[0]
+    const other = players[1]
+
+    const createRes = await fetch(`${server.baseUrl}/api/tables`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+    })
+    assert.equal(createRes.status, 201)
+    const { tableId } = await createRes.json()
+
+    // Seat the other player
+    await fetch(`${server.baseUrl}/api/tables/${tableId}/sit`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': other.sessionId,
+        'x-player-id': other.playerId,
+      },
+      body: JSON.stringify({ seat: 'east' }),
+    })
+
+    // Other player leaves
+    const leaveRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/leave`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': other.sessionId,
+        'x-player-id': other.playerId,
+      },
+    })
+    assert.equal(leaveRes.status, 200)
+    const body = await leaveRes.json()
+    assert.ok(body.message, 'should return a message')
+
+    // Seat should now be empty
+    const stateRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
+      headers: {
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+    })
+    // Host needs to be seated to check state — seat them first
+    await fetch(`${server.baseUrl}/api/tables/${tableId}/sit`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+      body: JSON.stringify({ seat: 'north' }),
+    })
+    const stateRes2 = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
+      headers: {
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+    })
+    assert.equal(stateRes2.status, 200)
+    const stateBody = await stateRes2.json()
+    assert.equal(stateBody.seats.east, null, 'east seat should be empty after player left')
+  })
+
+  it('returns 409 if player is not seated at the table', async () => {
+    const host = players[0]
+    const unseated = players[2]
+
+    const createRes = await fetch(`${server.baseUrl}/api/tables`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+    })
+    const { tableId } = await createRes.json()
+
+    const leaveRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/leave`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': unseated.sessionId,
+        'x-player-id': unseated.playerId,
+      },
+    })
+    assert.equal(leaveRes.status, 409)
+  })
+
+  it('returns 404 for unknown tableId', async () => {
+    const host = players[0]
+    const fakeId = '00000000-0000-0000-0000-000000000000'
+    const leaveRes = await fetch(`${server.baseUrl}/api/tables/${fakeId}/leave`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+    })
+    assert.equal(leaveRes.status, 404)
+  })
+
+  it('returns 401 without auth headers', async () => {
+    const res = await fetch(`${server.baseUrl}/api/tables/some-id/leave`, {
+      method: 'POST',
+    })
+    assert.equal(res.status, 401)
+  })
+
+  it('returns 409 if game is in progress', async () => {
+    const host = players[0]
+    const p2 = players[1]
+    const p3 = players[2]
+
+    const createRes = await fetch(`${server.baseUrl}/api/tables`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+    })
+    const { tableId } = await createRes.json()
+
+    // Seat 3 humans + 1 bot to start the game
+    const seats = ['north', 'east', 'south']
+    const seated = [host, p2, p3]
+    for (let i = 0; i < 3; i++) {
+      await fetch(`${server.baseUrl}/api/tables/${tableId}/sit`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-session-id': seated[i].sessionId,
+          'x-player-id': seated[i].playerId,
+        },
+        body: JSON.stringify({ seat: seats[i] }),
+      })
+    }
+    // Add a bot to fill the last seat and start the game
+    await fetch(`${server.baseUrl}/api/tables/${tableId}/add-bot`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+      body: JSON.stringify({ seat: 'west' }),
+    })
+
+    // Game should now be in progress — try to leave
+    const leaveRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/leave`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': p2.sessionId,
+        'x-player-id': p2.playerId,
+      },
+    })
+    assert.equal(leaveRes.status, 409)
+  })
+})


### PR DESCRIPTION
Adds `POST /api/tables/:tableId/leave` endpoint that removes the requesting player from their seat on a waiting table (returns 409 if game is in progress). Replaces the non-functional "Leave table" navigation link on the waiting screen with a proper button that calls the API before redirecting to the lobby.

Generated with [Claude Code](https://claude.ai/code)