### PR TITLE
fix: leave in-progress game — bot substitution, host reassignment, auto-terminate

### DIFF
--- a/server/game/state.js
+++ b/server/game/state.js
@@ -10,6 +10,7 @@ import {
 } from './bid.js'
 import { getLegalPlays, determineTrickWinner, isCardLegal } from './trick.js'
 import { scoreHand, applyBagPenalties, checkWinLoss } from './score.js'
+import { isBot, getBotPlayerId, botBid, botPlay, botBlindNilExchange } from './bot.js'
 
 /** Seats in clockwise order starting from north. */
 export const CLOCKWISE_SEATS = ['north', 'east', 'south', 'west']
@@ -517,4 +518,59 @@ export function getPlayerView(state, seat) {
     // Include played cards from the current trick (visible to all)
     // Do NOT include other players' unplayed hands
   }
+}
+
+/**
+ * Automatically advance the game state through any consecutive bot turns.
+ * Loops until it is a human player's turn or the game is over.
+ *
+ * @param {object} state - Current game state
+ * @returns {object} Updated game state after all bot actions are applied
+ */
+export function advanceBotTurns(state) {
+  let current = state
+  while (true) {
+    if (current.phase === 'bidding') {
+      const seat = current.currentBidderSeat
+      if (!seat || !isBot(current.players[seat])) break
+      const partnerSeat = getPartnerSeat(seat)
+      const partnerBid = current.bids[partnerSeat]
+      const bid = botBid(current.hands[seat], partnerBid)
+      console.log('Bot bid:', { seat, bid, tableId: current.tableId })
+      current = placeBid(current, seat, bid)
+    } else if (current.phase === 'playing') {
+      const seat = current.currentPlayerSeat
+      if (!seat || !isBot(current.players[seat])) break
+      const card = botPlay(current.hands[seat], current.currentTrick, current.spadesbroken, current.isFirstTrick)
+      console.log('Bot play:', { seat, card, tableId: current.tableId })
+      current = playCard(current, seat, card)
+    } else if (current.phase === 'blind_nil_exchange') {
+      const { currentBlindNilSeat, step } = current.blindNilExchange
+      // Bots never bid blind nil, so they can only act as the partner (step: partner_to_blind)
+      if (step !== 'partner_to_blind') break
+      const partnerSeat = getPartnerSeat(currentBlindNilSeat)
+      if (!isBot(current.players[partnerSeat])) break
+      const cards = botBlindNilExchange(current.hands[partnerSeat])
+      console.log('Bot blind nil exchange:', { seat: partnerSeat, cards, tableId: current.tableId })
+      current = submitBlindNilExchange(current, partnerSeat, cards)
+    } else {
+      // game_over — nothing to auto-advance
+      break
+    }
+  }
+  return current
+}
+
+/**
+ * Replace a human player at the given seat with a bot and advance any bot turns.
+ * Called when a human leaves an in-progress game.
+ *
+ * @param {object} gameState - Current game state
+ * @param {string} seat - The seat being vacated
+ * @returns {object} Updated game state with the bot seated and all immediate bot turns applied
+ */
+export function substitutePlayerWithBot(gameState, seat) {
+  const botId = getBotPlayerId(seat)
+  const withBot = { ...gameState, players: { ...gameState.players, [seat]: botId } }
+  return advanceBotTurns(withBot)
 }

