### PR TITLE
fix: preserve hand context during 13th-trick hold for non-final hands

### DIFF
--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -11,7 +11,7 @@ import {
 import { navigate } from '../router.js'
 import { handSpreadHtml, handDiagramHtml, lastTrickHtml } from '../hand.js'
 import { relSeats } from '../seatUtils.js'
-import { HOLD_DURATIONS, detectCompletedTrick, trickHoldHtml } from '../trickHold.js'
+import { HOLD_DURATIONS, detectCompletedTrick, isHandTransition, trickHoldHtml } from '../trickHold.js'
 import { createInputBlocker } from '../inputBlock.js'
 import { endOfHandSummaryHtml } from '../endOfHandSummary.js'
 import { BAG_ICON } from '../icons.js'
@@ -276,12 +276,27 @@ export function renderGameScreen(container) {
         } else {
           const prevState = state
           const completedTrick = detectCompletedTrick(prevState, s)
-          state = s
           if (completedTrick) {
             // A trick completed while we were polling — trigger the hold so all
             // players (not just the one who played the last card) see the result.
+            //
+            // If this was the 13th trick of a non-final hand (handHistory grew
+            // and state advanced to the next hand's bidding phase), keep rendering
+            // prevState during the hold so the player sees the 13th trick in its
+            // original hand context rather than the new hand's bidding screen.
+            // For game_over the 13th trick is detected via completedTricks growth
+            // (not reset), so state = s is safe there.
+            if (!isHandTransition(prevState, s)) {
+              state = s
+            }
             startHold(completedTrick)
+            if (isHandTransition(prevState, s)) {
+              // startHold clears queuedState; override it with the new state so
+              // the hold timer applies it after expiry.
+              queuedState = s
+            }
           } else {
+            state = s
             render()
           }
         }
@@ -669,11 +684,23 @@ export function renderGameScreen(container) {
               const s = await apiPlay({ tableId, card, sessionId, playerId })
               if (!mounted) return
               const completedTrick = detectCompletedTrick(prevState, s)
-              state = s
               if (completedTrick) {
+                // If this was the 13th trick of a non-final hand (state already
+                // advanced to the next hand's bidding phase), keep rendering
+                // prevState during the hold so the player sees the 13th trick in
+                // context, not the new hand's bidding screen.
+                if (!isHandTransition(prevState, s)) {
+                  state = s
+                }
                 startHold(completedTrick)
+                if (isHandTransition(prevState, s)) {
+                  // startHold clears queuedState; override with new-hand state so
+                  // the hold timer applies it after expiry.
+                  queuedState = s
+                }
                 // inputBlocker stays blocked until the hold timer fires
               } else {
+                state = s
                 inputBlocker.unblock()
                 render()
               }

--- a/client/web/src/trickHold.js
+++ b/client/web/src/trickHold.js
@@ -17,6 +17,27 @@ function esc(s) {
 export const HOLD_DURATIONS = { slow: 2500, normal: 1500, fast: 800 }
 
 /**
+ * Returns true when nextState has transitioned to a new (non-final) hand.
+ * In this case completedTricks was reset to [] for the new hand, meaning the
+ * caller should keep prevState visible during the trick-hold window instead of
+ * immediately rendering the new hand's bidding screen.
+ *
+ * Returns false for game_over because completedTricks is NOT reset there —
+ * the final state is safe to render during the hold.
+ *
+ * @param {object|null} prevState
+ * @param {object} nextState
+ * @returns {boolean}
+ */
+export function isHandTransition(prevState, nextState) {
+  if (!prevState || !nextState) return false
+  if (nextState.phase === 'game_over') return false
+  const prevHistoryLen = Array.isArray(prevState.handHistory) ? prevState.handHistory.length : 0
+  const nextHistoryLen = Array.isArray(nextState.handHistory) ? nextState.handHistory.length : 0
+  return nextHistoryLen > prevHistoryLen
+}
+
+/**
  * Compare two successive game states and return the trick that was just
  * completed, or null if no new trick completed between the two states.
  *

--- a/test/unit/web/trickHold.test.js
+++ b/test/unit/web/trickHold.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { HOLD_DURATIONS, detectCompletedTrick, trickHoldHtml } from '../../../client/web/src/trickHold.js'
+import { HOLD_DURATIONS, detectCompletedTrick, isHandTransition, trickHoldHtml } from '../../../client/web/src/trickHold.js'
 
 // ---------------------------------------------------------------------------
 // HOLD_DURATIONS
@@ -17,6 +17,54 @@ describe('HOLD_DURATIONS', () => {
 
   it('exports fast duration of 800 ms', () => {
     assert.equal(HOLD_DURATIONS.fast, 800)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isHandTransition
+// ---------------------------------------------------------------------------
+
+describe('isHandTransition', () => {
+  it('returns false when prevState is null', () => {
+    const next = { handHistory: [{}], phase: 'bidding' }
+    assert.equal(isHandTransition(null, next), false)
+  })
+
+  it('returns false when nextState is null', () => {
+    assert.equal(isHandTransition({ handHistory: [] }, null), false)
+  })
+
+  it('returns false when handHistory length is unchanged', () => {
+    const prev = { handHistory: [{}], phase: 'playing' }
+    const next = { handHistory: [{}], phase: 'playing' }
+    assert.equal(isHandTransition(prev, next), false)
+  })
+
+  it('returns false when game_over even if handHistory grew', () => {
+    // game_over: completedTricks preserved, state is safe to render during hold
+    const prev = { handHistory: [], phase: 'playing' }
+    const next = { handHistory: [{}], phase: 'game_over' }
+    assert.equal(isHandTransition(prev, next), false)
+  })
+
+  it('returns true when handHistory grew and phase is bidding (non-final hand transition)', () => {
+    // 13th trick scored: server moved to next hand's bidding phase;
+    // client must keep prevState during hold to avoid showing next hand context
+    const prev = { handHistory: [], phase: 'playing' }
+    const next = { handHistory: [{}], phase: 'bidding' }
+    assert.equal(isHandTransition(prev, next), true)
+  })
+
+  it('returns true when handHistory grew and phase is playing (bots already played tricks of new hand)', () => {
+    const prev = { handHistory: [{}], phase: 'playing' }
+    const next = { handHistory: [{}, {}], phase: 'playing' }
+    assert.equal(isHandTransition(prev, next), true)
+  })
+
+  it('handles missing handHistory arrays gracefully', () => {
+    const prev = {}
+    const next = { phase: 'bidding' }
+    assert.equal(isHandTransition(prev, next), false)
   })
 })
 


### PR DESCRIPTION
When the 13th trick of a non-final hand was played, the server immediately transitioned to the next hand. The client triggered the 1500ms hold but had already updated `state` to the new-hand state, so the hold showed the trick area correctly but the rest of the screen rendered the next hand's bidding UI and new cards.

**Changes:**
- `client/web/src/trickHold.js`: Export `isHandTransition(prevState, nextState)` helper
- `client/web/src/screens/game.js`: In both card-play and polling paths, keep prevState during hold for non-final hand transitions and queue new-hand state via queuedState
- `test/unit/web/trickHold.test.js`: 7 new unit tests for isHandTransition

Closes #212

Generated with [Claude Code](https://claude.ai/code)