### PR TITLE
fix: fix advanceBotTurns test - player sits at east not north

### DIFF
--- a/test/unit/game/state.test.js
+++ b/test/unit/game/state.test.js
@@ -843,13 +843,13 @@ describe('advanceBotTurns', () => {
 
   it('advances past bot bidders automatically after a human bids', () => {
     const players = {
-      north: 'player-north',
-      east: 'bot:east',
+      north: 'bot:north',
+      east: 'player-east',
       south: 'bot:south',
       west: 'bot:west',
     }
     let state = createGame('table-1', players)
-    state = placeBid(state, 'north', 3)
+    state = placeBid(state, 'east', 3)
     const result = advanceBotTurns(state)
     assert.notEqual(result.phase, 'bidding', 'all bot bids should be resolved')
   })


### PR DESCRIPTION
Fix failing test in `test/unit/game/state.test.js`: the `advanceBotTurns` test was placing a bid as `north` (the dealer), but bidding starts with `east` (left of dealer). Fixed by making east the human player and bidding from east.

Closes #206

Generated with [Claude Code](https://claude.ai/code)