--- a/server/lobby/table.js
+++ b/server/lobby/table.js
@@ -231,6 +231,49 @@ export async function leaveTable(redis, tableId, playerId) {
 }
 
 /**
+ * Remove a human player from an in-progress game by replacing them with a bot.
+ * If the departing player is the host, reassigns host to the next seated human.
+ * If no human players remain after substitution, the table is terminated.
+ *
+ * @param {import('redis').RedisClientType} redis
+ * @param {string} tableId
+ * @param {string} playerId
+ * @returns {Promise<{ terminated: true, seat: string } | { table: TableState, seat: string, botId: string, wasPlaying: true }>}
+ * @throws {Error} If the table is not found, game is not in progress, or player is not seated
+ */
+export async function leaveInProgressGame(redis, tableId, playerId) {
+  const table = await getTable(redis, tableId)
+  if (!table) {
+    throw Object.assign(new Error('Table not found'), { code: 'NOT_FOUND' })
+  }
+  if (table.status !== 'playing') {
+    throw Object.assign(new Error('Game is not in progress'), { code: 'NOT_IN_PROGRESS' })
+  }
+  const seatEntry = Object.entries(table.seats).find(([, id]) => id === playerId)
+  if (!seatEntry) {
+    throw Object.assign(new Error('You are not seated at this table'), { code: 'NOT_SEATED' })
+  }
+  const [seat] = seatEntry
+  const botId = `bot:${seat}`
+  const updatedSeats = { ...table.seats, [seat]: botId }
+
+  // If no humans remain after substitution, terminate the table
+  const remainingHuman = Object.values(updatedSeats).find((id) => id && !id.startsWith('bot:'))
+  if (!remainingHuman) {
+    await terminateTable(redis, tableId)
+    console.log('Table terminated — no human players remain:', { tableId, playerId, seat })
+    return { terminated: true, seat }
+  }
+
+  // Reassign host to a remaining human if the departing player was the host
+  const newHostId = table.hostPlayerId === playerId ? remainingHuman : table.hostPlayerId
+  const updated = { ...table, seats: updatedSeats, hostPlayerId: newHostId }
+  await saveTable(redis, updated)
+  console.log('Player left in-progress game, replaced by bot:', { tableId, playerId, seat, botId })
+  return { table: updated, seat, botId, wasPlaying: true }
+}
+
+/**
  * Terminate a table and its associated game state, removing all Redis keys.
  * Used by the host to forcibly end a game at any point (waiting or in progress).
  *

--- a/server/server.js
+++ b/server/server.js
@@ -21,55 +21,13 @@ import {
   terminateTable,
   findTableForPlayer,
   leaveTable,
+  leaveInProgressGame,
 } from './lobby/table.js'
-import { createGame, placeBid, playCard, submitBlindNilExchange, revealHand, getPlayerView } from './game/state.js'
-import { getPartnerSeat } from './game/bid.js'
+import { createGame, placeBid, playCard, submitBlindNilExchange, revealHand, getPlayerView, advanceBotTurns, substitutePlayerWithBot } from './game/state.js'
 import { getSeatForPlayer, validateCardPlay, validateBidTurn } from './anticheat/validate.js'
-import { isBot, botBid, botPlay, botBlindNilExchange } from './game/bot.js'
 
 function sendJSON(res, statusCode, data) {
   res.status(statusCode).json(data)
-}
-
-/**
- * Automatically advance the game state through any consecutive bot turns.
- * Loops until it is a human player's turn or the game is over.
- *
- * @param {object} state - Current game state
- * @returns {object} Updated game state after all bot actions are applied
- */
-function advanceBotTurns(state) {
-  let current = state
-  while (true) {
-    if (current.phase === 'bidding') {
-      const seat = current.currentBidderSeat
-      if (!seat || !isBot(current.players[seat])) break
-      const partnerSeat = getPartnerSeat(seat)
-      const partnerBid = current.bids[partnerSeat]
-      const bid = botBid(current.hands[seat], partnerBid)
-      console.log('Bot bid:', { seat, bid, tableId: current.tableId })
-      current = placeBid(current, seat, bid)
-    } else if (current.phase === 'playing') {
-      const seat = current.currentPlayerSeat
-      if (!seat || !isBot(current.players[seat])) break
-      const card = botPlay(current.hands[seat], current.currentTrick, current.spadesbroken, current.isFirstTrick)
-      console.log('Bot play:', { seat, card, tableId: current.tableId })
-      current = playCard(current, seat, card)
-    } else if (current.phase === 'blind_nil_exchange') {
-      const { currentBlindNilSeat, step } = current.blindNilExchange
-      // Bots never bid blind nil, so they can only act as the partner (step: partner_to_blind)
-      if (step !== 'partner_to_blind') break
-      const partnerSeat = getPartnerSeat(currentBlindNilSeat)
-      if (!isBot(current.players[partnerSeat])) break
-      const cards = botBlindNilExchange(current.hands[partnerSeat])
-      console.log('Bot blind nil exchange:', { seat: partnerSeat, cards, tableId: current.tableId })
-      current = submitBlindNilExchange(current, partnerSeat, cards)
-    } else {
-      // game_over — nothing to auto-advance
-      break
-    }
-  }
-  return current
 }
 
 /**
@@ -367,19 +325,36 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
     }
   })
 
-  // POST /api/tables/:tableId/leave — leave a waiting table (removes player from their seat)
+  // POST /api/tables/:tableId/leave — leave a table (waiting: removes seat; in-progress: replaces with bot)
   app.post('/api/tables/:tableId/leave', async (req, res) => {
     const { tableId } = req.params
     try {
       const redisClient = await getRedis()
       const session = await validateAuthHeaders(redisClient, req)
+      const table = await getTable(redisClient, tableId)
+      if (!table) return sendJSON(res, 404, { error: 'Table not found.' })
+
+      if (table.status === 'playing') {
+        const result = await leaveInProgressGame(redisClient, tableId, session.playerId)
+        if (result.terminated) {
+          console.log('Player left in-progress game, table terminated:', { tableId, playerId: session.playerId })
+          return sendJSON(res, 200, { message: 'Left game. No human players remain — table terminated.' })
+        }
+        const gameState = await getGameState(redisClient, tableId)
+        if (gameState) {
+          const newState = substitutePlayerWithBot(gameState, result.seat)
+          await saveGameState(redisClient, tableId, newState)
+        }
+        console.log('Player left in-progress game:', { tableId, playerId: session.playerId, seat: result.seat })
+        return sendJSON(res, 200, { message: 'Left game. A bot has taken your place.' })
+      }
+
       await leaveTable(redisClient, tableId, session.playerId)
       console.log('Player left table:', { tableId, playerId: session.playerId })
       sendJSON(res, 200, { message: 'Left table.' })
     } catch (err) {
       if (err.code === 'UNAUTHORIZED') return sendJSON(res, 401, { error: err.message })
       if (err.code === 'NOT_FOUND') return sendJSON(res, 404, { error: err.message })
-      if (err.code === 'GAME_IN_PROGRESS') return sendJSON(res, 409, { error: err.message })
       if (err.code === 'NOT_SEATED') return sendJSON(res, 409, { error: err.message })
       console.error('Leave table error:', { tableId, error: err.message })
       sendJSON(res, 500, { error: 'Internal server error' })

--- a/test/integration/game/leaveTable.test.js
+++ b/test/integration/game/leaveTable.test.js
@@ -209,7 +209,7 @@ describe('POST /api/tables/:tableId/leave', { skip }, () => {
     assert.equal(res.status, 401)
   })
 
-  it('returns 409 if game is in progress', async () => {
+  it('human can leave an in-progress game — bot takes their seat', async () => {
     const host = players[0]
     const p2 = players[1]
     const p3 = players[2]
@@ -238,7 +238,6 @@ describe('POST /api/tables/:tableId/leave', { skip }, () => {
         body: JSON.stringify({ seat: seats[i] }),
       })
     }
-    // Add a bot to fill the last seat and start the game
     await fetch(`${server.baseUrl}/api/tables/${tableId}/add-bot`, {
       method: 'POST',
       headers: {
@@ -249,7 +248,7 @@ describe('POST /api/tables/:tableId/leave', { skip }, () => {
       body: JSON.stringify({ seat: 'west' }),
     })
 
-    // Game should now be in progress — try to leave
+    // p2 (east) leaves the in-progress game
     const leaveRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/leave`, {
       method: 'POST',
       headers: {
@@ -258,6 +257,138 @@ describe('POST /api/tables/:tableId/leave', { skip }, () => {
         'x-player-id': p2.playerId,
       },
     })
-    assert.equal(leaveRes.status, 409)
+    assert.equal(leaveRes.status, 200)
+    const body = await leaveRes.json()
+    assert.ok(body.message)
+
+    // Host should still be able to get game state (east seat is now a bot)
+    const stateRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
+      headers: {
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+    })
+    assert.equal(stateRes.status, 200)
+    const stateBody = await stateRes.json()
+    assert.equal(stateBody.players.east, 'bot:east', 'east seat should be occupied by a bot')
+  })
+
+  it('host leaving in-progress game reassigns host to remaining human', async () => {
+    const host = players[0]
+    const p2 = players[1]
+    const p3 = players[2]
+
+    const createRes = await fetch(`${server.baseUrl}/api/tables`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+    })
+    const { tableId } = await createRes.json()
+
+    const seats = ['north', 'east', 'south']
+    const seated = [host, p2, p3]
+    for (let i = 0; i < 3; i++) {
+      await fetch(`${server.baseUrl}/api/tables/${tableId}/sit`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-session-id': seated[i].sessionId,
+          'x-player-id': seated[i].playerId,
+        },
+        body: JSON.stringify({ seat: seats[i] }),
+      })
+    }
+    await fetch(`${server.baseUrl}/api/tables/${tableId}/add-bot`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+      body: JSON.stringify({ seat: 'west' }),
+    })
+
+    // Host (north) leaves — host should be reassigned
+    const leaveRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/leave`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+    })
+    assert.equal(leaveRes.status, 200)
+
+    // p2 (east) should now be the host — they can terminate the game
+    const terminateRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/terminate`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': p2.sessionId,
+        'x-player-id': p2.playerId,
+      },
+    })
+    assert.equal(terminateRes.status, 200, 'new host should be able to terminate the game')
+  })
+
+  it('last human leaving in-progress game terminates the table', async () => {
+    const host = players[0]
+
+    const createRes = await fetch(`${server.baseUrl}/api/tables`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+    })
+    const { tableId } = await createRes.json()
+
+    // Seat host at north, fill remaining 3 seats with bots
+    await fetch(`${server.baseUrl}/api/tables/${tableId}/sit`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+      body: JSON.stringify({ seat: 'north' }),
+    })
+    for (const seat of ['east', 'south', 'west']) {
+      await fetch(`${server.baseUrl}/api/tables/${tableId}/add-bot`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-session-id': host.sessionId,
+          'x-player-id': host.playerId,
+        },
+        body: JSON.stringify({ seat }),
+      })
+    }
+
+    // Host (only human) leaves — table should be terminated
+    const leaveRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/leave`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+    })
+    assert.equal(leaveRes.status, 200)
+    const body = await leaveRes.json()
+    assert.ok(body.message.includes('terminated'), 'response should mention termination')
+
+    // Table should no longer exist
+    const stateRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
+      headers: {
+        'x-session-id': host.sessionId,
+        'x-player-id': host.playerId,
+      },
+    })
+    assert.equal(stateRes.status, 404, 'table should be gone after last human leaves')
   })
 })

--- a/test/unit/game/state.test.js
+++ b/test/unit/game/state.test.js
@@ -6,6 +6,8 @@ import {
   playCard,
   submitBlindNilExchange,
   getPlayerView,
+  advanceBotTurns,
+  substitutePlayerWithBot,
   CLOCKWISE_SEATS,
 } from '../../../server/game/state.js'
 
@@ -788,5 +790,67 @@ describe('game over — phase transition', () => {
     assert.ok('bags' in view, 'view should include bags')
     assert.ok(!('hands' in view), 'view must not expose the full hands object')
     assert.ok('myHand' in view, 'view must expose myHand for the requesting player')
+  })
+})
+
+const HUMAN_PLAYERS = {
+  north: 'player-north',
+  east: 'player-east',
+  south: 'player-south',
+  west: 'player-west',
+}
+
+describe('substitutePlayerWithBot', () => {
+  it('replaces the human player with a bot at the given seat', () => {
+    const state = createGame('table-1', HUMAN_PLAYERS)
+    const updated = substitutePlayerWithBot(state, 'east')
+    assert.equal(updated.players.east, 'bot:east')
+    assert.equal(updated.players.north, 'player-north')
+    assert.equal(updated.players.south, 'player-south')
+    assert.equal(updated.players.west, 'player-west')
+  })
+
+  it('does not mutate the original state', () => {
+    const state = createGame('table-1', HUMAN_PLAYERS)
+    substitutePlayerWithBot(state, 'east')
+    assert.equal(state.players.east, 'player-east', 'original state must not be mutated')
+  })
+
+  it('advances bot turns immediately after substitution when all remaining bidders are bots', () => {
+    const allBotsExceptNorth = {
+      north: 'player-north',
+      east: 'bot:east',
+      south: 'bot:south',
+      west: 'bot:west',
+    }
+    const state = createGame('table-1', allBotsExceptNorth)
+    assert.equal(state.phase, 'bidding')
+    assert.equal(state.currentBidderSeat, 'north')
+
+    const updated = substitutePlayerWithBot(state, 'north')
+    assert.notEqual(updated.phase, 'bidding', 'bidding should complete when all seats are bots')
+  })
+})
+
+describe('advanceBotTurns', () => {
+  it('returns state unchanged when current bidder is human', () => {
+    const state = createGame('table-1', HUMAN_PLAYERS)
+    assert.equal(state.phase, 'bidding')
+    const result = advanceBotTurns(state)
+    assert.equal(result.phase, 'bidding')
+    assert.equal(result.currentBidderSeat, state.currentBidderSeat)
+  })
+
+  it('advances past bot bidders automatically after a human bids', () => {
+    const players = {
+      north: 'player-north',
+      east: 'bot:east',
+      south: 'bot:south',
+      west: 'bot:west',
+    }
+    let state = createGame('table-1', players)
+    state = placeBid(state, 'north', 3)
+    const result = advanceBotTurns(state)
+    assert.notEqual(result.phase, 'bidding', 'all bot bids should be resolved')
   })
 })

--- a/test/unit/game/state.test.js
+++ b/test/unit/game/state.test.js
@@ -825,7 +825,7 @@ describe('substitutePlayerWithBot', () => {
     }
     const state = createGame('table-1', allBotsExceptNorth)
     assert.equal(state.phase, 'bidding')
-    assert.equal(state.currentBidderSeat, 'north')
+    assert.equal(state.currentBidderSeat, 'east')
 
     const updated = substitutePlayerWithBot(state, 'north')
     assert.notEqual(updated.phase, 'bidding', 'bidding should complete when all seats are bots')


### PR DESCRIPTION
Fixes the two issues found in the PR review (#202) plus the requested no-humans termination:

- Extract `advanceBotTurns` from `server.js` into `server/game/state.js` and add `substitutePlayerWithBot(gameState, seat)` per the CLAUDE.md rule that game logic must live in `server/game/`
- Add `leaveInProgressGame` to `server/lobby/table.js`: replaces the departing player with a bot, reassigns host if the host is leaving, and terminates the table when no human players remain
- `POST /api/tables/:tableId/leave` now succeeds for in-progress games instead of returning 409
- Integration and unit tests for all new behaviour

Closes #202

Generated with [Claude Code](https://claude.ai/code)