### PR TITLE
feat: auto-login on registration when DEV_AUTO_VERIFY is active

### DIFF
--- a/server/auth/registration.js
+++ b/server/auth/registration.js
@@ -77,7 +77,7 @@ export async function registerPlayer(db, { email, username, password }, sendVeri
 
   if (autoVerify) {
     console.log('DEV_AUTO_VERIFY: skipped email verification for player', player.id)
-    return { playerId: player.id }
+    return { playerId: player.id, email: normalizedEmail, username: trimmedUsername, autoVerified: true }
   }
 
   const token = generateVerificationToken()

--- a/server/server.js
+++ b/server/server.js
@@ -50,6 +50,19 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
     try {
       const db = getDb()
       const result = await registerPlayer(db, { email, username, password }, emailer)
+      if (result.autoVerified) {
+        const redis = await getRedis()
+        const sessionId = await createSession(redis, {
+          playerId: result.playerId,
+          email: result.email,
+          username: result.username,
+        })
+        return sendJSON(res, 201, {
+          sessionId,
+          playerId: result.playerId,
+          username: result.username,
+        })
+      }
       sendJSON(res, 201, {
         message: 'Registration successful. Please check your email to verify your account.',
         playerId: result.playerId,

--- a/test/unit/auth/registration.test.js
+++ b/test/unit/auth/registration.test.js
@@ -195,6 +195,9 @@ describe('registerPlayer — DEV_AUTO_VERIFY', () => {
     delete process.env.DEV_AUTO_VERIFY
 
     assert.equal(result.playerId, 'auto-id')
+    assert.equal(result.autoVerified, true, 'should return autoVerified: true')
+    assert.equal(result.email, 'dev@example.com', 'should return normalised email')
+    assert.equal(result.username, 'devuser', 'should return username')
     assert.equal(emailsSent.length, 0, 'should not send verification email')
     const tokenInsert = queries.find((q) => q.sql.includes('email_verification_tokens'))
     assert.ok(!tokenInsert, 'should not insert a verification token')


### PR DESCRIPTION
When DEV_AUTO_VERIFY bypasses email verification, the register endpoint now creates a session and returns `sessionId`, `playerId`, `username` — identical to the login response shape — so the client goes straight to logged-in state without a separate login call.

Closes #208

Generated with [Claude Code](https://claude.ai/code)