### PR TITLE
Allow players to leave in-progress games; bot fills vacated seat

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -22,7 +22,7 @@
 - [x] `P1` Build player profile page (username, avatar, career win/loss record, recent 20 games, cosmetics)
 - [x] `P1` Add logout button to the lobby screen (`client/web/src/screens/lobby.js`): calls `POST /api/auth/logout`, clears `sessionStorage`, and redirects to the login screen
 - [x] `DEV` Host terminate game — `POST /api/tables/:tableId/terminate` lets the table host immediately end a game at any point (waiting or in progress). Deletes the table and game state from Redis. All seated players are redirected to the lobby on their next poll (404 from state endpoint). A "Terminate Game" button with a browser confirm prompt is shown to the host on both the waiting screen and during active play (`server/lobby/table.js`, `server/server.js`, `client/web/src/api.js`, `client/web/src/screens/game.js`).
-- [x] `P1` Leave table — `POST /api/tables/:tableId/leave` removes the requesting player from their seat at a waiting table. Only allowed while the table status is 'waiting'; returns 409 if a game is in progress. A "Leave Table" button on the waiting screen calls this endpoint and redirects the player to the lobby on success (`server/lobby/table.js`, `server/server.js`, `client/web/src/api.js`, `client/web/src/screens/game.js`).
+- [x] `P1` Leave table — `POST /api/tables/:tableId/leave` removes the requesting player from their seat. If the table is 'waiting', the seat is vacated. If a game is in progress, the vacated seat is immediately filled by a bot (`bot:<seat>`) and the game continues uninterrupted (see PRD Section 6.4.7). A "Leave Table" button on the waiting screen calls this endpoint and redirects the player to the lobby on success (`server/lobby/table.js`, `server/server.js`, `client/web/src/api.js`, `client/web/src/screens/game.js`).
 
 ---
 
@@ -184,7 +184,7 @@
 > Do not implement. Scope defined in `docs/spades_prd.md` Section 9.
 
 - `v1.1` Spectator chat settings (no chat / separate channel / shared)
-- `v1.1` Standard bot + disconnect fill
+- `v1.1` Standard bot + disconnect fill (voluntary-leave bot-fill is already in v1.0 — see PRD Section 6.4.7; this covers network-disconnect fill and full casual-bot experience)
 - `v1.2` Solo ranked queue + MMR system
 - `v1.2` Duo ranked queue
 - `v1.3` Premium cosmetics & billing

