### PR TITLE
fix: block DEV_AUTO_VERIFY in NODE_ENV=production

### DIFF
--- a/server/auth/registration.js
+++ b/server/auth/registration.js
@@ -45,8 +45,13 @@ export async function registerPlayer(db, { email, username, password }, sendVeri
   const passwordHash = await hashPassword(password)
 
   // DEV_AUTO_VERIFY=true skips email verification entirely — for local testing only.
-  // Never set this in production.
-  const autoVerify = process.env.DEV_AUTO_VERIFY === 'true'
+  // Blocked unconditionally in production even if the env var is set, so it can
+  // never accidentally reach a production deployment.
+  if (process.env.DEV_AUTO_VERIFY === 'true' && process.env.NODE_ENV === 'production') {
+    console.warn('DEV_AUTO_VERIFY is set but has no effect in NODE_ENV=production')
+  }
+  const autoVerify =
+    process.env.NODE_ENV !== 'production' && process.env.DEV_AUTO_VERIFY === 'true'
 
   let player
   try {

--- a/test/unit/auth/registration.test.js
+++ b/test/unit/auth/registration.test.js
@@ -203,6 +203,27 @@ describe('registerPlayer — DEV_AUTO_VERIFY', () => {
     assert.equal(playerInsert.params[3], true)
   })
 
+  it('does NOT skip verification when NODE_ENV=production, even if DEV_AUTO_VERIFY=true', async () => {
+    process.env.DEV_AUTO_VERIFY = 'true'
+    process.env.NODE_ENV = 'production'
+    const emailsSent = []
+    const db = {
+      query: async (sql) => {
+        if (sql.includes('INSERT INTO players')) return { rows: [{ id: 'prod-id' }] }
+        return { rows: [] }
+      },
+    }
+    await registerPlayer(
+      db,
+      { email: 'prod@example.com', username: 'produser', password: 'password123' },
+      async (email) => emailsSent.push(email),
+    )
+    delete process.env.DEV_AUTO_VERIFY
+    delete process.env.NODE_ENV
+
+    assert.equal(emailsSent.length, 1, 'should still send verification email in production')
+  })
+
   it('sends email normally when DEV_AUTO_VERIFY is not set', async () => {
     delete process.env.DEV_AUTO_VERIFY
     const emailsSent = []


### PR DESCRIPTION
The existing DEV_AUTO_VERIFY env var skips email verification for local development, but had no production guard. This PR adds a NODE_ENV !== 'production' check so the flag is inert in production regardless of how the env var is configured, plus a console.warn and a unit test covering the production-block path.

Closes #208

Generated with [Claude Code](https://claude.ai/code)