### PR TITLE
feat: redirect to lobby on auto-verified registration

### DIFF
--- a/client/web/src/screens/register.js
+++ b/client/web/src/screens/register.js
@@ -1,5 +1,6 @@
 import { validateRegisterForm } from '../validation.js'
 import { registerUser, resendVerification } from '../api.js'
+import { navigate } from '../router.js'
 
 /**
  * Render the registration screen into `container`.
@@ -70,7 +71,17 @@ export function renderRegisterScreen(container) {
     btn.textContent = 'Creating account\u2026'
 
     try {
-      await registerUser({ email, username, password })
+      const result = await registerUser({ email, username, password })
+
+      if (result.sessionId) {
+        sessionStorage.setItem('sessionId', result.sessionId)
+        sessionStorage.setItem('playerId', result.playerId)
+        sessionStorage.setItem('username', result.username)
+        console.log('Auto-verified registration, going to lobby:', { playerId: result.playerId, username: result.username })
+        navigate('#/lobby')
+        return
+      }
+
       const safeEmail = escapeHtml(email)
       container.innerHTML = `
         <div class="auth-card">

--- a/test/unit/web/api.test.js
+++ b/test/unit/web/api.test.js
@@ -22,6 +22,16 @@ describe('registerUser', () => {
     assert.equal(result.playerId, 'uuid-123')
   })
 
+  it('resolves with sessionId and username when DEV_AUTO_VERIFY is active', async () => {
+    const result = await registerUser(
+      { email: 'a@b.com', username: 'alice', password: 'password123' },
+      mockFetch(201, { sessionId: 'sess-abc', playerId: 'uuid-123', username: 'alice' }),
+    )
+    assert.equal(result.sessionId, 'sess-abc')
+    assert.equal(result.playerId, 'uuid-123')
+    assert.equal(result.username, 'alice')
+  })
+
   it('throws with status 409 on duplicate email/username', async () => {
     await assert.rejects(
       () =>


### PR DESCRIPTION
When DEV_AUTO_VERIFY bypasses email verification, the register screen now stores the session and navigates to #/lobby — matching the normal login flow. The "check your email" path is unchanged.

Closes #208

Generated with [Claude Code](https://claude.ai/code)