--- a/docs/spades_prd.md
+++ b/docs/spades_prd.md
@@ -288,6 +288,10 @@ The WebSocket server uses Redis pub/sub as its broadcast bus. Each room (`table:
 2. If the player reconnects and re-authenticates within the window, they re-join the room and receive a full state re-hydration via `GET /api/tables/:tableId/state`.
 3. If the reconnect window expires: the game stalls for other players with a "waiting for reconnect" indicator. The v1.1 disconnect-fill bot (see [Section 9](#9-post-launch-roadmap)) takes over at the start of the next hand once this infrastructure is in place.
 
+#### 6.4.7 Player-Initiated Leave During In-Progress Game
+
+**Decision (recorded April 2026):** When a seated player calls `POST /api/tables/:tableId/leave` while a game is in progress, the server immediately replaces the vacated seat with a bot (`bot:<seat>`). The bot takes over from the current game state and plays automatically for the remainder of the game using the existing bot logic. This is distinct from the v1.1 disconnect-fill, which applies only on network disconnect and activates at the start of the next hand. The voluntary-leave bot-fill is in scope for v1.0.
+
 ---
 
 ## 7. Open Questions
@@ -344,6 +348,8 @@ A rule-based AI opponent that plays legal, competent Spades. Serves two purposes
 - **Disconnect fill** — when a player disconnects and does not reconnect by the start of the next hand, a bot takes their seat for that hand. The player may rejoin at the start of any subsequent hand.
 
 Table host may configure: bot fill on disconnect only, always allow bots, or no bots.
+
+> **Note:** Voluntary-leave bot-fill (player presses "Leave Table" during an in-progress game) was promoted to v1.0 scope (see Section 6.4.7). This v1.1 item covers disconnect-fill and the full casual-bot experience only.
 
 ---
 

--- a/docs/spades_prd.md
+++ b/docs/spades_prd.md
@@ -286,11 +286,11 @@ The WebSocket server uses Redis pub/sub as its broadcast bus. Each room (`table:
 
 1. When a WebSocket connection drops (ping failure or clean close), the server emits `PLAYER_DISCONNECTED` to the room with a countdown (default 60 seconds).
 2. If the player reconnects and re-authenticates within the window, they re-join the room and receive a full state re-hydration via `GET /api/tables/:tableId/state`.
-3. If the reconnect window expires: the game stalls for other players with a "waiting for reconnect" indicator. The v1.1 disconnect-fill bot (see [Section 9](#9-post-launch-roadmap)) takes over at the start of the next hand once this infrastructure is in place.
+3. If the reconnect window expires: the v1.1 disconnect-fill bot (see [Section 9](#9-post-launch-roadmap)) immediately takes over the disconnected player's seat so the current hand can continue. If the player reconnects mid-hand, they are placed in spectator mode and may rejoin as an active player at the start of the next hand once this infrastructure is in place.
 
 #### 6.4.7 Player-Initiated Leave During In-Progress Game
 
-**Decision (recorded April 2026):** When a seated player calls `POST /api/tables/:tableId/leave` while a game is in progress, the server immediately replaces the vacated seat with a bot (`bot:<seat>`). The bot takes over from the current game state and plays automatically for the remainder of the game using the existing bot logic. This is distinct from the v1.1 disconnect-fill, which applies only on network disconnect and activates at the start of the next hand. The voluntary-leave bot-fill is in scope for v1.0.
+**Decision (recorded April 2026):** When a seated player calls `POST /api/tables/:tableId/leave` while a game is in progress, the server immediately replaces the vacated seat with a bot (`bot:<seat>`). The bot takes over from the current game state and plays automatically for the remainder of the game using the existing bot logic. This is distinct from the v1.1 disconnect-fill, which applies only on network disconnect: the bot fills immediately when the reconnect window expires so the current hand can continue; if the player reconnects mid-hand they are placed in spectator mode and may rejoin as an active player at the start of the next hand. The voluntary-leave bot-fill is in scope for v1.0.
 
 ---
 
@@ -345,7 +345,7 @@ Default to be decided before v1.1 ships.
 A rule-based AI opponent that plays legal, competent Spades. Serves two purposes:
 
 - **Casual play opponent** — players may sit down against bots intentionally.
-- **Disconnect fill** — when a player disconnects and does not reconnect by the start of the next hand, a bot takes their seat for that hand. The player may rejoin at the start of any subsequent hand.
+- **Disconnect fill** — when a player disconnects and the reconnect window expires, a bot immediately takes their seat so the current hand can continue. If the player reconnects mid-hand, they are placed in spectator mode and may rejoin as an active player at the start of any subsequent hand.
 
 Table host may configure: bot fill on disconnect only, always allow bots, or no bots.
 

--- a/server/lobby/table.js
+++ b/server/lobby/table.js
@@ -201,33 +201,41 @@ export async function removePlayerFromTables(redis, playerId) {
 }
 
 /**
- * Remove the requesting player from a waiting table's seat.
- * Only allowed while the table is in 'waiting' status — in-progress games
- * require separate disconnect handling.
+ * Remove the requesting player from a table's seat.
+ *
+ * - If the table is 'waiting': the seat is vacated (set to null).
+ * - If the table is 'playing': the seat is taken over by a bot (`bot:<seat>`)
+ *   so the game can continue uninterrupted (see PRD Section 6.4.7).
  *
  * @param {import('redis').RedisClientType} redis
  * @param {string} tableId
  * @param {string} playerId
- * @returns {Promise<TableState>}
- * @throws {Error} If the table is not found, game is in progress, or player is not seated
+ * @returns {Promise<{ table: TableState, seat: string, wasPlaying: boolean }>}
+ * @throws {Error} If the table is not found or the player is not seated
  */
 export async function leaveTable(redis, tableId, playerId) {
   const table = await getTable(redis, tableId)
   if (!table) {
     throw Object.assign(new Error('Table not found'), { code: 'NOT_FOUND' })
   }
-  if (table.status === 'playing') {
-    throw Object.assign(new Error('Cannot leave a game in progress'), { code: 'GAME_IN_PROGRESS' })
-  }
   const seatEntry = Object.entries(table.seats).find(([, id]) => id === playerId)
   if (!seatEntry) {
     throw Object.assign(new Error('You are not seated at this table'), { code: 'NOT_SEATED' })
   }
   const [seat] = seatEntry
+
+  if (table.status === 'playing') {
+    const botId = `bot:${seat}`
+    const updated = { ...table, seats: { ...table.seats, [seat]: botId } }
+    await saveTable(redis, updated)
+    console.log('Player left in-progress game, replaced by bot:', { tableId, playerId, seat, botId })
+    return { table: updated, seat, wasPlaying: true }
+  }
+
   const updated = { ...table, seats: { ...table.seats, [seat]: null } }
   await saveTable(redis, updated)
-  console.log('Player left table:', { tableId, playerId, seat })
-  return updated
+  console.log('Player left waiting table:', { tableId, playerId, seat })
+  return { table: updated, seat, wasPlaying: false }
 }
 
 /**

--- a/server/server.js
+++ b/server/server.js
@@ -367,19 +367,30 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
     }
   })
 
-  // POST /api/tables/:tableId/leave — leave a waiting table (removes player from their seat)
+  // POST /api/tables/:tableId/leave — leave a table (bot fills seat if game is in progress)
   app.post('/api/tables/:tableId/leave', async (req, res) => {
     const { tableId } = req.params
     try {
       const redisClient = await getRedis()
       const session = await validateAuthHeaders(redisClient, req)
-      await leaveTable(redisClient, tableId, session.playerId)
-      console.log('Player left table:', { tableId, playerId: session.playerId })
+      const { seat, wasPlaying } = await leaveTable(redisClient, tableId, session.playerId)
+
+      if (wasPlaying) {
+        // Replace player with bot in the game state and advance any consecutive bot turns
+        let gameState = await getGameState(redisClient, tableId)
+        if (gameState && gameState.phase !== 'game_over') {
+          gameState = { ...gameState, players: { ...gameState.players, [seat]: `bot:${seat}` } }
+          gameState = advanceBotTurns(gameState)
+          await saveGameState(redisClient, tableId, gameState)
+          console.log('Bot filled vacated seat and advanced turns:', { tableId, seat })
+        }
+      }
+
+      console.log('Player left table:', { tableId, playerId: session.playerId, seat, wasPlaying })
       sendJSON(res, 200, { message: 'Left table.' })
     } catch (err) {
       if (err.code === 'UNAUTHORIZED') return sendJSON(res, 401, { error: err.message })
       if (err.code === 'NOT_FOUND') return sendJSON(res, 404, { error: err.message })
-      if (err.code === 'GAME_IN_PROGRESS') return sendJSON(res, 409, { error: err.message })
       if (err.code === 'NOT_SEATED') return sendJSON(res, 409, { error: err.message })
       console.error('Leave table error:', { tableId, error: err.message })
       sendJSON(res, 500, { error: 'Internal server error' })

--- a/test/integration/game/leaveTable.test.js
+++ b/test/integration/game/leaveTable.test.js
@@ -209,7 +209,7 @@ describe('POST /api/tables/:tableId/leave', { skip }, () => {
     assert.equal(res.status, 401)
   })
 
-  it('returns 409 if game is in progress', async () => {
+  it('player leaving an in-progress game is replaced by a bot and game continues', async () => {
     const host = players[0]
     const p2 = players[1]
     const p3 = players[2]
@@ -249,7 +249,7 @@ describe('POST /api/tables/:tableId/leave', { skip }, () => {
       body: JSON.stringify({ seat: 'west' }),
     })
 
-    // Game should now be in progress — try to leave
+    // Game should now be in progress — p2 (east seat) leaves
     const leaveRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/leave`, {
       method: 'POST',
       headers: {
@@ -258,6 +258,26 @@ describe('POST /api/tables/:tableId/leave', { skip }, () => {
         'x-player-id': p2.playerId,
       },
     })
-    assert.equal(leaveRes.status, 409)
+    assert.equal(leaveRes.status, 200)
+
+    // The vacated seat should now be occupied by a bot
+    const stateRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
+      headers: {
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+    })
+    assert.equal(stateRes.status, 200)
+    const stateBody = await stateRes.json()
+    assert.equal(stateBody.seats.east, 'bot:east', 'east seat should be occupied by bot:east')
+
+    // p2 should no longer be able to get state (not seated)
+    const p2StateRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
+      headers: {
+        'x-session-id': p2.sessionId,
+        'x-player-id': p2.playerId,
+      },
+    })
+    assert.equal(p2StateRes.status, 403)
   })
 })


### PR DESCRIPTION
When a player calls `POST /api/tables/:tableId/leave` during an in-progress game, their seat is now immediately taken over by a bot (`bot:<seat>`) and the game continues uninterrupted. Previously this returned 409.

Closes #198

Generated with [Claude Code](https://claude.ai/code)) · [`claude/issue-198-20260403-2310`](https://github.com/dantonel/spades/tree/claude/issue-198-20260403-2310