### PR TITLE
feat: use WS_PORT env variable for WebSocket server

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ Card format: rank + suit initial (e.g. `AS` = Ace of Spades, `KH` = King of Hear
 
 ## Real-Time (WebSocket)
 
-The WebSocket server shares the same HTTP server as the REST API (configurable via `WS_PORT`, default `3001`).
+The WebSocket server runs on its own port (configurable via `WS_PORT`, default `3001`). Set `WS_PORT` to the same value as `PORT` to share the HTTP server instead.
 
 ### Connection & Authentication
 

--- a/server/app.js
+++ b/server/app.js
@@ -1,13 +1,16 @@
 import express from 'express'
+import { createServer } from 'http'
 import { fileURLToPath } from 'url'
 import { dirname, join } from 'path'
 import { handler } from './server.js'
 import { getRedis } from './redis.js'
+import { createWsServer } from './ws/index.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 const app = express()
-const PORT = process.env.PORT || 3000
+const PORT = parseInt(process.env.PORT || '3000', 10)
+const WS_PORT = parseInt(process.env.WS_PORT || '3001', 10)
 
 app.use(express.json())
 
@@ -31,7 +34,22 @@ handler(app, { redis })
 // Serve the web client as static files
 app.use(express.static(join(__dirname, '..', 'client', 'web')))
 
-app.listen(PORT, () => {
+const httpServer = createServer(app)
+
+if (WS_PORT === PORT) {
+  // Share the HTTP server when ports match
+  createWsServer(httpServer, { redis })
+  console.log(`WebSocket server sharing HTTP server on port ${PORT}`)
+} else {
+  // Run WebSocket on its own dedicated server
+  const wsHttpServer = createServer()
+  createWsServer(wsHttpServer, { redis })
+  wsHttpServer.listen(WS_PORT, () => {
+    console.log(`WebSocket server listening on port ${WS_PORT}`)
+  })
+}
+
+httpServer.listen(PORT, () => {
   console.log(`Spades Online server listening on port ${PORT}`)
 })
 

--- a/test/ws/startup.test.js
+++ b/test/ws/startup.test.js
@@ -7,22 +7,32 @@ import { getRedis, closeRedis } from '../../server/redis.js'
 
 const skip = !process.env.REDIS_URL ? 'REDIS_URL must be set' : false
 
-function wsConnect(server, headers = {}) {
+const TEST_TIMEOUT_MS = 5000
+
+function wsConnect(server, headers = {}, timeoutMs = TEST_TIMEOUT_MS) {
   const { port } = server.address()
   return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      ws.terminate()
+      reject(new Error(`wsConnect timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
     const ws = new WebSocket(`ws://127.0.0.1:${port}`, { headers })
-    ws.once('open', () => resolve(ws))
-    ws.once('error', reject)
+    ws.once('open', () => { clearTimeout(timer); resolve(ws) })
+    ws.once('error', (err) => { clearTimeout(timer); reject(err) })
     ws.once('unexpected-response', (_req, res) => {
+      clearTimeout(timer)
       reject(Object.assign(new Error(`HTTP ${res.statusCode}`), { statusCode: res.statusCode }))
     })
   })
 }
 
-function waitClose(ws) {
-  return new Promise((resolve) => {
+function waitClose(ws, timeoutMs = TEST_TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
     if (ws.readyState === WebSocket.CLOSED) return resolve(ws._closeCode ?? ws.closeCode)
-    ws.once('close', (code) => resolve(code))
+    const timer = setTimeout(() => {
+      reject(new Error(`waitClose timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+    ws.once('close', (code) => { clearTimeout(timer); resolve(code) })
   })
 }
 
@@ -59,14 +69,14 @@ describe('app.js WS_PORT startup branching', { skip }, () => {
       await new Promise((resolve) => httpServer.close(resolve))
     })
 
-    it('accepts authenticated WebSocket connections on the shared server', async () => {
+    it('accepts authenticated WebSocket connections on the shared server', { timeout: TEST_TIMEOUT_MS }, async () => {
       const ws = await wsConnect(httpServer, { 'x-session-id': 'startup-session' })
       assert.equal(ws.readyState, WebSocket.OPEN)
       ws.close()
       await waitClose(ws)
     })
 
-    it('rejects unauthenticated WebSocket connections on the shared server', async () => {
+    it('rejects unauthenticated WebSocket connections on the shared server', { timeout: TEST_TIMEOUT_MS }, async () => {
       const err = await wsConnect(httpServer).then(
         () => { throw new Error('expected rejection') },
         (e) => e,
@@ -102,20 +112,20 @@ describe('app.js WS_PORT startup branching', { skip }, () => {
       ])
     })
 
-    it('dedicated WS server and main HTTP server listen on different ports', () => {
+    it('dedicated WS server and main HTTP server listen on different ports', { timeout: TEST_TIMEOUT_MS }, () => {
       const wsPort = wsHttpServer.address().port
       const httpPort = httpServer.address().port
       assert.notEqual(wsPort, httpPort, 'WS server and HTTP server must be on different ports')
     })
 
-    it('accepts authenticated WebSocket connections on the dedicated WS server', async () => {
+    it('accepts authenticated WebSocket connections on the dedicated WS server', { timeout: TEST_TIMEOUT_MS }, async () => {
       const ws = await wsConnect(wsHttpServer, { 'x-session-id': 'startup-session' })
       assert.equal(ws.readyState, WebSocket.OPEN)
       ws.close()
       await waitClose(ws)
     })
 
-    it('rejects unauthenticated WebSocket connections on the dedicated WS server', async () => {
+    it('rejects unauthenticated WebSocket connections on the dedicated WS server', { timeout: TEST_TIMEOUT_MS }, async () => {
       const err = await wsConnect(wsHttpServer).then(
         () => { throw new Error('expected rejection') },
         (e) => e,
@@ -126,8 +136,10 @@ describe('app.js WS_PORT startup branching', { skip }, () => {
       )
     })
 
-    it('WebSocket upgrade is not handled on the main HTTP server', async () => {
-      // The main HTTP server has no WS handler attached — the upgrade should fail
+    it('WebSocket upgrade is not handled on the main HTTP server', { timeout: TEST_TIMEOUT_MS }, async () => {
+      // The main HTTP server has no WS handler attached — the upgrade should fail or be refused.
+      // Node.js destroys the socket when no 'upgrade' listener is present, causing an ECONNRESET
+      // or similar error on the client side.
       const err = await wsConnect(httpServer, { 'x-session-id': 'startup-session' }).then(
         () => { throw new Error('expected connection to main HTTP server to fail') },
         (e) => e,

--- a/test/ws/startup.test.js
+++ b/test/ws/startup.test.js
@@ -140,7 +140,8 @@ describe('app.js WS_PORT startup branching', { skip }, () => {
       // The main HTTP server has no WS handler attached — the upgrade should fail or be refused.
       // Node.js destroys the socket when no 'upgrade' listener is present, causing an ECONNRESET
       // or similar error on the client side.
-      const err = await wsConnect(httpServer, { 'x-session-id': 'startup-session' }).then(
+      // Use a shorter connect timeout (3000ms) so it rejects before the test runner's 5000ms limit.
+      const err = await wsConnect(httpServer, { 'x-session-id': 'startup-session' }, 3000).then(
         () => { throw new Error('expected connection to main HTTP server to fail') },
         (e) => e,
       )

--- a/test/ws/startup.test.js
+++ b/test/ws/startup.test.js
@@ -1,0 +1,138 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import http from 'node:http'
+import WebSocket from 'ws'
+import { createWsServer } from '../../server/ws/index.js'
+import { getRedis, closeRedis } from '../../server/redis.js'
+
+const skip = !process.env.REDIS_URL ? 'REDIS_URL must be set' : false
+
+function wsConnect(server, headers = {}) {
+  const { port } = server.address()
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`, { headers })
+    ws.once('open', () => resolve(ws))
+    ws.once('error', reject)
+    ws.once('unexpected-response', (_req, res) => {
+      reject(Object.assign(new Error(`HTTP ${res.statusCode}`), { statusCode: res.statusCode }))
+    })
+  })
+}
+
+function waitClose(ws) {
+  return new Promise((resolve) => {
+    if (ws.readyState === WebSocket.CLOSED) return resolve(ws._closeCode ?? ws.closeCode)
+    ws.once('close', (code) => resolve(code))
+  })
+}
+
+describe('app.js WS_PORT startup branching', { skip }, () => {
+  let redis
+
+  before(async () => {
+    redis = await getRedis()
+    await redis.set(
+      'session:startup-session',
+      JSON.stringify({ playerId: 'startup-player', username: 'StartupUser' }),
+    )
+  })
+
+  after(async () => {
+    await redis.del('session:startup-session')
+    await closeRedis()
+  })
+
+  // ── WS_PORT === PORT: shared HTTP server ─────────────────────────────────────
+
+  describe('WS_PORT === PORT (shared HTTP server)', () => {
+    let httpServer, wss
+
+    before(async () => {
+      // Mirrors the app.js branch: createWsServer(httpServer, { redis })
+      httpServer = http.createServer()
+      wss = createWsServer(httpServer, { redis })
+      await new Promise((resolve) => httpServer.listen(0, '127.0.0.1', resolve))
+    })
+
+    after(async () => {
+      wss.close()
+      await new Promise((resolve) => httpServer.close(resolve))
+    })
+
+    it('accepts authenticated WebSocket connections on the shared server', async () => {
+      const ws = await wsConnect(httpServer, { 'x-session-id': 'startup-session' })
+      assert.equal(ws.readyState, WebSocket.OPEN)
+      ws.close()
+      await waitClose(ws)
+    })
+
+    it('rejects unauthenticated WebSocket connections on the shared server', async () => {
+      const err = await wsConnect(httpServer).then(
+        () => { throw new Error('expected rejection') },
+        (e) => e,
+      )
+      assert.ok(
+        err.statusCode === 401 || err.message.includes('401'),
+        `expected 401, got: ${err.message}`,
+      )
+    })
+  })
+
+  // ── WS_PORT !== PORT: dedicated WebSocket server ─────────────────────────────
+
+  describe('WS_PORT !== PORT (dedicated WebSocket server)', () => {
+    let httpServer, wsHttpServer, wss
+
+    before(async () => {
+      // Mirrors the app.js branch: separate wsHttpServer for WebSocket traffic
+      httpServer = http.createServer()
+      wsHttpServer = http.createServer()
+      wss = createWsServer(wsHttpServer, { redis })
+      await Promise.all([
+        new Promise((resolve) => httpServer.listen(0, '127.0.0.1', resolve)),
+        new Promise((resolve) => wsHttpServer.listen(0, '127.0.0.1', resolve)),
+      ])
+    })
+
+    after(async () => {
+      wss.close()
+      await Promise.all([
+        new Promise((resolve) => httpServer.close(resolve)),
+        new Promise((resolve) => wsHttpServer.close(resolve)),
+      ])
+    })
+
+    it('dedicated WS server and main HTTP server listen on different ports', () => {
+      const wsPort = wsHttpServer.address().port
+      const httpPort = httpServer.address().port
+      assert.notEqual(wsPort, httpPort, 'WS server and HTTP server must be on different ports')
+    })
+
+    it('accepts authenticated WebSocket connections on the dedicated WS server', async () => {
+      const ws = await wsConnect(wsHttpServer, { 'x-session-id': 'startup-session' })
+      assert.equal(ws.readyState, WebSocket.OPEN)
+      ws.close()
+      await waitClose(ws)
+    })
+
+    it('rejects unauthenticated WebSocket connections on the dedicated WS server', async () => {
+      const err = await wsConnect(wsHttpServer).then(
+        () => { throw new Error('expected rejection') },
+        (e) => e,
+      )
+      assert.ok(
+        err.statusCode === 401 || err.message.includes('401'),
+        `expected 401, got: ${err.message}`,
+      )
+    })
+
+    it('WebSocket upgrade is not handled on the main HTTP server', async () => {
+      // The main HTTP server has no WS handler attached — the upgrade should fail
+      const err = await wsConnect(httpServer, { 'x-session-id': 'startup-session' }).then(
+        () => { throw new Error('expected connection to main HTTP server to fail') },
+        (e) => e,
+      )
+      assert.ok(err instanceof Error, 'expected an error when connecting to main server (no WS handler)')
+    })
+  })
+})


### PR DESCRIPTION
Fixes #228

## Changes

- `server/app.js`: import and initialise `createWsServer` using `WS_PORT` (default `3001`). When `WS_PORT !== PORT` a dedicated HTTP server is created for WebSocket traffic; when they match the WS server shares the main HTTP server.
- `README.md`: update the WebSocket section (line 499) to accurately describe the new behaviour. The connection example (`ws://localhost:3001/`) is now correct since 3001 is the actual default WS_PORT.

Generated with [Claude Code](https://claude.ai/code)