### PR TITLE
fix: fail closed on JOIN when Redis unavailable; document JOIN_DENIED in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,7 @@ All messages are JSON: `{ "type": "<TYPE>", "payload": { ... } }`.
 |---|---|---|
 | `JOINED` | `{ "tableId": "<uuid>" }` | Confirms the client has joined the table room. |
 | `LEFT` | `{ "tableId": "<uuid>" }` | Confirms the client has left the table room. |
+| `JOIN_DENIED` | `{ "tableId": "<uuid>", "reason": "not_seated" \| "table_not_found" \| "error" }` | Sent when a `JOIN` request is rejected because the player is not seated at the table, the table does not exist, or an internal error occurred. |
 | `JOINED_LOBBY` | `{}` | Confirms the client has joined the lobby channel. |
 | `LEFT_LOBBY` | `{}` | Confirms the client has left the lobby channel. |
 

--- a/server/ws/index.js
+++ b/server/ws/index.js
@@ -142,26 +142,29 @@ export function createWsServer(httpServer, opts = {}) {
         const { tableId } = payload
         if (!tableId) return
 
-        // Security: verify the player is seated at this table before subscribing
-        if (redis) {
-          try {
-            const tableData = await redis.get(`table:${tableId}`)
-            if (!tableData) {
-              ws.send(JSON.stringify({ type: 'JOIN_DENIED', payload: { tableId, reason: 'table_not_found' } }))
-              return
-            }
-            const table = JSON.parse(tableData)
-            const isSeated = Object.values(table.seats).includes(playerId)
-            if (!isSeated) {
-              console.log('WebSocket JOIN denied — not seated:', { playerId, tableId })
-              ws.send(JSON.stringify({ type: 'JOIN_DENIED', payload: { tableId, reason: 'not_seated' } }))
-              return
-            }
-          } catch (err) {
-            console.error('WebSocket JOIN auth error:', { playerId, tableId, error: err.message })
-            ws.send(JSON.stringify({ type: 'JOIN_DENIED', payload: { tableId, reason: 'error' } }))
+        // Security: verify the player is seated at this table before subscribing.
+        // Fail closed — deny the JOIN if Redis is unavailable rather than allowing unchecked access.
+        if (!redis) {
+          ws.send(JSON.stringify({ type: 'JOIN_DENIED', payload: { tableId, reason: 'error' } }))
+          return
+        }
+        try {
+          const tableData = await redis.get(`table:${tableId}`)
+          if (!tableData) {
+            ws.send(JSON.stringify({ type: 'JOIN_DENIED', payload: { tableId, reason: 'table_not_found' } }))
             return
           }
+          const table = JSON.parse(tableData)
+          const isSeated = Object.values(table.seats).includes(playerId)
+          if (!isSeated) {
+            console.log('WebSocket JOIN denied — not seated:', { playerId, tableId })
+            ws.send(JSON.stringify({ type: 'JOIN_DENIED', payload: { tableId, reason: 'not_seated' } }))
+            return
+          }
+        } catch (err) {
+          console.error('WebSocket JOIN auth error:', { playerId, tableId, error: err.message })
+          ws.send(JSON.stringify({ type: 'JOIN_DENIED', payload: { tableId, reason: 'error' } }))
+          return
         }
 
         const roomKey = `table:${tableId}`


### PR DESCRIPTION
Fixes two code review issues from #225:

- **Security fix**: The `if (redis)` guard around the WebSocket JOIN seat-verification block was failing open — any authenticated client could subscribe to any table room when Redis was unavailable. Inverted to fail closed: send `JOIN_DENIED` with `reason: 'error'` and return immediately when Redis is absent.
- **README update**: Added `JOIN_DENIED` row to the Server → Client Events table as required by CLAUDE.md.

Closes #225

Generated with [Claude Code](https://claude.ai/code)