### PR TITLE
Add timeouts to all tests per CLAUDE.md rules

### DIFF
--- a/test/integration/auth/login.test.js
+++ b/test/integration/auth/login.test.js
@@ -80,7 +80,7 @@ describe('POST /api/auth/login', { skip }, () => {
     await closeRedis()
   })
 
-  it('returns 200 with sessionId, playerId, and username on valid credentials', async () => {
+  it('returns 200 with sessionId, playerId, and username on valid credentials', { timeout: 10000 }, async () => {
     const res = await fetch(`${server.baseUrl}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -93,7 +93,7 @@ describe('POST /api/auth/login', { skip }, () => {
     assert.ok(body.username, 'response should include username')
   })
 
-  it('stores the session in Redis under session:{sessionId}', async () => {
+  it('stores the session in Redis under session:{sessionId}', { timeout: 10000 }, async () => {
     const res = await fetch(`${server.baseUrl}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -107,7 +107,7 @@ describe('POST /api/auth/login', { skip }, () => {
     assert.equal(session.username, body.username)
   })
 
-  it('returns 401 for a wrong password', async () => {
+  it('returns 401 for a wrong password', { timeout: 10000 }, async () => {
     const res = await fetch(`${server.baseUrl}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -116,7 +116,7 @@ describe('POST /api/auth/login', { skip }, () => {
     assert.equal(res.status, 401)
   })
 
-  it('returns 401 for an unknown email', async () => {
+  it('returns 401 for an unknown email', { timeout: 10000 }, async () => {
     const res = await fetch(`${server.baseUrl}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -125,7 +125,7 @@ describe('POST /api/auth/login', { skip }, () => {
     assert.equal(res.status, 401)
   })
 
-  it('returns 403 for an unverified account', async () => {
+  it('returns 403 for an unverified account', { timeout: 10000 }, async () => {
     const hash = await bcrypt.hash('password123', 4)
     await db.query(
       `INSERT INTO players (email, username, password_hash, is_verified)
@@ -144,7 +144,7 @@ describe('POST /api/auth/login', { skip }, () => {
     assert.equal(res.status, 403)
   })
 
-  it('returns 400 when email is missing', async () => {
+  it('returns 400 when email is missing', { timeout: 10000 }, async () => {
     const res = await fetch(`${server.baseUrl}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -153,7 +153,7 @@ describe('POST /api/auth/login', { skip }, () => {
     assert.equal(res.status, 400)
   })
 
-  it('returns 400 when password is missing', async () => {
+  it('returns 400 when password is missing', { timeout: 10000 }, async () => {
     const res = await fetch(`${server.baseUrl}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -186,7 +186,7 @@ describe('POST /api/auth/logout', { skip }, () => {
     await closeRedis()
   })
 
-  it('returns 200 and removes the session from Redis', async () => {
+  it('returns 200 and removes the session from Redis', { timeout: 10000 }, async () => {
     const loginRes = await fetch(`${server.baseUrl}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -204,14 +204,14 @@ describe('POST /api/auth/logout', { skip }, () => {
     assert.equal(stored, null, 'session should be deleted from Redis after logout')
   })
 
-  it('returns 200 when no session header is provided (idempotent logout)', async () => {
+  it('returns 200 when no session header is provided (idempotent logout)', { timeout: 10000 }, async () => {
     const res = await fetch(`${server.baseUrl}/api/auth/logout`, {
       method: 'POST',
     })
     assert.equal(res.status, 200)
   })
 
-  it('removes the player from any waiting table they are seated at', async () => {
+  it('removes the player from any waiting table they are seated at', { timeout: 10000 }, async () => {
     const loginRes = await fetch(`${server.baseUrl}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -273,7 +273,7 @@ describe('Auth header validation', { skip }, () => {
     await closeRedis()
   })
 
-  it('a valid session grants access to protected routes', async () => {
+  it('a valid session grants access to protected routes', { timeout: 10000 }, async () => {
     const loginRes = await fetch(`${server.baseUrl}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -288,7 +288,7 @@ describe('Auth header validation', { skip }, () => {
     assert.equal(session.playerId, playerId)
   })
 
-  it('session is expired/absent after logout', async () => {
+  it('session is expired/absent after logout', { timeout: 10000 }, async () => {
     const loginRes = await fetch(`${server.baseUrl}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/test/integration/auth/rateLimiter.test.js
+++ b/test/integration/auth/rateLimiter.test.js
@@ -55,7 +55,7 @@ describe('Auth endpoint rate limiting', { skip }, () => {
     await closeRedis()
   })
 
-  it('sets X-RateLimit-* headers on POST /api/auth/register', async () => {
+  it('sets X-RateLimit-* headers on POST /api/auth/register', { timeout: 10000 }, async () => {
     const res = await fetch(`${server.baseUrl}/api/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -66,7 +66,7 @@ describe('Auth endpoint rate limiting', { skip }, () => {
     assert.ok(res.headers.get('x-ratelimit-reset'), 'X-RateLimit-Reset should be set')
   })
 
-  it('returns 429 after limit is exceeded on POST /api/auth/register', async () => {
+  it('returns 429 after limit is exceeded on POST /api/auth/register', { timeout: 10000 }, async () => {
     for (let i = 0; i < 3; i++) {
       await fetch(`${server.baseUrl}/api/auth/register`, {
         method: 'POST',
@@ -86,7 +86,7 @@ describe('Auth endpoint rate limiting', { skip }, () => {
     assert.ok(body.error, 'error message should be in response body')
   })
 
-  it('returns 429 after limit is exceeded on POST /api/auth/login', async () => {
+  it('returns 429 after limit is exceeded on POST /api/auth/login', { timeout: 10000 }, async () => {
     for (let i = 0; i < 3; i++) {
       await fetch(`${server.baseUrl}/api/auth/login`, {
         method: 'POST',
@@ -104,7 +104,7 @@ describe('Auth endpoint rate limiting', { skip }, () => {
     assert.ok(blocked.headers.get('retry-after'), 'Retry-After header should be set on 429')
   })
 
-  it('returns 429 after limit is exceeded on GET /api/auth/verify-email', async () => {
+  it('returns 429 after limit is exceeded on GET /api/auth/verify-email', { timeout: 10000 }, async () => {
     for (let i = 0; i < 3; i++) {
       await fetch(`${server.baseUrl}/api/auth/verify-email?token=some-token-${i}`)
     }
@@ -114,7 +114,7 @@ describe('Auth endpoint rate limiting', { skip }, () => {
     assert.ok(blocked.headers.get('retry-after'), 'Retry-After header should be set on 429')
   })
 
-  it('shares a single counter across all auth endpoints (same IP)', async () => {
+  it('shares a single counter across all auth endpoints (same IP)', { timeout: 10000 }, async () => {
     // Mix register, login, and verify-email — all share the same rate limit key per IP
     await fetch(`${server.baseUrl}/api/auth/register`, {
       method: 'POST',

--- a/test/integration/auth/registration.test.js
+++ b/test/integration/auth/registration.test.js
@@ -74,7 +74,7 @@ describe('POST /api/auth/register', { skip }, () => {
     await closeDb()
   })
 
-  it('returns 201 and a playerId on valid registration', async () => {
+  it('returns 201 and a playerId on valid registration', { timeout: 10000 }, async () => {
     const res = await fetch(`${server.baseUrl}/api/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -90,7 +90,7 @@ describe('POST /api/auth/register', { skip }, () => {
     assert.ok(body.message, 'response should include a message')
   })
 
-  it('sends a verification email on registration', async () => {
+  it('sends a verification email on registration', { timeout: 10000 }, async () => {
     server.sentEmails.length = 0
     await fetch(`${server.baseUrl}/api/auth/register`, {
       method: 'POST',
@@ -106,7 +106,7 @@ describe('POST /api/auth/register', { skip }, () => {
     assert.ok(server.sentEmails[0].token, 'email should carry a verification token')
   })
 
-  it('stores account as unverified after registration', async () => {
+  it('stores account as unverified after registration', { timeout: 10000 }, async () => {
     await fetch(`${server.baseUrl}/api/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -123,7 +123,7 @@ describe('POST /api/auth/register', { skip }, () => {
     assert.equal(result.rows[0].is_verified, false)
   })
 
-  it('returns 400 when email is missing', async () => {
+  it('returns 400 when email is missing', { timeout: 10000 }, async () => {
     const res = await fetch(`${server.baseUrl}/api/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -132,7 +132,7 @@ describe('POST /api/auth/register', { skip }, () => {
     assert.equal(res.status, 400)
   })
 
-  it('returns 400 when password is too short', async () => {
+  it('returns 400 when password is too short', { timeout: 10000 }, async () => {
     const res = await fetch(`${server.baseUrl}/api/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -145,7 +145,7 @@ describe('POST /api/auth/register', { skip }, () => {
     assert.equal(res.status, 400)
   })
 
-  it('returns 409 when email is already registered', async () => {
+  it('returns 409 when email is already registered', { timeout: 10000 }, async () => {
     const payload = {
       email: 'dup@test.spades.invalid',
       username: 'dup_test',
@@ -164,7 +164,7 @@ describe('POST /api/auth/register', { skip }, () => {
     assert.equal(res.status, 409)
   })
 
-  it('returns 409 when username is already taken', async () => {
+  it('returns 409 when username is already taken', { timeout: 10000 }, async () => {
     await fetch(`${server.baseUrl}/api/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -202,7 +202,7 @@ describe('GET /api/auth/verify-email', { skip }, () => {
     await closeDb()
   })
 
-  it('redirects to /#/verify-email-success and marks account verified with a valid token', async () => {
+  it('redirects to /#/verify-email-success and marks account verified with a valid token', { timeout: 10000 }, async () => {
     // Register a player to get a real token
     server.sentEmails.length = 0
     await fetch(`${server.baseUrl}/api/auth/register`, {
@@ -227,7 +227,7 @@ describe('GET /api/auth/verify-email', { skip }, () => {
     assert.equal(result.rows[0].is_verified, true)
   })
 
-  it('redirects to /#/verify-email-error for an invalid token', async () => {
+  it('redirects to /#/verify-email-error for an invalid token', { timeout: 10000 }, async () => {
     const res = await fetch(
       `${server.baseUrl}/api/auth/verify-email?token=00000000-0000-4000-8000-000000000000`,
       { redirect: 'manual' },
@@ -236,13 +236,13 @@ describe('GET /api/auth/verify-email', { skip }, () => {
     assert.ok(res.headers.get('location').includes('/verify-email-error'))
   })
 
-  it('redirects to /#/verify-email-error when no token is provided', async () => {
+  it('redirects to /#/verify-email-error when no token is provided', { timeout: 10000 }, async () => {
     const res = await fetch(`${server.baseUrl}/api/auth/verify-email`, { redirect: 'manual' })
     assert.equal(res.status, 302)
     assert.ok(res.headers.get('location').includes('/verify-email-error'))
   })
 
-  it('redirects to /#/verify-email-error when the same token is used twice (single use)', async () => {
+  it('redirects to /#/verify-email-error when the same token is used twice (single use)', { timeout: 10000 }, async () => {
     server.sentEmails.length = 0
     await fetch(`${server.baseUrl}/api/auth/register`, {
       method: 'POST',

--- a/test/integration/game/blindNilHiding.test.js
+++ b/test/integration/game/blindNilHiding.test.js
@@ -160,7 +160,7 @@ describe('Blind Nil hand hiding — integration', { skip }, () => {
     await closeRedis()
   })
 
-  it('eligible player hand is withheld on initial state fetch', async () => {
+  it('eligible player hand is withheld on initial state fetch', { timeout: 10000 }, async () => {
     const { tableId, seatMap } = await setupEligibleGame(server.baseUrl, players)
 
     const northRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
@@ -176,7 +176,7 @@ describe('Blind Nil hand hiding — integration', { skip }, () => {
     assert.equal(northState.myHand, undefined, 'north myHand should be withheld')
   })
 
-  it('ineligible team (EW) receives full hand immediately', async () => {
+  it('ineligible team (EW) receives full hand immediately', { timeout: 10000 }, async () => {
     const { tableId, seatMap } = await setupEligibleGame(server.baseUrl, players)
 
     const eastRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
@@ -192,7 +192,7 @@ describe('Blind Nil hand hiding — integration', { skip }, () => {
     assert.equal(eastState.myHand.length, 13)
   })
 
-  it('reveal-then-bid: eligible player reveals hand then bids normally', async () => {
+  it('reveal-then-bid: eligible player reveals hand then bids normally', { timeout: 10000 }, async () => {
     const { tableId, seatMap } = await setupEligibleGame(server.baseUrl, players)
 
     const northHdrs = {
@@ -252,7 +252,7 @@ describe('Blind Nil hand hiding — integration', { skip }, () => {
     )
   })
 
-  it('bid-blind-nil-directly: eligible player bids Blind Nil without revealing', async () => {
+  it('bid-blind-nil-directly: eligible player bids Blind Nil without revealing', { timeout: 10000 }, async () => {
     const { tableId, seatMap } = await setupEligibleGame(server.baseUrl, players)
 
     // Bidding order with north dealer: east, south, west, north
@@ -313,7 +313,7 @@ describe('Blind Nil hand hiding — integration', { skip }, () => {
     )
   })
 
-  it('reveal-hand is rejected if player has already placed a bid', async () => {
+  it('reveal-hand is rejected if player has already placed a bid', { timeout: 10000 }, async () => {
     const { tableId, seatMap } = await setupEligibleGame(server.baseUrl, players)
 
     // Inject a state where north has already bid (non-null) but phase is still 'bidding'
@@ -340,7 +340,7 @@ describe('Blind Nil hand hiding — integration', { skip }, () => {
     assert.ok(body.error, 'error message should be present')
   })
 
-  it('reveal-hand is rejected if player is not eligible', async () => {
+  it('reveal-hand is rejected if player is not eligible', { timeout: 10000 }, async () => {
     // Create a fresh game with default scores (nobody eligible)
     const seats = ['north', 'east', 'south', 'west']
     const seatMap = {}

--- a/test/integration/game/fullgame.test.js
+++ b/test/integration/game/fullgame.test.js
@@ -157,7 +157,7 @@ describe('E2E: 4 players complete a full game from table creation to game over',
     await closeRedis()
   })
 
-  it('4 players complete a full game from table creation to game over', async () => {
+  it('4 players complete a full game from table creation to game over', { timeout: 30000 }, async () => {
     const seats = ['north', 'east', 'south', 'west']
 
     // seat → player credentials

--- a/test/integration/game/leaveTable.test.js
+++ b/test/integration/game/leaveTable.test.js
@@ -96,7 +96,7 @@ describe('POST /api/tables/:tableId/leave', { skip }, () => {
     await closeRedis()
   })
 
-  it('seated player can leave a waiting table', async () => {
+  it('seated player can leave a waiting table', { timeout: 10000 }, async () => {
     const host = players[0]
     const other = players[1]
 
@@ -163,7 +163,7 @@ describe('POST /api/tables/:tableId/leave', { skip }, () => {
     assert.equal(stateBody.seats.east, null, 'east seat should be empty after player left')
   })
 
-  it('returns 409 if player is not seated at the table', async () => {
+  it('returns 409 if player is not seated at the table', { timeout: 10000 }, async () => {
     const host = players[0]
     const unseated = players[2]
 
@@ -188,7 +188,7 @@ describe('POST /api/tables/:tableId/leave', { skip }, () => {
     assert.equal(leaveRes.status, 409)
   })
 
-  it('returns 404 for unknown tableId', async () => {
+  it('returns 404 for unknown tableId', { timeout: 10000 }, async () => {
     const host = players[0]
     const fakeId = '00000000-0000-0000-0000-000000000000'
     const leaveRes = await fetch(`${server.baseUrl}/api/tables/${fakeId}/leave`, {
@@ -202,14 +202,14 @@ describe('POST /api/tables/:tableId/leave', { skip }, () => {
     assert.equal(leaveRes.status, 404)
   })
 
-  it('returns 401 without auth headers', async () => {
+  it('returns 401 without auth headers', { timeout: 10000 }, async () => {
     const res = await fetch(`${server.baseUrl}/api/tables/some-id/leave`, {
       method: 'POST',
     })
     assert.equal(res.status, 401)
   })
 
-  it('human can leave an in-progress game — bot takes their seat', async () => {
+  it('human can leave an in-progress game — bot takes their seat', { timeout: 10000 }, async () => {
     const host = players[0]
     const p2 = players[1]
     const p3 = players[2]
@@ -273,7 +273,7 @@ describe('POST /api/tables/:tableId/leave', { skip }, () => {
     assert.equal(stateBody.players.east, 'bot:east', 'east seat should be occupied by a bot')
   })
 
-  it('host leaving in-progress game reassigns host to remaining human', async () => {
+  it('host leaving in-progress game reassigns host to remaining human', { timeout: 10000 }, async () => {
     const host = players[0]
     const p2 = players[1]
     const p3 = players[2]
@@ -334,7 +334,7 @@ describe('POST /api/tables/:tableId/leave', { skip }, () => {
     assert.equal(terminateRes.status, 200, 'new host should be able to terminate the game')
   })
 
-  it('last human leaving in-progress game terminates the table', async () => {
+  it('last human leaving in-progress game terminates the table', { timeout: 10000 }, async () => {
     const host = players[0]
 
     const createRes = await fetch(`${server.baseUrl}/api/tables`, {

--- a/test/integration/game/playerTable.test.js
+++ b/test/integration/game/playerTable.test.js
@@ -104,12 +104,12 @@ describe('GET /api/player/table', { skip }, () => {
     await closeRedis()
   })
 
-  it('returns 401 without auth headers', async () => {
+  it('returns 401 without auth headers', { timeout: 10000 }, async () => {
     const res = await fetch(`${server.baseUrl}/api/player/table`)
     assert.equal(res.status, 401)
   })
 
-  it('returns { tableId: null } when player is not seated at any table', async () => {
+  it('returns { tableId: null } when player is not seated at any table', { timeout: 10000 }, async () => {
     const { sessionId, playerId } = await loginPlayer(
       server.baseUrl,
       'pt_player1@pttest.spades.invalid',
@@ -123,7 +123,7 @@ describe('GET /api/player/table', { skip }, () => {
     assert.equal(body.tableId, null)
   })
 
-  it('returns the tableId when player is seated at a waiting table', async () => {
+  it('returns the tableId when player is seated at a waiting table', { timeout: 10000 }, async () => {
     const { sessionId, playerId } = await loginPlayer(
       server.baseUrl,
       'pt_player1@pttest.spades.invalid',
@@ -144,7 +144,7 @@ describe('GET /api/player/table', { skip }, () => {
     await redis.hDel('lobby:tables', tableId)
   })
 
-  it('returns the tableId when player is seated at a playing table (game not over)', async () => {
+  it('returns the tableId when player is seated at a playing table (game not over)', { timeout: 10000 }, async () => {
     // Log in 4 players
     const players = []
     for (let i = 1; i <= 4; i++) {
@@ -177,7 +177,7 @@ describe('GET /api/player/table', { skip }, () => {
     await redis.hDel('lobby:tables', tableId)
   })
 
-  it('returns { tableId: null } when player is seated at a game_over table', async () => {
+  it('returns { tableId: null } when player is seated at a game_over table', { timeout: 10000 }, async () => {
     // Log in 4 players
     const players = []
     for (let i = 1; i <= 4; i++) {

--- a/test/integration/game/table.test.js
+++ b/test/integration/game/table.test.js
@@ -85,7 +85,7 @@ describe('POST /api/tables', { skip }, () => {
     await closeRedis()
   })
 
-  it('creates a table and returns tableId for authenticated player', async () => {
+  it('creates a table and returns tableId for authenticated player', { timeout: 10000 }, async () => {
     const { sessionId, playerId } = await loginPlayer(
       server.baseUrl,
       'host@gtest.spades.invalid',
@@ -100,7 +100,7 @@ describe('POST /api/tables', { skip }, () => {
     assert.ok(body.tableId, 'should return a tableId')
   })
 
-  it('returns 401 without auth headers', async () => {
+  it('returns 401 without auth headers', { timeout: 10000 }, async () => {
     const res = await fetch(`${server.baseUrl}/api/tables`, { method: 'POST' })
     assert.equal(res.status, 401)
   })
@@ -139,7 +139,7 @@ describe('POST /api/tables/:tableId/sit', { skip }, () => {
     await closeRedis()
   })
 
-  it('4 players can sit and game starts automatically', async () => {
+  it('4 players can sit and game starts automatically', { timeout: 10000 }, async () => {
     // Host creates table
     const { sessionId, playerId } = players[0]
     const createRes = await fetch(`${server.baseUrl}/api/tables`, {
@@ -173,7 +173,7 @@ describe('POST /api/tables/:tableId/sit', { skip }, () => {
     assert.equal(state.myHand.length, 13, 'player should have 13 cards')
   })
 
-  it('game state remains waiting when only 3 of 4 seats are filled', async () => {
+  it('game state remains waiting when only 3 of 4 seats are filled', { timeout: 10000 }, async () => {
     const { sessionId, playerId } = players[0]
     const createRes = await fetch(`${server.baseUrl}/api/tables`, {
       method: 'POST',
@@ -206,7 +206,7 @@ describe('POST /api/tables/:tableId/sit', { skip }, () => {
     assert.equal(state.phase, undefined, 'no game phase should exist yet')
   })
 
-  it('returns 409 when seat is already taken', async () => {
+  it('returns 409 when seat is already taken', { timeout: 10000 }, async () => {
     const { sessionId, playerId } = players[0]
     const createRes = await fetch(`${server.baseUrl}/api/tables`, {
       method: 'POST',
@@ -238,7 +238,7 @@ describe('POST /api/tables/:tableId/sit', { skip }, () => {
     assert.equal(res.status, 409)
   })
 
-  it('returns 400 for an invalid seat name', async () => {
+  it('returns 400 for an invalid seat name', { timeout: 10000 }, async () => {
     const { sessionId, playerId } = players[0]
     const createRes = await fetch(`${server.baseUrl}/api/tables`, {
       method: 'POST',
@@ -258,7 +258,7 @@ describe('POST /api/tables/:tableId/sit', { skip }, () => {
     assert.equal(res.status, 400)
   })
 
-  it('returns 409 when player is already seated at this table', async () => {
+  it('returns 409 when player is already seated at this table', { timeout: 10000 }, async () => {
     const { sessionId, playerId } = players[0]
     const createRes = await fetch(`${server.baseUrl}/api/tables`, {
       method: 'POST',
@@ -290,7 +290,7 @@ describe('POST /api/tables/:tableId/sit', { skip }, () => {
     assert.equal(res.status, 409)
   })
 
-  it('returns 404 for a non-existent table', async () => {
+  it('returns 404 for a non-existent table', { timeout: 10000 }, async () => {
     const { sessionId, playerId } = players[0]
     const res = await fetch(`${server.baseUrl}/api/tables/00000000-0000-0000-0000-000000000000/sit`, {
       method: 'POST',
@@ -304,7 +304,7 @@ describe('POST /api/tables/:tableId/sit', { skip }, () => {
     assert.equal(res.status, 404)
   })
 
-  it('GET /api/tables/:tableId/state returns 403 when player is not seated', async () => {
+  it('GET /api/tables/:tableId/state returns 403 when player is not seated', { timeout: 10000 }, async () => {
     const { sessionId, playerId } = players[0]
     const createRes = await fetch(`${server.baseUrl}/api/tables`, {
       method: 'POST',
@@ -377,7 +377,7 @@ describe('POST /api/tables/:tableId/bid', { skip }, () => {
     await closeRedis()
   })
 
-  it('east player bids first (left of north dealer)', async () => {
+  it('east player bids first (left of north dealer)', { timeout: 10000 }, async () => {
     // players[1] is east (second player seated)
     const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/bid`, {
       method: 'POST',
@@ -394,7 +394,7 @@ describe('POST /api/tables/:tableId/bid', { skip }, () => {
     assert.equal(state.currentBidderSeat, 'south')
   })
 
-  it('returns 409 when wrong player tries to bid', async () => {
+  it('returns 409 when wrong player tries to bid', { timeout: 10000 }, async () => {
     // players[0] is north — but it should be south's turn now
     const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/bid`, {
       method: 'POST',
@@ -408,7 +408,7 @@ describe('POST /api/tables/:tableId/bid', { skip }, () => {
     assert.equal(res.status, 409)
   })
 
-  it('returns 400 for an invalid bid value', async () => {
+  it('returns 400 for an invalid bid value', { timeout: 10000 }, async () => {
     const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/bid`, {
       method: 'POST',
       headers: {
@@ -421,7 +421,7 @@ describe('POST /api/tables/:tableId/bid', { skip }, () => {
     assert.equal(res.status, 400)
   })
 
-  it('returns 400 when bidding blind nil without eligibility (team not 100+ behind)', async () => {
+  it('returns 400 when bidding blind nil without eligibility (team not 100+ behind)', { timeout: 10000 }, async () => {
     // Scores start at 0-0; NS is not 100+ behind
     // players[1] is east — that's the current bidder
     const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/bid`, {
@@ -460,12 +460,12 @@ describe('GET /api/tables', { skip }, () => {
     await closeRedis()
   })
 
-  it('returns 401 without auth headers', async () => {
+  it('returns 401 without auth headers', { timeout: 10000 }, async () => {
     const res = await fetch(`${server.baseUrl}/api/tables`)
     assert.equal(res.status, 401)
   })
 
-  it('returns 200 with tables array when authenticated', async () => {
+  it('returns 200 with tables array when authenticated', { timeout: 10000 }, async () => {
     const { sessionId, playerId } = await loginPlayer(
       server.baseUrl,
       'listhost@gtest.spades.invalid',
@@ -479,7 +479,7 @@ describe('GET /api/tables', { skip }, () => {
     assert.ok(Array.isArray(body.tables), 'should return a tables array')
   })
 
-  it('includes newly created waiting tables in the list', async () => {
+  it('includes newly created waiting tables in the list', { timeout: 10000 }, async () => {
     const { sessionId, playerId } = await loginPlayer(
       server.baseUrl,
       'listhost@gtest.spades.invalid',
@@ -508,7 +508,7 @@ describe('GET /api/tables', { skip }, () => {
     assert.equal(found.seatsAvailable, 4)
   })
 
-  it('does not include tables that are already playing', async () => {
+  it('does not include tables that are already playing', { timeout: 10000 }, async () => {
     const players = []
     for (let i = 1; i <= 4; i++) {
       await insertVerifiedPlayer(db, {
@@ -662,13 +662,13 @@ describe('POST /api/tables/:tableId/blind-nil-exchange', { skip }, () => {
     return res.json()
   }
 
-  it('transitions to blind_nil_exchange phase after all bids when a player bids blind nil', async () => {
+  it('transitions to blind_nil_exchange phase after all bids when a player bids blind nil', { timeout: 10000 }, async () => {
     const state = await bidToBlindNilExchange()
     assert.equal(state.phase, 'blind_nil_exchange')
     assert.equal(state.bids.south, 'blind_nil')
   })
 
-  it('blind nil player sends 2 cards to partner, then partner sends 2 back — phase becomes playing', async () => {
+  it('blind nil player sends 2 cards to partner, then partner sends 2 back — phase becomes playing', { timeout: 10000 }, async () => {
     // Get south's hand (blind nil player)
     const southStateRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
       headers: { 'x-session-id': players[2].sessionId, 'x-player-id': players[2].playerId },
@@ -711,7 +711,7 @@ describe('POST /api/tables/:tableId/blind-nil-exchange', { skip }, () => {
     assert.equal(finalState.phase, 'playing', 'game should transition to playing after full exchange')
   })
 
-  it('returns 400 when wrong player tries to submit exchange', async () => {
+  it('returns 400 when wrong player tries to submit exchange', { timeout: 10000 }, async () => {
     // After the exchange above, game is in 'playing'. We need a fresh game state in
     // blind_nil_exchange phase for this test. Re-set the game state in Redis directly.
     const gameStateRaw = await redis.get(`game:${tableId}`)
@@ -749,7 +749,7 @@ describe('POST /api/tables/:tableId/blind-nil-exchange', { skip }, () => {
     assert.equal(res.status, 400)
   })
 
-  it('returns 400 when submitting wrong number of cards (not 2)', async () => {
+  it('returns 400 when submitting wrong number of cards (not 2)', { timeout: 10000 }, async () => {
     // Get south's current hand
     const southStateRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
       headers: { 'x-session-id': players[2].sessionId, 'x-player-id': players[2].playerId },
@@ -824,7 +824,7 @@ describe('Card visibility: GET /api/tables/:tableId/state', { skip }, () => {
     await closeRedis()
   })
 
-  it('state response never contains a hands key for any player', async () => {
+  it('state response never contains a hands key for any player', { timeout: 10000 }, async () => {
     for (const p of players) {
       const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
         headers: { 'x-session-id': p.sessionId, 'x-player-id': p.playerId },
@@ -835,7 +835,7 @@ describe('Card visibility: GET /api/tables/:tableId/state', { skip }, () => {
     }
   })
 
-  it('each player receives exactly 13 cards in myHand', async () => {
+  it('each player receives exactly 13 cards in myHand', { timeout: 10000 }, async () => {
     for (const p of players) {
       const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
         headers: { 'x-session-id': p.sessionId, 'x-player-id': p.playerId },
@@ -846,7 +846,7 @@ describe('Card visibility: GET /api/tables/:tableId/state', { skip }, () => {
     }
   })
 
-  it('each player receives a distinct myHand (no two players share any card)', async () => {
+  it('each player receives a distinct myHand (no two players share any card)', { timeout: 10000 }, async () => {
     const hands = []
     for (const p of players) {
       const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
@@ -868,7 +868,7 @@ describe('Card visibility: GET /api/tables/:tableId/state', { skip }, () => {
     }
   })
 
-  it('state response after a bid still contains no hands key', async () => {
+  it('state response after a bid still contains no hands key', { timeout: 10000 }, async () => {
     // players[1] is east — first to bid (north deals, east bids first)
     const bidRes = await fetch(`${server.baseUrl}/api/tables/${tableId}/bid`, {
       method: 'POST',
@@ -959,7 +959,7 @@ describe('GET /api/tables/:tableId/state — game_over phase', { skip }, () => {
     await closeRedis()
   })
 
-  it('returns phase=game_over with correct winner, scores, and bags', async () => {
+  it('returns phase=game_over with correct winner, scores, and bags', { timeout: 10000 }, async () => {
     const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
       headers: { 'x-session-id': players[0].sessionId, 'x-player-id': players[0].playerId },
     })
@@ -971,7 +971,7 @@ describe('GET /api/tables/:tableId/state — game_over phase', { skip }, () => {
     assert.deepEqual(body.bags, { ns: 2, ew: 0 })
   })
 
-  it('game_over state response does not expose the hands key', async () => {
+  it('game_over state response does not expose the hands key', { timeout: 10000 }, async () => {
     const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
       headers: { 'x-session-id': players[0].sessionId, 'x-player-id': players[0].playerId },
     })
@@ -979,7 +979,7 @@ describe('GET /api/tables/:tableId/state — game_over phase', { skip }, () => {
     assert.ok(!('hands' in body), 'response must not contain a hands key')
   })
 
-  it('all four players see the same game_over result', async () => {
+  it('all four players see the same game_over result', { timeout: 10000 }, async () => {
     for (const player of players) {
       const res = await fetch(`${server.baseUrl}/api/tables/${tableId}/state`, {
         headers: { 'x-session-id': player.sessionId, 'x-player-id': player.playerId },

--- a/test/integration/game/terminate.test.js
+++ b/test/integration/game/terminate.test.js
@@ -96,7 +96,7 @@ describe('POST /api/tables/:tableId/terminate', { skip }, () => {
     await closeRedis()
   })
 
-  it('host can terminate a waiting table', async () => {
+  it('host can terminate a waiting table', { timeout: 10000 }, async () => {
     const host = players[0]
     const createRes = await fetch(`${server.baseUrl}/api/tables`, {
       method: 'POST',
@@ -139,7 +139,7 @@ describe('POST /api/tables/:tableId/terminate', { skip }, () => {
     assert.equal(stateRes.status, 404, 'table should be gone after termination')
   })
 
-  it('non-host player gets 403', async () => {
+  it('non-host player gets 403', { timeout: 10000 }, async () => {
     const host = players[0]
     const other = players[1]
 
@@ -164,7 +164,7 @@ describe('POST /api/tables/:tableId/terminate', { skip }, () => {
     assert.equal(termRes.status, 403)
   })
 
-  it('returns 404 for unknown tableId', async () => {
+  it('returns 404 for unknown tableId', { timeout: 10000 }, async () => {
     const host = players[0]
     const fakeId = '00000000-0000-0000-0000-000000000000'
     const termRes = await fetch(`${server.baseUrl}/api/tables/${fakeId}/terminate`, {
@@ -178,7 +178,7 @@ describe('POST /api/tables/:tableId/terminate', { skip }, () => {
     assert.equal(termRes.status, 404)
   })
 
-  it('returns 401 without auth headers', async () => {
+  it('returns 401 without auth headers', { timeout: 10000 }, async () => {
     const res = await fetch(`${server.baseUrl}/api/tables/some-id/terminate`, {
       method: 'POST',
     })

--- a/test/integration/social/profile.test.js
+++ b/test/integration/social/profile.test.js
@@ -113,7 +113,7 @@ describe('GET /api/profile/:playerId', { skip }, () => {
     await closeDb()
   })
 
-  it('returns 200 with profile data for a known player', async () => {
+  it('returns 200 with profile data for a known player', { timeout: 10000 }, async () => {
     const playerId = await insertTestPlayer(db, {
       email: 'profile_basic@test.spades.invalid',
       username: 'profile_basic',
@@ -131,7 +131,7 @@ describe('GET /api/profile/:playerId', { skip }, () => {
     assert.ok(Array.isArray(body.recentGames), 'recentGames should be an array')
   })
 
-  it('returns default avatar and cosmetics for a player with no profile record', async () => {
+  it('returns default avatar and cosmetics for a player with no profile record', { timeout: 10000 }, async () => {
     const playerId = await insertTestPlayer(db, {
       email: 'profile_defaults@test.spades.invalid',
       username: 'profile_defaults',
@@ -145,7 +145,7 @@ describe('GET /api/profile/:playerId', { skip }, () => {
     assert.equal(body.cosmetics.cardBack, 'standard-red')
   })
 
-  it('returns custom avatar and cosmetics when a profile record exists', async () => {
+  it('returns custom avatar and cosmetics when a profile record exists', { timeout: 10000 }, async () => {
     const playerId = await insertTestPlayer(db, {
       email: 'profile_custom@test.spades.invalid',
       username: 'profile_custom',
@@ -164,7 +164,7 @@ describe('GET /api/profile/:playerId', { skip }, () => {
     assert.equal(body.cosmetics.cardBack, 'minimal')
   })
 
-  it('returns correct career win/loss counts', async () => {
+  it('returns correct career win/loss counts', { timeout: 10000 }, async () => {
     const playerId = await insertTestPlayer(db, {
       email: 'profile_career@test.spades.invalid',
       username: 'profile_career',
@@ -180,7 +180,7 @@ describe('GET /api/profile/:playerId', { skip }, () => {
     assert.equal(body.career.losses, 1)
   })
 
-  it('returns zero wins and losses for a player with no games', async () => {
+  it('returns zero wins and losses for a player with no games', { timeout: 10000 }, async () => {
     const playerId = await insertTestPlayer(db, {
       email: 'profile_nogames@test.spades.invalid',
       username: 'profile_nogames',
@@ -194,7 +194,7 @@ describe('GET /api/profile/:playerId', { skip }, () => {
     assert.deepEqual(body.recentGames, [])
   })
 
-  it('returns at most 20 recent games ordered most recent first', async () => {
+  it('returns at most 20 recent games ordered most recent first', { timeout: 10000 }, async () => {
     const playerId = await insertTestPlayer(db, {
       email: 'profile_history@test.spades.invalid',
       username: 'profile_history',
@@ -223,7 +223,7 @@ describe('GET /api/profile/:playerId', { skip }, () => {
     }
   })
 
-  it('recent games include gameId, playedAt, won, scoreNs, scoreEw, seat', async () => {
+  it('recent games include gameId, playedAt, won, scoreNs, scoreEw, seat', { timeout: 10000 }, async () => {
     const playerId = await insertTestPlayer(db, {
       email: 'profile_gamefields@test.spades.invalid',
       username: 'profile_gamefields',
@@ -243,14 +243,14 @@ describe('GET /api/profile/:playerId', { skip }, () => {
     assert.equal(game.seat, 'east')
   })
 
-  it('returns 404 for an unknown playerId', async () => {
+  it('returns 404 for an unknown playerId', { timeout: 10000 }, async () => {
     const res = await fetch(
       `${server.baseUrl}/api/profile/00000000-0000-4000-8000-000000000000`,
     )
     assert.equal(res.status, 404)
   })
 
-  it('returns 400 for a non-UUID playerId', async () => {
+  it('returns 400 for a non-UUID playerId', { timeout: 10000 }, async () => {
     const res = await fetch(`${server.baseUrl}/api/profile/not-a-uuid`)
     assert.equal(res.status, 400)
   })

--- a/test/unit/anticheat/validate.test.js
+++ b/test/unit/anticheat/validate.test.js
@@ -24,8 +24,8 @@ function makeState(overrides = {}) {
   }
 }
 
-describe('validateCardPlay — phase and turn checks', () => {
-  it('throws INVALID_ACTION when game is not in playing phase', () => {
+describe('validateCardPlay — phase and turn checks', { timeout: 2000 }, () => {
+  it('throws INVALID_ACTION when game is not in playing phase', { timeout: 2000 }, () => {
     const state = makeState({ phase: 'bidding' })
     const err = assert.throws(
       () => validateCardPlay(state, 'east', { suit: 'clubs', rank: 'A' }),
@@ -33,7 +33,7 @@ describe('validateCardPlay — phase and turn checks', () => {
     )
   })
 
-  it('throws NOT_YOUR_TURN when it is not the player\'s turn', () => {
+  it('throws NOT_YOUR_TURN when it is not the player\'s turn', { timeout: 2000 }, () => {
     const state = makeState({ currentPlayerSeat: 'north' })
     assert.throws(
       () => validateCardPlay(state, 'east', { suit: 'clubs', rank: 'A' }),
@@ -41,7 +41,7 @@ describe('validateCardPlay — phase and turn checks', () => {
     )
   })
 
-  it('throws CARD_NOT_IN_HAND when player tries to play a card they do not hold', () => {
+  it('throws CARD_NOT_IN_HAND when player tries to play a card they do not hold', { timeout: 2000 }, () => {
     const state = makeState()
     assert.throws(
       () => validateCardPlay(state, 'east', { suit: 'diamonds', rank: '2' }),
@@ -50,15 +50,15 @@ describe('validateCardPlay — phase and turn checks', () => {
   })
 })
 
-describe('validateCardPlay — no Spade lead on first trick', () => {
-  it('allows leading a non-spade on the first trick', () => {
+describe('validateCardPlay — no Spade lead on first trick', { timeout: 2000 }, () => {
+  it('allows leading a non-spade on the first trick', { timeout: 2000 }, () => {
     const state = makeState()
     assert.doesNotThrow(() =>
       validateCardPlay(state, 'east', { suit: 'clubs', rank: 'A' }),
     )
   })
 
-  it('rejects leading a spade on the first trick when non-spades are available', () => {
+  it('rejects leading a spade on the first trick when non-spades are available', { timeout: 2000 }, () => {
     const state = makeState()
     // East has clubs, hearts, and spades — leading spades is illegal
     assert.throws(
@@ -67,7 +67,7 @@ describe('validateCardPlay — no Spade lead on first trick', () => {
     )
   })
 
-  it('allows leading a spade on the first trick when hand contains only spades', () => {
+  it('allows leading a spade on the first trick when hand contains only spades', { timeout: 2000 }, () => {
     const state = makeState({
       hands: {
         east: [
@@ -81,7 +81,7 @@ describe('validateCardPlay — no Spade lead on first trick', () => {
     )
   })
 
-  it('rejects playing a spade on the first trick when following (void in led suit) and non-spades exist', () => {
+  it('rejects playing a spade on the first trick when following (void in led suit) and non-spades exist', { timeout: 2000 }, () => {
     // A heart was led; east has no hearts but has clubs and spades
     const state = makeState({
       currentTrick: [{ seat: 'north', card: { suit: 'hearts', rank: 'Q' } }],
@@ -98,7 +98,7 @@ describe('validateCardPlay — no Spade lead on first trick', () => {
     )
   })
 
-  it('allows playing a spade on the first trick when following and only spades remain after exhausting led suit', () => {
+  it('allows playing a spade on the first trick when following and only spades remain after exhausting led suit', { timeout: 2000 }, () => {
     // A heart was led; east has only spades left — must play spades
     const state = makeState({
       currentTrick: [{ seat: 'north', card: { suit: 'hearts', rank: 'Q' } }],
@@ -111,7 +111,7 @@ describe('validateCardPlay — no Spade lead on first trick', () => {
     )
   })
 
-  it('enforces suit-following on the first trick (must follow led suit if able)', () => {
+  it('enforces suit-following on the first trick (must follow led suit if able)', { timeout: 2000 }, () => {
     // A clubs was led; east has a clubs — must follow suit, cannot play hearts
     const state = makeState({
       currentTrick: [{ seat: 'north', card: { suit: 'clubs', rank: '2' } }],
@@ -129,7 +129,7 @@ describe('validateCardPlay — no Spade lead on first trick', () => {
   })
 })
 
-describe('validateBidTurn — phase and turn checks', () => {
+describe('validateBidTurn — phase and turn checks', { timeout: 2000 }, () => {
   function makeBidState(overrides = {}) {
     return {
       phase: 'bidding',
@@ -138,7 +138,7 @@ describe('validateBidTurn — phase and turn checks', () => {
     }
   }
 
-  it('throws INVALID_ACTION when game is not in bidding phase', () => {
+  it('throws INVALID_ACTION when game is not in bidding phase', { timeout: 2000 }, () => {
     const state = makeBidState({ phase: 'playing' })
     assert.throws(
       () => validateBidTurn(state, 'north'),
@@ -146,7 +146,7 @@ describe('validateBidTurn — phase and turn checks', () => {
     )
   })
 
-  it('throws NOT_YOUR_TURN when it is not the player\'s turn to bid', () => {
+  it('throws NOT_YOUR_TURN when it is not the player\'s turn to bid', { timeout: 2000 }, () => {
     const state = makeBidState({ currentBidderSeat: 'east' })
     assert.throws(
       () => validateBidTurn(state, 'north'),
@@ -154,14 +154,14 @@ describe('validateBidTurn — phase and turn checks', () => {
     )
   })
 
-  it('does not throw when phase is bidding and it is the player\'s turn', () => {
+  it('does not throw when phase is bidding and it is the player\'s turn', { timeout: 2000 }, () => {
     const state = makeBidState()
     assert.doesNotThrow(() => validateBidTurn(state, 'north'))
   })
 })
 
-describe('validateCardPlay — Spades breaking (subsequent tricks)', () => {
-  it('rejects leading a spade before spades are broken when non-spades are available', () => {
+describe('validateCardPlay — Spades breaking (subsequent tricks)', { timeout: 2000 }, () => {
+  it('rejects leading a spade before spades are broken when non-spades are available', { timeout: 2000 }, () => {
     const state = makeState({
       isFirstTrick: false,
       spadesbroken: false,
@@ -179,7 +179,7 @@ describe('validateCardPlay — Spades breaking (subsequent tricks)', () => {
     )
   })
 
-  it('allows leading a spade after spades are broken', () => {
+  it('allows leading a spade after spades are broken', { timeout: 2000 }, () => {
     const state = makeState({
       isFirstTrick: false,
       spadesbroken: true,
@@ -196,7 +196,7 @@ describe('validateCardPlay — Spades breaking (subsequent tricks)', () => {
     )
   })
 
-  it('allows playing any card on non-first trick when void in led suit', () => {
+  it('allows playing any card on non-first trick when void in led suit', { timeout: 2000 }, () => {
     const state = makeState({
       isFirstTrick: false,
       spadesbroken: false,

--- a/test/unit/auth/email.test.js
+++ b/test/unit/auth/email.test.js
@@ -2,8 +2,8 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { buildVerificationEmailContent, buildPasswordResetEmailContent } from '../../../server/auth/email.js'
 
-describe('buildVerificationEmailContent', () => {
-  it('includes the full verification URL in the plain-text body', () => {
+describe('buildVerificationEmailContent', { timeout: 2000 }, () => {
+  it('includes the full verification URL in the plain-text body', { timeout: 2000 }, () => {
     const token = 'abc-123-token'
     const appUrl = 'https://spades.example.com'
     const { text } = buildVerificationEmailContent(token, appUrl)
@@ -13,7 +13,7 @@ describe('buildVerificationEmailContent', () => {
     )
   })
 
-  it('includes the full verification URL in the HTML body', () => {
+  it('includes the full verification URL in the HTML body', { timeout: 2000 }, () => {
     const token = 'abc-123-token'
     const appUrl = 'https://spades.example.com'
     const { html } = buildVerificationEmailContent(token, appUrl)
@@ -23,19 +23,19 @@ describe('buildVerificationEmailContent', () => {
     )
   })
 
-  it('has a non-empty subject line', () => {
+  it('has a non-empty subject line', { timeout: 2000 }, () => {
     const { subject } = buildVerificationEmailContent('tok', 'https://example.com')
     assert.ok(typeof subject === 'string' && subject.length > 0)
   })
 
-  it('mentions the 24-hour expiry window', () => {
+  it('mentions the 24-hour expiry window', { timeout: 2000 }, () => {
     const { text } = buildVerificationEmailContent('tok', 'https://example.com')
     assert.ok(text.includes('24 hours'), 'should tell the user the link expires in 24 hours')
   })
 })
 
-describe('buildPasswordResetEmailContent', () => {
-  it('includes the full reset URL in the plain-text body', () => {
+describe('buildPasswordResetEmailContent', { timeout: 2000 }, () => {
+  it('includes the full reset URL in the plain-text body', { timeout: 2000 }, () => {
     const token = 'reset-token-123'
     const appUrl = 'https://spades.example.com'
     const { text } = buildPasswordResetEmailContent(token, appUrl)
@@ -45,7 +45,7 @@ describe('buildPasswordResetEmailContent', () => {
     )
   })
 
-  it('includes the full reset URL in the HTML body', () => {
+  it('includes the full reset URL in the HTML body', { timeout: 2000 }, () => {
     const token = 'reset-token-123'
     const appUrl = 'https://spades.example.com'
     const { html } = buildPasswordResetEmailContent(token, appUrl)
@@ -55,12 +55,12 @@ describe('buildPasswordResetEmailContent', () => {
     )
   })
 
-  it('has a non-empty subject line', () => {
+  it('has a non-empty subject line', { timeout: 2000 }, () => {
     const { subject } = buildPasswordResetEmailContent('tok', 'https://example.com')
     assert.ok(typeof subject === 'string' && subject.length > 0)
   })
 
-  it('mentions the 1-hour expiry window', () => {
+  it('mentions the 1-hour expiry window', { timeout: 2000 }, () => {
     const { text } = buildPasswordResetEmailContent('tok', 'https://example.com')
     assert.ok(text.includes('1 hour'), 'should tell the user the link expires in 1 hour')
   })

--- a/test/unit/auth/passwordReset.test.js
+++ b/test/unit/auth/passwordReset.test.js
@@ -2,8 +2,8 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { forgotPassword, resetPassword } from '../../../server/auth/passwordReset.js'
 
-describe('forgotPassword', () => {
-  it('succeeds silently when email is not found (prevents enumeration)', async () => {
+describe('forgotPassword', { timeout: 2000 }, () => {
+  it('succeeds silently when email is not found (prevents enumeration)', { timeout: 2000 }, async () => {
     const db = {
       query: async (sql) => {
         if (sql.includes('SELECT')) return { rows: [] }
@@ -15,7 +15,7 @@ describe('forgotPassword', () => {
     assert.equal(emails.length, 0)
   })
 
-  it('deletes old tokens, creates a new one, and sends email for existing player', async () => {
+  it('deletes old tokens, creates a new one, and sends email for existing player', { timeout: 2000 }, async () => {
     const queries = []
     const db = {
       query: async (sql, params) => {
@@ -39,7 +39,7 @@ describe('forgotPassword', () => {
     assert.equal(emails[0], 'alice@example.com')
   })
 
-  it('normalises email to lowercase before lookup', async () => {
+  it('normalises email to lowercase before lookup', { timeout: 2000 }, async () => {
     const lookups = []
     const db = {
       query: async (sql, params) => {
@@ -50,13 +50,13 @@ describe('forgotPassword', () => {
         return { rows: [] }
       },
     }
-    await forgotPassword(db, 'Alice@EXAMPLE.COM', async () => {})
+    await forgotPassword(db, 'Alice@EXAMPLE.COM', { timeout: 2000 }, async () => {})
     assert.equal(lookups[0], 'alice@example.com')
   })
 })
 
-describe('resetPassword', () => {
-  it('throws VALIDATION_ERROR when token is missing', async () => {
+describe('resetPassword', { timeout: 2000 }, () => {
+  it('throws VALIDATION_ERROR when token is missing', { timeout: 2000 }, async () => {
     const db = {}
     await assert.rejects(
       () => resetPassword(db, undefined, 'newpassword123'),
@@ -67,7 +67,7 @@ describe('resetPassword', () => {
     )
   })
 
-  it('throws VALIDATION_ERROR when new password is too short', async () => {
+  it('throws VALIDATION_ERROR when new password is too short', { timeout: 2000 }, async () => {
     const db = {}
     await assert.rejects(
       () => resetPassword(db, 'some-token', 'short'),
@@ -78,7 +78,7 @@ describe('resetPassword', () => {
     )
   })
 
-  it('throws INVALID_TOKEN when token is not found', async () => {
+  it('throws INVALID_TOKEN when token is not found', { timeout: 2000 }, async () => {
     const db = {
       query: async () => ({ rows: [] }),
     }
@@ -91,7 +91,7 @@ describe('resetPassword', () => {
     )
   })
 
-  it('throws EXPIRED_TOKEN when token is past its expiry', async () => {
+  it('throws EXPIRED_TOKEN when token is past its expiry', { timeout: 2000 }, async () => {
     const db = {
       query: async (sql) => {
         if (sql.includes('SELECT')) {
@@ -111,7 +111,7 @@ describe('resetPassword', () => {
     )
   })
 
-  it('updates the password hash and deletes the token on success', async () => {
+  it('updates the password hash and deletes the token on success', { timeout: 2000 }, async () => {
     const queries = []
     const db = {
       query: async (sql, params) => {

--- a/test/unit/auth/registration.test.js
+++ b/test/unit/auth/registration.test.js
@@ -9,33 +9,33 @@ import {
   resendVerificationEmail,
 } from '../../../server/auth/registration.js'
 
-describe('hashPassword', () => {
-  it('produces a non-empty hash', async () => {
+describe('hashPassword', { timeout: 2000 }, () => {
+  it('produces a non-empty hash', { timeout: 2000 }, async () => {
     const hash = await hashPassword('hunter2')
     assert.ok(hash.length > 0)
   })
 
-  it('produces different hashes for the same password (bcrypt salting)', async () => {
+  it('produces different hashes for the same password (bcrypt salting)', { timeout: 2000 }, async () => {
     const hash1 = await hashPassword('hunter2')
     const hash2 = await hashPassword('hunter2')
     assert.notEqual(hash1, hash2)
   })
 })
 
-describe('verifyPassword', () => {
-  it('returns true for correct password', async () => {
+describe('verifyPassword', { timeout: 2000 }, () => {
+  it('returns true for correct password', { timeout: 2000 }, async () => {
     const hash = await hashPassword('correcthorse')
     assert.ok(await verifyPassword('correcthorse', hash))
   })
 
-  it('returns false for wrong password', async () => {
+  it('returns false for wrong password', { timeout: 2000 }, async () => {
     const hash = await hashPassword('correcthorse')
     assert.ok(!(await verifyPassword('wrongpassword', hash)))
   })
 })
 
-describe('generateVerificationToken', () => {
-  it('returns a UUID v4-formatted string', () => {
+describe('generateVerificationToken', { timeout: 2000 }, () => {
+  it('returns a UUID v4-formatted string', { timeout: 2000 }, () => {
     const token = generateVerificationToken()
     assert.match(
       token,
@@ -43,16 +43,16 @@ describe('generateVerificationToken', () => {
     )
   })
 
-  it('returns unique tokens on each call', () => {
+  it('returns unique tokens on each call', { timeout: 2000 }, () => {
     const tokens = new Set(Array.from({ length: 100 }, generateVerificationToken))
     assert.equal(tokens.size, 100)
   })
 })
 
-describe('registerPlayer — input validation', () => {
+describe('registerPlayer — input validation', { timeout: 2000 }, () => {
   const noop = async () => {}
 
-  it('throws VALIDATION_ERROR when email is missing', async () => {
+  it('throws VALIDATION_ERROR when email is missing', { timeout: 2000 }, async () => {
     const db = {}
     await assert.rejects(
       () => registerPlayer(db, { username: 'alice', password: 'password123' }, noop),
@@ -63,7 +63,7 @@ describe('registerPlayer — input validation', () => {
     )
   })
 
-  it('throws VALIDATION_ERROR when username is missing', async () => {
+  it('throws VALIDATION_ERROR when username is missing', { timeout: 2000 }, async () => {
     const db = {}
     await assert.rejects(
       () => registerPlayer(db, { email: 'a@b.com', password: 'password123' }, noop),
@@ -74,7 +74,7 @@ describe('registerPlayer — input validation', () => {
     )
   })
 
-  it('throws VALIDATION_ERROR when password is missing', async () => {
+  it('throws VALIDATION_ERROR when password is missing', { timeout: 2000 }, async () => {
     const db = {}
     await assert.rejects(
       () => registerPlayer(db, { email: 'a@b.com', username: 'alice' }, noop),
@@ -85,7 +85,7 @@ describe('registerPlayer — input validation', () => {
     )
   })
 
-  it('throws VALIDATION_ERROR when password is too short', async () => {
+  it('throws VALIDATION_ERROR when password is too short', { timeout: 2000 }, async () => {
     const db = {}
     await assert.rejects(
       () => registerPlayer(db, { email: 'a@b.com', username: 'alice', password: 'short' }, noop),
@@ -96,7 +96,7 @@ describe('registerPlayer — input validation', () => {
     )
   })
 
-  it('normalises email to lowercase before insert', async () => {
+  it('normalises email to lowercase before insert', { timeout: 2000 }, async () => {
     let capturedEmail
     const db = {
       query: async (sql, params) => {
@@ -116,8 +116,8 @@ describe('registerPlayer — input validation', () => {
   })
 })
 
-describe('resendVerificationEmail', () => {
-  it('succeeds silently when email is not found (prevents enumeration)', async () => {
+describe('resendVerificationEmail', { timeout: 2000 }, () => {
+  it('succeeds silently when email is not found (prevents enumeration)', { timeout: 2000 }, async () => {
     const db = {
       query: async (sql) => {
         if (sql.includes('SELECT')) return { rows: [] }
@@ -129,7 +129,7 @@ describe('resendVerificationEmail', () => {
     assert.equal(emails.length, 0)
   })
 
-  it('succeeds silently when player is already verified (prevents enumeration)', async () => {
+  it('succeeds silently when player is already verified (prevents enumeration)', { timeout: 2000 }, async () => {
     const db = {
       query: async (sql) => {
         if (sql.includes('SELECT')) return { rows: [{ id: 'player-1', is_verified: true }] }
@@ -141,7 +141,7 @@ describe('resendVerificationEmail', () => {
     assert.equal(emails.length, 0)
   })
 
-  it('deletes old tokens and sends a new one for unverified player', async () => {
+  it('deletes old tokens and sends a new one for unverified player', { timeout: 2000 }, async () => {
     const queries = []
     const db = {
       query: async (sql, params) => {
@@ -159,7 +159,7 @@ describe('resendVerificationEmail', () => {
     assert.equal(emails[0], 'alice@example.com')
   })
 
-  it('normalises email to lowercase before lookup', async () => {
+  it('normalises email to lowercase before lookup', { timeout: 2000 }, async () => {
     const lookups = []
     const db = {
       query: async (sql, params) => {
@@ -170,13 +170,13 @@ describe('resendVerificationEmail', () => {
         return { rows: [] }
       },
     }
-    await resendVerificationEmail(db, 'Alice@EXAMPLE.COM', async () => {})
+    await resendVerificationEmail(db, 'Alice@EXAMPLE.COM', { timeout: 2000 }, async () => {})
     assert.equal(lookups[0], 'alice@example.com')
   })
 })
 
-describe('registerPlayer — DEV_AUTO_VERIFY', () => {
-  it('skips email and token when DEV_AUTO_VERIFY=true', async () => {
+describe('registerPlayer — DEV_AUTO_VERIFY', { timeout: 2000 }, () => {
+  it('skips email and token when DEV_AUTO_VERIFY=true', { timeout: 2000 }, async () => {
     process.env.DEV_AUTO_VERIFY = 'true'
     const queries = []
     const emailsSent = []
@@ -206,7 +206,7 @@ describe('registerPlayer — DEV_AUTO_VERIFY', () => {
     assert.equal(playerInsert.params[3], true)
   })
 
-  it('does NOT skip verification when NODE_ENV=production, even if DEV_AUTO_VERIFY=true', async () => {
+  it('does NOT skip verification when NODE_ENV=production, even if DEV_AUTO_VERIFY=true', { timeout: 2000 }, async () => {
     process.env.DEV_AUTO_VERIFY = 'true'
     process.env.NODE_ENV = 'production'
     const emailsSent = []
@@ -227,7 +227,7 @@ describe('registerPlayer — DEV_AUTO_VERIFY', () => {
     assert.equal(emailsSent.length, 1, 'should still send verification email in production')
   })
 
-  it('sends email normally when DEV_AUTO_VERIFY is not set', async () => {
+  it('sends email normally when DEV_AUTO_VERIFY is not set', { timeout: 2000 }, async () => {
     delete process.env.DEV_AUTO_VERIFY
     const emailsSent = []
     const db = {
@@ -246,8 +246,8 @@ describe('registerPlayer — DEV_AUTO_VERIFY', () => {
   })
 })
 
-describe('verifyEmailToken — input validation', () => {
-  it('throws VALIDATION_ERROR when token is missing', async () => {
+describe('verifyEmailToken — input validation', { timeout: 2000 }, () => {
+  it('throws VALIDATION_ERROR when token is missing', { timeout: 2000 }, async () => {
     const db = {}
     await assert.rejects(
       () => verifyEmailToken(db, undefined),
@@ -258,7 +258,7 @@ describe('verifyEmailToken — input validation', () => {
     )
   })
 
-  it('throws INVALID_TOKEN when token is not found', async () => {
+  it('throws INVALID_TOKEN when token is not found', { timeout: 2000 }, async () => {
     const db = {
       query: async () => ({ rows: [] }),
     }
@@ -271,7 +271,7 @@ describe('verifyEmailToken — input validation', () => {
     )
   })
 
-  it('throws EXPIRED_TOKEN when token is past its expiry', async () => {
+  it('throws EXPIRED_TOKEN when token is past its expiry', { timeout: 2000 }, async () => {
     const db = {
       query: async (sql) => {
         if (sql.includes('SELECT')) {

--- a/test/unit/game/bid.test.js
+++ b/test/unit/game/bid.test.js
@@ -11,156 +11,156 @@ import {
   TEAM_FOR_SEAT,
 } from '../../../server/game/bid.js'
 
-describe('getBiddingOrder', () => {
-  it('starts with player left of dealer (clockwise)', () => {
+describe('getBiddingOrder', { timeout: 2000 }, () => {
+  it('starts with player left of dealer (clockwise)', { timeout: 2000 }, () => {
     // North deals → east goes first
     const order = getBiddingOrder('north')
     assert.deepEqual(order, ['east', 'south', 'west', 'north'])
   })
 
-  it('rotates correctly for east dealer', () => {
+  it('rotates correctly for east dealer', { timeout: 2000 }, () => {
     const order = getBiddingOrder('east')
     assert.deepEqual(order, ['south', 'west', 'north', 'east'])
   })
 
-  it('rotates correctly for south dealer', () => {
+  it('rotates correctly for south dealer', { timeout: 2000 }, () => {
     const order = getBiddingOrder('south')
     assert.deepEqual(order, ['west', 'north', 'east', 'south'])
   })
 
-  it('rotates correctly for west dealer', () => {
+  it('rotates correctly for west dealer', { timeout: 2000 }, () => {
     const order = getBiddingOrder('west')
     assert.deepEqual(order, ['north', 'east', 'south', 'west'])
   })
 })
 
-describe('TEAM_FOR_SEAT', () => {
-  it('north and south are on ns team', () => {
+describe('TEAM_FOR_SEAT', { timeout: 2000 }, () => {
+  it('north and south are on ns team', { timeout: 2000 }, () => {
     assert.equal(TEAM_FOR_SEAT.north, 'ns')
     assert.equal(TEAM_FOR_SEAT.south, 'ns')
   })
 
-  it('east and west are on ew team', () => {
+  it('east and west are on ew team', { timeout: 2000 }, () => {
     assert.equal(TEAM_FOR_SEAT.east, 'ew')
     assert.equal(TEAM_FOR_SEAT.west, 'ew')
   })
 })
 
-describe('getPartnerSeat', () => {
-  it('north partner is south', () => {
+describe('getPartnerSeat', { timeout: 2000 }, () => {
+  it('north partner is south', { timeout: 2000 }, () => {
     assert.equal(getPartnerSeat('north'), 'south')
   })
 
-  it('south partner is north', () => {
+  it('south partner is north', { timeout: 2000 }, () => {
     assert.equal(getPartnerSeat('south'), 'north')
   })
 
-  it('east partner is west', () => {
+  it('east partner is west', { timeout: 2000 }, () => {
     assert.equal(getPartnerSeat('east'), 'west')
   })
 
-  it('west partner is east', () => {
+  it('west partner is east', { timeout: 2000 }, () => {
     assert.equal(getPartnerSeat('west'), 'east')
   })
 })
 
-describe('isEligibleForBlindNil', () => {
-  it('eligible when team is 100+ points behind', () => {
+describe('isEligibleForBlindNil', { timeout: 2000 }, () => {
+  it('eligible when team is 100+ points behind', { timeout: 2000 }, () => {
     assert.ok(isEligibleForBlindNil({ ns: 0, ew: 100 }, 'north'))
   })
 
-  it('eligible when exactly 100 behind', () => {
+  it('eligible when exactly 100 behind', { timeout: 2000 }, () => {
     assert.ok(isEligibleForBlindNil({ ns: 50, ew: 150 }, 'north'))
   })
 
-  it('not eligible when less than 100 behind', () => {
+  it('not eligible when less than 100 behind', { timeout: 2000 }, () => {
     assert.ok(!isEligibleForBlindNil({ ns: 50, ew: 149 }, 'north'))
   })
 
-  it('not eligible when ahead', () => {
+  it('not eligible when ahead', { timeout: 2000 }, () => {
     assert.ok(!isEligibleForBlindNil({ ns: 200, ew: 100 }, 'north'))
   })
 
-  it('works for ew team players', () => {
+  it('works for ew team players', { timeout: 2000 }, () => {
     assert.ok(isEligibleForBlindNil({ ns: 200, ew: 50 }, 'east'))
   })
 })
 
-describe('teamHasBlindNil', () => {
-  it('returns true if partner bid blind nil', () => {
+describe('teamHasBlindNil', { timeout: 2000 }, () => {
+  it('returns true if partner bid blind nil', { timeout: 2000 }, () => {
     const bids = { north: 'blind_nil', east: null, south: null, west: null }
     assert.ok(teamHasBlindNil(bids, 'south'))
   })
 
-  it('returns false if no one on team bid blind nil', () => {
+  it('returns false if no one on team bid blind nil', { timeout: 2000 }, () => {
     const bids = { north: 4, east: null, south: null, west: null }
     assert.ok(!teamHasBlindNil(bids, 'north'))
   })
 
-  it('returns true for the blind nil bidder themselves', () => {
+  it('returns true for the blind nil bidder themselves', { timeout: 2000 }, () => {
     const bids = { north: 'blind_nil', east: null, south: null, west: null }
     assert.ok(teamHasBlindNil(bids, 'north'))
   })
 })
 
-describe('isValidBidValue', () => {
-  it('accepts integers 0–13', () => {
+describe('isValidBidValue', { timeout: 2000 }, () => {
+  it('accepts integers 0–13', { timeout: 2000 }, () => {
     for (let i = 0; i <= 13; i++) {
       assert.ok(isValidBidValue(i), `${i} should be valid`)
     }
   })
 
-  it('rejects negative numbers', () => {
+  it('rejects negative numbers', { timeout: 2000 }, () => {
     assert.ok(!isValidBidValue(-1))
   })
 
-  it('rejects 14 and above', () => {
+  it('rejects 14 and above', { timeout: 2000 }, () => {
     assert.ok(!isValidBidValue(14))
   })
 
-  it('accepts "nil"', () => {
+  it('accepts "nil"', { timeout: 2000 }, () => {
     assert.ok(isValidBidValue('nil'))
   })
 
-  it('accepts "blind_nil"', () => {
+  it('accepts "blind_nil"', { timeout: 2000 }, () => {
     assert.ok(isValidBidValue('blind_nil'))
   })
 
-  it('rejects strings other than nil/blind_nil', () => {
+  it('rejects strings other than nil/blind_nil', { timeout: 2000 }, () => {
     assert.ok(!isValidBidValue('five'))
   })
 
-  it('rejects non-integer numbers', () => {
+  it('rejects non-integer numbers', { timeout: 2000 }, () => {
     assert.ok(!isValidBidValue(3.5))
   })
 })
 
-describe('isSecondTeamBidder', () => {
-  it('west is second EW bidder when north deals', () => {
+describe('isSecondTeamBidder', { timeout: 2000 }, () => {
+  it('west is second EW bidder when north deals', { timeout: 2000 }, () => {
     // North deals → order: east, south, west, north
     // EW: east bids first, west bids second
     const order = getBiddingOrder('north')
     assert.ok(isSecondTeamBidder('west', order))
   })
 
-  it('east is NOT second EW bidder when north deals', () => {
+  it('east is NOT second EW bidder when north deals', { timeout: 2000 }, () => {
     const order = getBiddingOrder('north')
     assert.ok(!isSecondTeamBidder('east', order))
   })
 
-  it('north is second NS bidder when north deals', () => {
+  it('north is second NS bidder when north deals', { timeout: 2000 }, () => {
     // North deals → order: east, south, west, north
     // NS: south bids first, north bids second
     const order = getBiddingOrder('north')
     assert.ok(isSecondTeamBidder('north', order))
   })
 
-  it('south is NOT second NS bidder when north deals', () => {
+  it('south is NOT second NS bidder when north deals', { timeout: 2000 }, () => {
     const order = getBiddingOrder('north')
     assert.ok(!isSecondTeamBidder('south', order))
   })
 
-  it('first and second bidder roles rotate with dealer', () => {
+  it('first and second bidder roles rotate with dealer', { timeout: 2000 }, () => {
     // East deals → order: south, west, north, east
     // NS: south bids first, north bids second
     // EW: west bids first, east bids second
@@ -172,8 +172,8 @@ describe('isSecondTeamBidder', () => {
   })
 })
 
-describe('computeTeamBids', () => {
-  it('second bidder number overrides first bidder number', () => {
+describe('computeTeamBids', { timeout: 2000 }, () => {
+  it('second bidder number overrides first bidder number', { timeout: 2000 }, () => {
     // North deals → bidding: east, south, west, north
     // EW: east bids first (4), west bids second (7) → EW team bid = 7
     // NS: south bids first (3), north bids second (5) → NS team bid = 5
@@ -184,7 +184,7 @@ describe('computeTeamBids', () => {
     assert.equal(teamBids.ns, 5)
   })
 
-  it('first bidder number is kept when second bidder bids nil', () => {
+  it('first bidder number is kept when second bidder bids nil', { timeout: 2000 }, () => {
     // EW: east bids 4 first, west bids nil → EW team bid = 4 (east's individual number)
     const bids = { north: 5, east: 4, south: 3, west: 'nil' }
     const biddingOrder = getBiddingOrder('north')
@@ -192,7 +192,7 @@ describe('computeTeamBids', () => {
     assert.equal(teamBids.ew, 4)
   })
 
-  it('returns null team bid for double nil team', () => {
+  it('returns null team bid for double nil team', { timeout: 2000 }, () => {
     // NS: both bid nil
     const bids = { north: 'nil', east: 4, south: 'nil', west: 7 }
     const biddingOrder = getBiddingOrder('north')
@@ -201,7 +201,7 @@ describe('computeTeamBids', () => {
     assert.equal(teamBids.ew, 7)
   })
 
-  it('handles first bidder nil with second bidder number', () => {
+  it('handles first bidder nil with second bidder number', { timeout: 2000 }, () => {
     // EW: east bids nil first, west bids 5 → EW team bid = 5 (west bids the team total, east's nil stands individually)
     const bids = { north: 5, east: 'nil', south: 3, west: 5 }
     const biddingOrder = getBiddingOrder('north')
@@ -209,7 +209,7 @@ describe('computeTeamBids', () => {
     assert.equal(teamBids.ew, 5)
   })
 
-  it('team bid of 0 is preserved', () => {
+  it('team bid of 0 is preserved', { timeout: 2000 }, () => {
     const bids = { north: 0, east: 4, south: 0, west: 7 }
     const biddingOrder = getBiddingOrder('north')
     const teamBids = computeTeamBids(bids, biddingOrder)

--- a/test/unit/game/blindNilHiding.test.js
+++ b/test/unit/game/blindNilHiding.test.js
@@ -28,20 +28,20 @@ function makeNoEligibleState() {
 
 // ── getPlayerView: hand hiding ──────────────────────────────────────────────
 
-describe('getPlayerView — Blind Nil hand hiding', () => {
-  it('eligible player does not receive myHand before revealing', () => {
+describe('getPlayerView — Blind Nil hand hiding', { timeout: 2000 }, () => {
+  it('eligible player does not receive myHand before revealing', { timeout: 2000 }, () => {
     const state = makeNsEligibleState()
     const view = getPlayerView(state, 'north')
     assert.equal(view.myHand, undefined, 'myHand should be omitted for eligible player')
   })
 
-  it('eligible player has blindNilEligible: true before revealing', () => {
+  it('eligible player has blindNilEligible: true before revealing', { timeout: 2000 }, () => {
     const state = makeNsEligibleState()
     const view = getPlayerView(state, 'north')
     assert.equal(view.blindNilEligible, true)
   })
 
-  it('both NS players are eligible when NS is 100+ behind', () => {
+  it('both NS players are eligible when NS is 100+ behind', { timeout: 2000 }, () => {
     const state = makeNsEligibleState()
     const northView = getPlayerView(state, 'north')
     const southView = getPlayerView(state, 'south')
@@ -51,7 +51,7 @@ describe('getPlayerView — Blind Nil hand hiding', () => {
     assert.equal(southView.blindNilEligible, true)
   })
 
-  it('ineligible team (EW) receives full hand immediately', () => {
+  it('ineligible team (EW) receives full hand immediately', { timeout: 2000 }, () => {
     const state = makeNsEligibleState()
     const eastView = getPlayerView(state, 'east')
     const westView = getPlayerView(state, 'west')
@@ -61,13 +61,13 @@ describe('getPlayerView — Blind Nil hand hiding', () => {
     assert.equal(westView.myHand.length, 13)
   })
 
-  it('ineligible player has blindNilEligible: false', () => {
+  it('ineligible player has blindNilEligible: false', { timeout: 2000 }, () => {
     const state = makeNsEligibleState()
     const eastView = getPlayerView(state, 'east')
     assert.equal(eastView.blindNilEligible, false, 'blindNilEligible must be false for ineligible player')
   })
 
-  it('eligible player receives myHand after reveal-hand', () => {
+  it('eligible player receives myHand after reveal-hand', { timeout: 2000 }, () => {
     const state = makeNsEligibleState()
     const revealed = revealHand(state, 'north')
     const view = getPlayerView(revealed, 'north')
@@ -75,14 +75,14 @@ describe('getPlayerView — Blind Nil hand hiding', () => {
     assert.equal(view.myHand.length, 13)
   })
 
-  it('HAND_REVEALED is not sent before reveal-hand — south still hidden after north reveals', () => {
+  it('HAND_REVEALED is not sent before reveal-hand — south still hidden after north reveals', { timeout: 2000 }, () => {
     const state = makeNsEligibleState()
     const revealedNorth = revealHand(state, 'north')
     const southView = getPlayerView(revealedNorth, 'south')
     assert.equal(southView.myHand, undefined, 'south hand should still be hidden')
   })
 
-  it('when no team is eligible all players receive their hand immediately', () => {
+  it('when no team is eligible all players receive their hand immediately', { timeout: 2000 }, () => {
     const state = makeNoEligibleState()
     for (const seat of ['north', 'east', 'south', 'west']) {
       const view = getPlayerView(state, seat)
@@ -94,8 +94,8 @@ describe('getPlayerView — Blind Nil hand hiding', () => {
 
 // ── revealHand: validation ──────────────────────────────────────────────────
 
-describe('revealHand — validation', () => {
-  it('rejects if player is not eligible for Blind Nil', () => {
+describe('revealHand — validation', { timeout: 2000 }, () => {
+  it('rejects if player is not eligible for Blind Nil', { timeout: 2000 }, () => {
     const state = makeNsEligibleState() // EW is not eligible
     assert.throws(
       () => revealHand(state, 'east'),
@@ -106,7 +106,7 @@ describe('revealHand — validation', () => {
     )
   })
 
-  it('rejects if player has already placed a bid', () => {
+  it('rejects if player has already placed a bid', { timeout: 2000 }, () => {
     const state = makeNsEligibleState()
     // Directly set a bid for north (last in bidding order for north dealer)
     const stateWithBid = { ...state, bids: { ...state.bids, north: 4 } }
@@ -119,7 +119,7 @@ describe('revealHand — validation', () => {
     )
   })
 
-  it('rejects if game is not in bidding phase', () => {
+  it('rejects if game is not in bidding phase', { timeout: 2000 }, () => {
     const state = makeNsEligibleState()
     const playingState = { ...state, phase: 'playing' }
     assert.throws(
@@ -131,13 +131,13 @@ describe('revealHand — validation', () => {
     )
   })
 
-  it('succeeds and returns state with seat in handRevealedSeats', () => {
+  it('succeeds and returns state with seat in handRevealedSeats', { timeout: 2000 }, () => {
     const state = makeNsEligibleState()
     const newState = revealHand(state, 'north')
     assert.ok(newState.handRevealedSeats.includes('north'))
   })
 
-  it('does not mutate original state', () => {
+  it('does not mutate original state', { timeout: 2000 }, () => {
     const state = makeNsEligibleState()
     revealHand(state, 'north')
     assert.deepEqual(state.handRevealedSeats, [])
@@ -146,8 +146,8 @@ describe('revealHand — validation', () => {
 
 // ── Bid Blind Nil directly — hand never revealed ────────────────────────────
 
-describe('Blind Nil bid without reveal — hand remains hidden during bidding', () => {
-  it('eligible player who bids Blind Nil directly never reveals their hand during bidding', () => {
+describe('Blind Nil bid without reveal — hand remains hidden during bidding', { timeout: 2000 }, () => {
+  it('eligible player who bids Blind Nil directly never reveals their hand during bidding', { timeout: 2000 }, () => {
     // North dealer → bidding order: east, south, west, north
     // NS is eligible; east bids first (EW), south bids second (NS)
     // Have east bid, then south bid blind_nil directly (without calling reveal-hand)

--- a/test/unit/game/bot.test.js
+++ b/test/unit/game/bot.test.js
@@ -2,15 +2,15 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { isBot, getBotPlayerId, botBid, botPlay, botBlindNilExchange } from '../../../server/game/bot.js'
 
-describe('isBot', () => {
-  it('returns true for bot player IDs', () => {
+describe('isBot', { timeout: 2000 }, () => {
+  it('returns true for bot player IDs', { timeout: 2000 }, () => {
     assert.equal(isBot('bot:north'), true)
     assert.equal(isBot('bot:south'), true)
     assert.equal(isBot('bot:east'), true)
     assert.equal(isBot('bot:west'), true)
   })
 
-  it('returns false for human player IDs', () => {
+  it('returns false for human player IDs', { timeout: 2000 }, () => {
     assert.equal(isBot('some-uuid-player-id'), false)
     assert.equal(isBot(null), false)
     assert.equal(isBot(undefined), false)
@@ -18,8 +18,8 @@ describe('isBot', () => {
   })
 })
 
-describe('getBotPlayerId', () => {
-  it('returns bot:<seat> for each seat', () => {
+describe('getBotPlayerId', { timeout: 2000 }, () => {
+  it('returns bot:<seat> for each seat', { timeout: 2000 }, () => {
     assert.equal(getBotPlayerId('north'), 'bot:north')
     assert.equal(getBotPlayerId('south'), 'bot:south')
     assert.equal(getBotPlayerId('east'), 'bot:east')
@@ -27,8 +27,8 @@ describe('getBotPlayerId', () => {
   })
 })
 
-describe('botBid', () => {
-  it('counts spades in hand', () => {
+describe('botBid', { timeout: 2000 }, () => {
+  it('counts spades in hand', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'spades', rank: 'A' },
       { suit: 'spades', rank: 'K' },
@@ -38,7 +38,7 @@ describe('botBid', () => {
     assert.equal(botBid(hand), 2)
   })
 
-  it('returns 0 when no spades in hand', () => {
+  it('returns 0 when no spades in hand', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'hearts', rank: 'A' },
       { suit: 'clubs', rank: 'K' },
@@ -47,7 +47,7 @@ describe('botBid', () => {
     assert.equal(botBid(hand), 0)
   })
 
-  it('returns 13 when hand is all spades', () => {
+  it('returns 13 when hand is all spades', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'spades', rank: 'A' },
       { suit: 'spades', rank: 'K' },
@@ -66,7 +66,7 @@ describe('botBid', () => {
     assert.equal(botBid(hand), 13)
   })
 
-  describe('second bidder (partnerBid provided)', () => {
+  describe('second bidder (partnerBid provided)', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'spades', rank: 'A' },
       { suit: 'spades', rank: 'K' },
@@ -74,26 +74,26 @@ describe('botBid', () => {
       { suit: 'clubs', rank: '7' },
     ] // 2 spades
 
-    it('returns partner bid + spades when partner bid a number', () => {
+    it('returns partner bid + spades when partner bid a number', { timeout: 2000 }, () => {
       assert.equal(botBid(hand, 4), 6) // team total = 4 + 2
     })
 
-    it('returns partner bid + spades when partner bid 0', () => {
+    it('returns partner bid + spades when partner bid 0', { timeout: 2000 }, () => {
       assert.equal(botBid(hand, 0), 2) // team total = 0 + 2
     })
 
-    it('returns just spades count when partner bid nil', () => {
+    it('returns just spades count when partner bid nil', { timeout: 2000 }, () => {
       assert.equal(botBid(hand, 'nil'), 2)
     })
 
-    it('returns just spades count when partner bid blind_nil', () => {
+    it('returns just spades count when partner bid blind_nil', { timeout: 2000 }, () => {
       assert.equal(botBid(hand, 'blind_nil'), 2)
     })
   })
 })
 
-describe('botPlay', () => {
-  it('returns a card that is in the hand', () => {
+describe('botPlay', { timeout: 2000 }, () => {
+  it('returns a card that is in the hand', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'hearts', rank: 'A' },
       { suit: 'clubs', rank: 'K' },
@@ -103,7 +103,7 @@ describe('botPlay', () => {
     assert.ok(hand.some((c) => c.suit === card.suit && c.rank === card.rank))
   })
 
-  it('does not lead spades on the first trick when alternatives exist', () => {
+  it('does not lead spades on the first trick when alternatives exist', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'hearts', rank: 'A' },
       { suit: 'spades', rank: 'K' },
@@ -112,7 +112,7 @@ describe('botPlay', () => {
     assert.equal(card.suit, 'hearts')
   })
 
-  it('follows suit if possible', () => {
+  it('follows suit if possible', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'hearts', rank: 'A' },
       { suit: 'spades', rank: 'K' },
@@ -122,7 +122,7 @@ describe('botPlay', () => {
     assert.equal(card.suit, 'hearts')
   })
 
-  it('can play any card when cannot follow suit', () => {
+  it('can play any card when cannot follow suit', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'spades', rank: 'K' },
       { suit: 'clubs', rank: '5' },
@@ -132,7 +132,7 @@ describe('botPlay', () => {
     assert.ok(hand.some((c) => c.suit === card.suit && c.rank === card.rank))
   })
 
-  it('returns a card from a single-card hand', () => {
+  it('returns a card from a single-card hand', { timeout: 2000 }, () => {
     const hand = [{ suit: 'clubs', rank: '2' }]
     const card = botPlay(hand, [], false, false)
     assert.equal(card.suit, 'clubs')
@@ -140,7 +140,7 @@ describe('botPlay', () => {
   })
 })
 
-describe('botBlindNilExchange', () => {
+describe('botBlindNilExchange', { timeout: 2000 }, () => {
   const hand = [
     { suit: 'spades', rank: 'A' },
     { suit: 'spades', rank: 'K' },
@@ -149,24 +149,24 @@ describe('botBlindNilExchange', () => {
     { suit: 'diamonds', rank: '3' },
   ]
 
-  it('returns exactly 2 cards', () => {
+  it('returns exactly 2 cards', { timeout: 2000 }, () => {
     const cards = botBlindNilExchange(hand)
     assert.equal(cards.length, 2)
   })
 
-  it('returns cards that are in the hand', () => {
+  it('returns cards that are in the hand', { timeout: 2000 }, () => {
     const cards = botBlindNilExchange(hand)
     for (const card of cards) {
       assert.ok(hand.some((c) => c.suit === card.suit && c.rank === card.rank))
     }
   })
 
-  it('returns 2 distinct cards (no duplicate)', () => {
+  it('returns 2 distinct cards (no duplicate)', { timeout: 2000 }, () => {
     const cards = botBlindNilExchange(hand)
     assert.notDeepEqual(cards[0], cards[1])
   })
 
-  it('does not mutate the original hand', () => {
+  it('does not mutate the original hand', { timeout: 2000 }, () => {
     const originalLength = hand.length
     botBlindNilExchange(hand)
     assert.equal(hand.length, originalLength)

--- a/test/unit/game/deck.test.js
+++ b/test/unit/game/deck.test.js
@@ -11,13 +11,13 @@ import {
   RANKS,
 } from '../../../server/game/deck.js'
 
-describe('createDeck', () => {
-  it('returns 52 cards', () => {
+describe('createDeck', { timeout: 2000 }, () => {
+  it('returns 52 cards', { timeout: 2000 }, () => {
     const deck = createDeck()
     assert.equal(deck.length, 52)
   })
 
-  it('has 13 cards per suit', () => {
+  it('has 13 cards per suit', { timeout: 2000 }, () => {
     const deck = createDeck()
     for (const suit of SUITS) {
       const count = deck.filter((c) => c.suit === suit).length
@@ -25,7 +25,7 @@ describe('createDeck', () => {
     }
   })
 
-  it('has 4 of each rank', () => {
+  it('has 4 of each rank', { timeout: 2000 }, () => {
     const deck = createDeck()
     for (const rank of RANKS) {
       const count = deck.filter((c) => c.rank === rank).length
@@ -33,28 +33,28 @@ describe('createDeck', () => {
     }
   })
 
-  it('has no duplicate cards', () => {
+  it('has no duplicate cards', { timeout: 2000 }, () => {
     const deck = createDeck()
     const unique = new Set(deck.map((c) => `${c.suit}:${c.rank}`))
     assert.equal(unique.size, 52)
   })
 })
 
-describe('shuffle', () => {
-  it('returns a deck with 52 cards', () => {
+describe('shuffle', { timeout: 2000 }, () => {
+  it('returns a deck with 52 cards', { timeout: 2000 }, () => {
     const deck = createDeck()
     const shuffled = shuffle(deck)
     assert.equal(shuffled.length, 52)
   })
 
-  it('does not mutate the original deck', () => {
+  it('does not mutate the original deck', { timeout: 2000 }, () => {
     const deck = createDeck()
     const original = deck.map((c) => ({ ...c }))
     shuffle(deck)
     assert.deepEqual(deck, original)
   })
 
-  it('contains the same cards as the original', () => {
+  it('contains the same cards as the original', { timeout: 2000 }, () => {
     const deck = createDeck()
     const shuffled = shuffle(deck)
     const toKey = (c) => `${c.suit}:${c.rank}`
@@ -65,8 +65,8 @@ describe('shuffle', () => {
   })
 })
 
-describe('deal', () => {
-  it('returns 4 hands of 13 cards each', () => {
+describe('deal', { timeout: 2000 }, () => {
+  it('returns 4 hands of 13 cards each', { timeout: 2000 }, () => {
     const deck = shuffle(createDeck())
     const hands = deal(deck)
     for (const seat of ['north', 'east', 'south', 'west']) {
@@ -74,7 +74,7 @@ describe('deal', () => {
     }
   })
 
-  it('distributes all 52 cards without duplication', () => {
+  it('distributes all 52 cards without duplication', { timeout: 2000 }, () => {
     const deck = shuffle(createDeck())
     const hands = deal(deck)
     const allCards = [
@@ -89,8 +89,8 @@ describe('deal', () => {
   })
 })
 
-describe('sortHand', () => {
-  it('sorts spades before hearts before clubs before diamonds', () => {
+describe('sortHand', { timeout: 2000 }, () => {
+  it('sorts spades before hearts before clubs before diamonds', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'spades', rank: '2' },
       { suit: 'hearts', rank: '3' },
@@ -104,7 +104,7 @@ describe('sortHand', () => {
     assert.equal(sorted[3].suit, 'diamonds')
   })
 
-  it('sorts by rank descending within the same suit', () => {
+  it('sorts by rank descending within the same suit', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'clubs', rank: 'A' },
       { suit: 'clubs', rank: '2' },
@@ -118,7 +118,7 @@ describe('sortHand', () => {
     )
   })
 
-  it('does not mutate the original hand', () => {
+  it('does not mutate the original hand', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'spades', rank: 'A' },
       { suit: 'clubs', rank: '2' },
@@ -129,40 +129,40 @@ describe('sortHand', () => {
   })
 })
 
-describe('rankValue', () => {
-  it('returns a higher value for A than K', () => {
+describe('rankValue', { timeout: 2000 }, () => {
+  it('returns a higher value for A than K', { timeout: 2000 }, () => {
     assert.ok(rankValue('A') > rankValue('K'))
   })
 
-  it('returns a higher value for K than Q', () => {
+  it('returns a higher value for K than Q', { timeout: 2000 }, () => {
     assert.ok(rankValue('K') > rankValue('Q'))
   })
 
-  it('returns a higher value for 10 than 9', () => {
+  it('returns a higher value for 10 than 9', { timeout: 2000 }, () => {
     assert.ok(rankValue('10') > rankValue('9'))
   })
 
-  it('returns a higher value for J than 10', () => {
+  it('returns a higher value for J than 10', { timeout: 2000 }, () => {
     assert.ok(rankValue('J') > rankValue('10'))
   })
 
-  it('returns the lowest value for 2', () => {
+  it('returns the lowest value for 2', { timeout: 2000 }, () => {
     for (const r of RANKS.filter((r) => r !== '2')) {
       assert.ok(rankValue('2') < rankValue(r), `2 should be less than ${r}`)
     }
   })
 })
 
-describe('cardEquals', () => {
-  it('returns true for the same card', () => {
+describe('cardEquals', { timeout: 2000 }, () => {
+  it('returns true for the same card', { timeout: 2000 }, () => {
     assert.ok(cardEquals({ suit: 'spades', rank: 'A' }, { suit: 'spades', rank: 'A' }))
   })
 
-  it('returns false when suit differs', () => {
+  it('returns false when suit differs', { timeout: 2000 }, () => {
     assert.ok(!cardEquals({ suit: 'spades', rank: 'A' }, { suit: 'hearts', rank: 'A' }))
   })
 
-  it('returns false when rank differs', () => {
+  it('returns false when rank differs', { timeout: 2000 }, () => {
     assert.ok(!cardEquals({ suit: 'spades', rank: 'A' }, { suit: 'spades', rank: 'K' }))
   })
 })

--- a/test/unit/game/handHistory.test.js
+++ b/test/unit/game/handHistory.test.js
@@ -72,27 +72,27 @@ function completeOneHand(state) {
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 
-describe('handHistory — initial state', () => {
-  it('createGame initialises handHistory as an empty array', () => {
+describe('handHistory — initial state', { timeout: 2000 }, () => {
+  it('createGame initialises handHistory as an empty array', { timeout: 2000 }, () => {
     const state = createGame('table-1', PLAYER_IDS)
     assert.deepEqual(state.handHistory, [])
   })
 })
 
-describe('handHistory — after one completed hand', () => {
-  it('handHistory has exactly one entry after one hand', () => {
+describe('handHistory — after one completed hand', { timeout: 2000 }, () => {
+  it('handHistory has exactly one entry after one hand', { timeout: 2000 }, () => {
     const initial = createGame('table-1', PLAYER_IDS)
     const state = completeOneHand(initial)
     assert.equal(state.handHistory.length, 1)
   })
 
-  it('entry has the correct handNumber', () => {
+  it('entry has the correct handNumber', { timeout: 2000 }, () => {
     const initial = createGame('table-1', PLAYER_IDS)
     const state = completeOneHand(initial)
     assert.equal(state.handHistory[0].handNumber, 1)
   })
 
-  it('entry has bids for all four seats', () => {
+  it('entry has bids for all four seats', { timeout: 2000 }, () => {
     const initial = createGame('table-1', PLAYER_IDS)
     const state = completeOneHand(initial)
     const { bids } = state.handHistory[0]
@@ -101,7 +101,7 @@ describe('handHistory — after one completed hand', () => {
     }
   })
 
-  it('entry has teamBids for both teams', () => {
+  it('entry has teamBids for both teams', { timeout: 2000 }, () => {
     const initial = createGame('table-1', PLAYER_IDS)
     const state = completeOneHand(initial)
     const { teamBids } = state.handHistory[0]
@@ -109,7 +109,7 @@ describe('handHistory — after one completed hand', () => {
     assert.ok(teamBids.ew !== null, 'teamBids.ew should be set')
   })
 
-  it('entry has tricksWon for all four seats summing to 13', () => {
+  it('entry has tricksWon for all four seats summing to 13', { timeout: 2000 }, () => {
     const initial = createGame('table-1', PLAYER_IDS)
     const state = completeOneHand(initial)
     const { tricksWon } = state.handHistory[0]
@@ -117,7 +117,7 @@ describe('handHistory — after one completed hand', () => {
     assert.equal(total, 13)
   })
 
-  it('entry has scoreDelta with ns and ew keys', () => {
+  it('entry has scoreDelta with ns and ew keys', { timeout: 2000 }, () => {
     const initial = createGame('table-1', PLAYER_IDS)
     const state = completeOneHand(initial)
     const { scoreDelta } = state.handHistory[0]
@@ -125,7 +125,7 @@ describe('handHistory — after one completed hand', () => {
     assert.ok('ew' in scoreDelta)
   })
 
-  it('entry has newBags with ns and ew keys', () => {
+  it('entry has newBags with ns and ew keys', { timeout: 2000 }, () => {
     const initial = createGame('table-1', PLAYER_IDS)
     const state = completeOneHand(initial)
     const { newBags } = state.handHistory[0]
@@ -133,7 +133,7 @@ describe('handHistory — after one completed hand', () => {
     assert.ok('ew' in newBags)
   })
 
-  it('entry has bagPenalty counts (numbers) for both teams', () => {
+  it('entry has bagPenalty counts (numbers) for both teams', { timeout: 2000 }, () => {
     const initial = createGame('table-1', PLAYER_IDS)
     const state = completeOneHand(initial)
     const { bagPenalty } = state.handHistory[0]
@@ -141,7 +141,7 @@ describe('handHistory — after one completed hand', () => {
     assert.equal(typeof bagPenalty.ew, 'number')
   })
 
-  it('entry has scoresAfter matching the state scores after the hand', () => {
+  it('entry has scoresAfter matching the state scores after the hand', { timeout: 2000 }, () => {
     const initial = createGame('table-1', PLAYER_IDS)
     const state = completeOneHand(initial)
     // If game is still going, state.scores should equal scoresAfter
@@ -153,13 +153,13 @@ describe('handHistory — after one completed hand', () => {
     }
   })
 
-  it('entry has bagsAfter matching the state bags after the hand', () => {
+  it('entry has bagsAfter matching the state bags after the hand', { timeout: 2000 }, () => {
     const initial = createGame('table-1', PLAYER_IDS)
     const state = completeOneHand(initial)
     assert.deepEqual(state.handHistory[0].bagsAfter, state.bags)
   })
 
-  it('bagPenalty.ns is 0 when bags are below 10', () => {
+  it('bagPenalty.ns is 0 when bags are below 10', { timeout: 2000 }, () => {
     // With bid=6 and 13 tricks total, bags are minimal; penalty at 10 bags is unlikely in hand 1
     const initial = createGame('table-1', PLAYER_IDS)
     const state = completeOneHand(initial)
@@ -174,8 +174,8 @@ describe('handHistory — after one completed hand', () => {
   })
 })
 
-describe('handHistory — accumulates across multiple hands', () => {
-  it('handHistory grows by one entry per completed hand', () => {
+describe('handHistory — accumulates across multiple hands', { timeout: 2000 }, () => {
+  it('handHistory grows by one entry per completed hand', { timeout: 2000 }, () => {
     let state = createGame('table-1', PLAYER_IDS)
     state = completeOneHand(state)
     const lengthAfterHand1 = state.handHistory.length
@@ -187,7 +187,7 @@ describe('handHistory — accumulates across multiple hands', () => {
     }
   })
 
-  it('second entry has handNumber 2', () => {
+  it('second entry has handNumber 2', { timeout: 2000 }, () => {
     let state = createGame('table-1', PLAYER_IDS)
     state = completeOneHand(state)
 
@@ -197,7 +197,7 @@ describe('handHistory — accumulates across multiple hands', () => {
     }
   })
 
-  it('each entry scoresAfter matches the running score progression', () => {
+  it('each entry scoresAfter matches the running score progression', { timeout: 2000 }, () => {
     let state = createGame('table-1', PLAYER_IDS)
     state = completeOneHand(state)
 
@@ -213,14 +213,14 @@ describe('handHistory — accumulates across multiple hands', () => {
   })
 })
 
-describe('handHistory — scoresBefore field', () => {
-  it('scoresBefore is { ns: 0, ew: 0 } for the first hand', () => {
+describe('handHistory — scoresBefore field', { timeout: 2000 }, () => {
+  it('scoresBefore is { ns: 0, ew: 0 } for the first hand', { timeout: 2000 }, () => {
     const initial = createGame('table-1', PLAYER_IDS)
     const state = completeOneHand(initial)
     assert.deepEqual(state.handHistory[0].scoresBefore, { ns: 0, ew: 0 })
   })
 
-  it('scoresBefore for hand 2 equals scoresAfter of hand 1', () => {
+  it('scoresBefore for hand 2 equals scoresAfter of hand 1', { timeout: 2000 }, () => {
     let state = createGame('table-1', PLAYER_IDS)
     state = completeOneHand(state)
     if (state.phase === 'game_over') return // skip if game ended in one hand
@@ -230,14 +230,14 @@ describe('handHistory — scoresBefore field', () => {
   })
 })
 
-describe('handHistory — bagsBefore field', () => {
-  it('bagsBefore is { ns: 0, ew: 0 } for the first hand', () => {
+describe('handHistory — bagsBefore field', { timeout: 2000 }, () => {
+  it('bagsBefore is { ns: 0, ew: 0 } for the first hand', { timeout: 2000 }, () => {
     const initial = createGame('table-1', PLAYER_IDS)
     const state = completeOneHand(initial)
     assert.deepEqual(state.handHistory[0].bagsBefore, { ns: 0, ew: 0 })
   })
 
-  it('bagsBefore for hand 2 equals bagsAfter of hand 1', () => {
+  it('bagsBefore for hand 2 equals bagsAfter of hand 1', { timeout: 2000 }, () => {
     let state = createGame('table-1', PLAYER_IDS)
     state = completeOneHand(state)
     if (state.phase === 'game_over') return // skip if game ended in one hand
@@ -247,8 +247,8 @@ describe('handHistory — bagsBefore field', () => {
   })
 })
 
-describe('handHistory — lastTrick field', () => {
-  it('entry contains a lastTrick field with winner and plays after a completed hand', () => {
+describe('handHistory — lastTrick field', { timeout: 2000 }, () => {
+  it('entry contains a lastTrick field with winner and plays after a completed hand', { timeout: 2000 }, () => {
     const initial = createGame('table-1', PLAYER_IDS)
     const state = completeOneHand(initial)
     const entry = state.handHistory[0]
@@ -258,14 +258,14 @@ describe('handHistory — lastTrick field', () => {
     assert.equal(entry.lastTrick.plays.length, 4, 'lastTrick.plays should have 4 cards')
   })
 
-  it('lastTrick.winner is one of the four seats', () => {
+  it('lastTrick.winner is one of the four seats', { timeout: 2000 }, () => {
     const initial = createGame('table-1', PLAYER_IDS)
     const state = completeOneHand(initial)
     const { lastTrick } = state.handHistory[0]
     assert.ok(CLOCKWISE_SEATS.includes(lastTrick.winner), 'lastTrick.winner should be a valid seat')
   })
 
-  it('lastTrick.plays has one card per seat', () => {
+  it('lastTrick.plays has one card per seat', { timeout: 2000 }, () => {
     const initial = createGame('table-1', PLAYER_IDS)
     const state = completeOneHand(initial)
     const { lastTrick } = state.handHistory[0]
@@ -276,8 +276,8 @@ describe('handHistory — lastTrick field', () => {
   })
 })
 
-describe('handHistory — bag penalty detection', () => {
-  it('bagPenalty.ns is 1 when ns crosses 10 bags in a hand', () => {
+describe('handHistory — bag penalty detection', { timeout: 2000 }, () => {
+  it('bagPenalty.ns is 1 when ns crosses 10 bags in a hand', { timeout: 2000 }, () => {
     // Construct a state with 9 bags for ns and force another bag this hand
     // We'll build a synthetic state snapshot rather than playing through it
     const initial = createGame('table-1', PLAYER_IDS)
@@ -303,7 +303,7 @@ describe('handHistory — bag penalty detection', () => {
     }
   })
 
-  it('bagPenalty.ns is 2 when ns accumulates 20+ bags (double bag-out) in a hand', () => {
+  it('bagPenalty.ns is 2 when ns accumulates 20+ bags (double bag-out) in a hand', { timeout: 2000 }, () => {
     // Start with 9 prior bags for NS. NS bids 0 (team total 0 → every trick is a bag).
     // With NS taking all 13 tricks: 9 + 13 = 22 total → Math.floor(22/10) = 2 penalties.
     // Use scoreHand directly with predetermined tricksWon to avoid random deck dependency.

--- a/test/unit/game/score.test.js
+++ b/test/unit/game/score.test.js
@@ -2,8 +2,8 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { scoreHand, checkWinLoss, applyBagPenalties } from '../../../server/game/score.js'
 
-describe('scoreHand — basic team bid', () => {
-  it('awards bid × 10 when team makes their bid exactly', () => {
+describe('scoreHand — basic team bid', { timeout: 2000 }, () => {
+  it('awards bid × 10 when team makes their bid exactly', { timeout: 2000 }, () => {
     const { scoreDelta, newBags } = scoreHand({
       bids: { north: 3, east: 4, south: 4, west: 3 },
       teamBids: { ns: 7, ew: 7 },
@@ -15,7 +15,7 @@ describe('scoreHand — basic team bid', () => {
     assert.equal(newBags.ew, 0)
   })
 
-  it('awards overtricks as bags (+1 per overtrick, not +10)', () => {
+  it('awards overtricks as bags (+1 per overtrick, not +10)', { timeout: 2000 }, () => {
     const { scoreDelta, newBags } = scoreHand({
       bids: { north: 3, east: 4, south: 4, west: 3 },
       teamBids: { ns: 7, ew: 7 },
@@ -29,7 +29,7 @@ describe('scoreHand — basic team bid', () => {
     assert.equal(newBags.ew, 1)
   })
 
-  it('deducts bid × 10 when team misses their bid', () => {
+  it('deducts bid × 10 when team misses their bid', { timeout: 2000 }, () => {
     const { scoreDelta, newBags } = scoreHand({
       bids: { north: 4, east: 4, south: 4, west: 3 },
       teamBids: { ns: 8, ew: 7 },
@@ -44,8 +44,8 @@ describe('scoreHand — basic team bid', () => {
   })
 })
 
-describe('scoreHand — nil bid', () => {
-  it('awards +50 for a successful nil', () => {
+describe('scoreHand — nil bid', { timeout: 2000 }, () => {
+  it('awards +50 for a successful nil', { timeout: 2000 }, () => {
     const { scoreDelta } = scoreHand({
       bids: { north: 'nil', east: 4, south: 5, west: 3 },
       teamBids: { ns: 5, ew: 7 },
@@ -55,7 +55,7 @@ describe('scoreHand — nil bid', () => {
     assert.equal(scoreDelta.ns, 50 + 50)
   })
 
-  it('deducts -50 for a failed nil', () => {
+  it('deducts -50 for a failed nil', { timeout: 2000 }, () => {
     const { scoreDelta, newBags } = scoreHand({
       bids: { north: 'nil', east: 4, south: 5, west: 3 },
       teamBids: { ns: 5, ew: 7 },
@@ -67,7 +67,7 @@ describe('scoreHand — nil bid', () => {
     assert.equal(newBags.ns, 0)
   })
 
-  it('nil bidder tricks that push team over bid create bags', () => {
+  it('nil bidder tricks that push team over bid create bags', { timeout: 2000 }, () => {
     const { scoreDelta, newBags } = scoreHand({
       bids: { north: 'nil', east: 4, south: 5, west: 3 },
       teamBids: { ns: 5, ew: 7 },
@@ -81,8 +81,8 @@ describe('scoreHand — nil bid', () => {
   })
 })
 
-describe('scoreHand — blind nil bid', () => {
-  it('awards +100 for a successful blind nil', () => {
+describe('scoreHand — blind nil bid', { timeout: 2000 }, () => {
+  it('awards +100 for a successful blind nil', { timeout: 2000 }, () => {
     const { scoreDelta } = scoreHand({
       bids: { north: 'blind_nil', east: 4, south: 5, west: 3 },
       teamBids: { ns: 5, ew: 7 },
@@ -91,7 +91,7 @@ describe('scoreHand — blind nil bid', () => {
     assert.ok(scoreDelta.ns >= 100 + 50) // +100 blind nil + +50 team
   })
 
-  it('deducts -100 for a failed blind nil', () => {
+  it('deducts -100 for a failed blind nil', { timeout: 2000 }, () => {
     const { scoreDelta } = scoreHand({
       bids: { north: 'blind_nil', east: 4, south: 5, west: 3 },
       teamBids: { ns: 5, ew: 7 },
@@ -103,8 +103,8 @@ describe('scoreHand — blind nil bid', () => {
   })
 })
 
-describe('scoreHand — double nil', () => {
-  it('awards +50 to each successful individual nil in a double nil', () => {
+describe('scoreHand — double nil', { timeout: 2000 }, () => {
+  it('awards +50 to each successful individual nil in a double nil', { timeout: 2000 }, () => {
     const { scoreDelta, newBags } = scoreHand({
       bids: { north: 'nil', east: 4, south: 'nil', west: 3 },
       teamBids: { ns: null, ew: 7 },
@@ -115,7 +115,7 @@ describe('scoreHand — double nil', () => {
     assert.equal(newBags.ns, 0)
   })
 
-  it('every trick in double nil is a bag and breaks individual nil', () => {
+  it('every trick in double nil is a bag and breaks individual nil', { timeout: 2000 }, () => {
     const { scoreDelta, newBags } = scoreHand({
       bids: { north: 'nil', east: 4, south: 'nil', west: 3 },
       teamBids: { ns: null, ew: 7 },
@@ -127,8 +127,8 @@ describe('scoreHand — double nil', () => {
   })
 })
 
-describe('scoreHand — team bid of 0', () => {
-  it('every trick is a bag when team bids 0', () => {
+describe('scoreHand — team bid of 0', { timeout: 2000 }, () => {
+  it('every trick is a bag when team bids 0', { timeout: 2000 }, () => {
     const { scoreDelta, newBags } = scoreHand({
       bids: { north: 0, east: 4, south: 0, west: 3 },
       teamBids: { ns: 0, ew: 7 },
@@ -140,8 +140,8 @@ describe('scoreHand — team bid of 0', () => {
   })
 })
 
-describe('applyBagPenalties', () => {
-  it('deducts 100 points per 10 bags accumulated', () => {
+describe('applyBagPenalties', { timeout: 2000 }, () => {
+  it('deducts 100 points per 10 bags accumulated', { timeout: 2000 }, () => {
     const { scores, bags } = applyBagPenalties(
       { ns: 150, ew: 100 },
       { ns: 9, ew: 5 },
@@ -155,7 +155,7 @@ describe('applyBagPenalties', () => {
     assert.equal(bags.ew, 7)
   })
 
-  it('deducts 200 when accumulating 20+ bags', () => {
+  it('deducts 200 when accumulating 20+ bags', { timeout: 2000 }, () => {
     const { scores, bags } = applyBagPenalties(
       { ns: 300, ew: 100 },
       { ns: 15, ew: 0 },
@@ -166,7 +166,7 @@ describe('applyBagPenalties', () => {
     assert.equal(bags.ns, 3)
   })
 
-  it('does not deduct when fewer than 10 bags total', () => {
+  it('does not deduct when fewer than 10 bags total', { timeout: 2000 }, () => {
     const { scores, bags } = applyBagPenalties(
       { ns: 100, ew: 100 },
       { ns: 4, ew: 4 },
@@ -179,45 +179,45 @@ describe('applyBagPenalties', () => {
   })
 })
 
-describe('checkWinLoss', () => {
-  it('returns win for team that reaches 250', () => {
+describe('checkWinLoss', { timeout: 2000 }, () => {
+  it('returns win for team that reaches 250', { timeout: 2000 }, () => {
     const result = checkWinLoss({ ns: 250, ew: 100 })
     assert.equal(result.winner, 'ns')
     assert.equal(result.loser, 'ew')
   })
 
-  it('returns win for higher-scoring team when both reach 250', () => {
+  it('returns win for higher-scoring team when both reach 250', { timeout: 2000 }, () => {
     const result = checkWinLoss({ ns: 260, ew: 255 })
     assert.equal(result.winner, 'ns')
   })
 
-  it('returns null when tied at exactly 250 (play another hand)', () => {
+  it('returns null when tied at exactly 250 (play another hand)', { timeout: 2000 }, () => {
     const result = checkWinLoss({ ns: 250, ew: 250 })
     assert.equal(result, null)
   })
 
-  it('returns loss for team that reaches -250', () => {
+  it('returns loss for team that reaches -250', { timeout: 2000 }, () => {
     const result = checkWinLoss({ ns: -250, ew: 100 })
     assert.equal(result.loser, 'ns')
     assert.equal(result.winner, 'ew')
   })
 
-  it('higher score wins when both reach -250', () => {
+  it('higher score wins when both reach -250', { timeout: 2000 }, () => {
     const result = checkWinLoss({ ns: -260, ew: -255 })
     assert.equal(result.winner, 'ew') // ew has higher score
   })
 
-  it('returns null when tied at exactly -250 (play another hand)', () => {
+  it('returns null when tied at exactly -250 (play another hand)', { timeout: 2000 }, () => {
     const result = checkWinLoss({ ns: -250, ew: -250 })
     assert.equal(result, null)
   })
 
-  it('returns null when neither threshold is reached', () => {
+  it('returns null when neither threshold is reached', { timeout: 2000 }, () => {
     const result = checkWinLoss({ ns: 100, ew: 150 })
     assert.equal(result, null)
   })
 
-  it('win condition takes priority over loss when one team hits 250 and other hits -250', () => {
+  it('win condition takes priority over loss when one team hits 250 and other hits -250', { timeout: 2000 }, () => {
     // Both conditions — winner is the team above 250
     const result = checkWinLoss({ ns: 250, ew: -250 })
     assert.equal(result.winner, 'ns')

--- a/test/unit/game/state.test.js
+++ b/test/unit/game/state.test.js
@@ -35,20 +35,20 @@ const PLAYER_IDS = {
   west: 'player-west',
 }
 
-describe('createGame', () => {
-  it('creates a game in bidding phase', () => {
+describe('createGame', { timeout: 2000 }, () => {
+  it('creates a game in bidding phase', { timeout: 2000 }, () => {
     const state = createGame('table-1', PLAYER_IDS)
     assert.equal(state.phase, 'bidding')
   })
 
-  it('deals 13 cards to each player', () => {
+  it('deals 13 cards to each player', { timeout: 2000 }, () => {
     const state = createGame('table-1', PLAYER_IDS)
     for (const seat of CLOCKWISE_SEATS) {
       assert.equal(state.hands[seat].length, 13)
     }
   })
 
-  it('hands are sorted by suit then rank', () => {
+  it('hands are sorted by suit then rank', { timeout: 2000 }, () => {
     const state = createGame('table-1', PLAYER_IDS)
     for (const seat of CLOCKWISE_SEATS) {
       const hand = state.hands[seat]
@@ -72,44 +72,44 @@ describe('createGame', () => {
     }
   })
 
-  it('north is the dealer on the first hand', () => {
+  it('north is the dealer on the first hand', { timeout: 2000 }, () => {
     const state = createGame('table-1', PLAYER_IDS)
     assert.equal(state.dealerSeat, 'north')
   })
 
-  it('first bidder is east (left of north dealer)', () => {
+  it('first bidder is east (left of north dealer)', { timeout: 2000 }, () => {
     const state = createGame('table-1', PLAYER_IDS)
     assert.equal(state.currentBidderSeat, 'east')
   })
 
-  it('initialises scores and bags to zero', () => {
+  it('initialises scores and bags to zero', { timeout: 2000 }, () => {
     const state = createGame('table-1', PLAYER_IDS)
     assert.deepEqual(state.scores, { ns: 0, ew: 0 })
     assert.deepEqual(state.bags, { ns: 0, ew: 0 })
   })
 })
 
-describe('placeBid', () => {
-  it('throws if not in bidding phase', () => {
+describe('placeBid', { timeout: 2000 }, () => {
+  it('throws if not in bidding phase', { timeout: 2000 }, () => {
     const state = createGame('table-1', PLAYER_IDS)
     // Manually set phase
     const badState = { ...state, phase: 'playing' }
     assert.throws(() => placeBid(badState, 'east', 3), /not in bidding phase/i)
   })
 
-  it('throws if wrong player bids', () => {
+  it('throws if wrong player bids', { timeout: 2000 }, () => {
     const state = createGame('table-1', PLAYER_IDS)
     assert.throws(() => placeBid(state, 'north', 3), /not your turn/i)
   })
 
-  it('records the bid and advances to next bidder', () => {
+  it('records the bid and advances to next bidder', { timeout: 2000 }, () => {
     let state = createGame('table-1', PLAYER_IDS)
     state = placeBid(state, 'east', 3)
     assert.equal(state.bids.east, 3)
     assert.equal(state.currentBidderSeat, 'south')
   })
 
-  it('transitions to playing phase after all 4 bids', () => {
+  it('transitions to playing phase after all 4 bids', { timeout: 2000 }, () => {
     let state = createGame('table-1', PLAYER_IDS)
     state = bidAll(state, [
       ['east', 3],
@@ -120,7 +120,7 @@ describe('placeBid', () => {
     assert.equal(state.phase, 'playing')
   })
 
-  it('second bidder number becomes the team bid — first bidder is advisory only', () => {
+  it('second bidder number becomes the team bid — first bidder is advisory only', { timeout: 2000 }, () => {
     // North deals → bidding order: east, south, west, north
     // EW: east bids first (advisory 4), west bids second (sets team total to 7)
     // NS: south bids first (advisory 3), north bids second (sets team total to 5)
@@ -136,7 +136,7 @@ describe('placeBid', () => {
     assert.equal(state.teamBids.ns, 5)
   })
 
-  it('second bidder can set team total lower than first bidder advisory number', () => {
+  it('second bidder can set team total lower than first bidder advisory number', { timeout: 2000 }, () => {
     // PRD §5.2: "The team's combined bid may be lower than the first bidder's individual bid."
     let state = createGame('table-1', PLAYER_IDS)
     state = bidAll(state, [
@@ -148,7 +148,7 @@ describe('placeBid', () => {
     assert.equal(state.teamBids.ew, 4) // team bid is 4, not east's advisory 6
   })
 
-  it('when first bidder bids nil, second bidder number is the team target and nil stands', () => {
+  it('when first bidder bids nil, second bidder number is the team target and nil stands', { timeout: 2000 }, () => {
     // East bids nil (individual bid stands), west sets team total to 5
     let state = createGame('table-1', PLAYER_IDS)
     state = bidAll(state, [
@@ -161,7 +161,7 @@ describe('placeBid', () => {
     assert.equal(state.teamBids.ew, 5)
   })
 
-  it('transitions to blind_nil_exchange when a player bids blind nil', () => {
+  it('transitions to blind_nil_exchange when a player bids blind nil', { timeout: 2000 }, () => {
     // Make NS far behind so blind nil is eligible
     let state = createGame('table-1', PLAYER_IDS)
     state = { ...state, scores: { ns: 0, ew: 100 } }
@@ -172,17 +172,17 @@ describe('placeBid', () => {
     assert.equal(state.phase, 'blind_nil_exchange')
   })
 
-  it('rejects invalid bid value', () => {
+  it('rejects invalid bid value', { timeout: 2000 }, () => {
     const state = createGame('table-1', PLAYER_IDS)
     assert.throws(() => placeBid(state, 'east', 14), /invalid bid/i)
   })
 
-  it('rejects blind nil when team is not 100+ behind', () => {
+  it('rejects blind nil when team is not 100+ behind', { timeout: 2000 }, () => {
     const state = createGame('table-1', PLAYER_IDS)
     assert.throws(() => placeBid(state, 'east', 'blind_nil'), /not eligible/i)
   })
 
-  it('rejects second blind nil for same team', () => {
+  it('rejects second blind nil for same team', { timeout: 2000 }, () => {
     let state = createGame('table-1', PLAYER_IDS)
     // NS must be 100+ behind EW for NS players to bid blind nil
     state = { ...state, scores: { ns: 0, ew: 100 } }
@@ -195,7 +195,7 @@ describe('placeBid', () => {
   })
 })
 
-describe('playCard', () => {
+describe('playCard', { timeout: 2000 }, () => {
   function getToPlayingPhase() {
     let state = createGame('table-1', PLAYER_IDS)
     state = bidAll(state, [
@@ -207,20 +207,20 @@ describe('playCard', () => {
     return state
   }
 
-  it('throws if not in playing phase', () => {
+  it('throws if not in playing phase', { timeout: 2000 }, () => {
     const state = createGame('table-1', PLAYER_IDS)
     const card = state.hands.east[0]
     assert.throws(() => playCard(state, 'east', card), /not in playing phase/i)
   })
 
-  it('throws if wrong player plays', () => {
+  it('throws if wrong player plays', { timeout: 2000 }, () => {
     let state = getToPlayingPhase()
     const wrongCard = state.hands.north[0]
     // East leads the first trick after north deals
     assert.throws(() => playCard(state, 'north', wrongCard), /not your turn/i)
   })
 
-  it('throws if card not in hand', () => {
+  it('throws if card not in hand', { timeout: 2000 }, () => {
     let state = getToPlayingPhase()
     // Use a card from north's hand — since all 52 cards are dealt to exactly one
     // player, any card in north's hand is guaranteed not to be in east's hand.
@@ -234,7 +234,7 @@ describe('playCard', () => {
     )
   })
 
-  it('removes played card from hand', () => {
+  it('removes played card from hand', { timeout: 2000 }, () => {
     let state = getToPlayingPhase()
     // east[0] may be a spade (illegal on trick 1); pick first non-spade card instead
     const card = state.hands.east.find((c) => c.suit !== 'spades')
@@ -243,7 +243,7 @@ describe('playCard', () => {
     assert.ok(!state.hands.east.some((c) => c.suit === card.suit && c.rank === card.rank))
   })
 
-  it('spades are broken when first spade is played (after the first trick)', () => {
+  it('spades are broken when first spade is played (after the first trick)', { timeout: 2000 }, () => {
     let state = getToPlayingPhase()
     assert.equal(state.spadesbroken, false)
 
@@ -261,7 +261,7 @@ describe('playCard', () => {
   })
 })
 
-describe('Spades-breaking', () => {
+describe('Spades-breaking', { timeout: 2000 }, () => {
   function getPlayingState() {
     let state = createGame('table-1', PLAYER_IDS)
     return bidAll(state, [
@@ -272,7 +272,7 @@ describe('Spades-breaking', () => {
     ])
   }
 
-  it('playing a spade on the first trick does not break spades', () => {
+  it('playing a spade on the first trick does not break spades', { timeout: 2000 }, () => {
     // PRD §5.1: "Spades are broken by the first Spade played (after the first trick)"
     let state = getPlayingState()
     // East has only spades — legal to lead on trick 1 when player holds nothing else
@@ -287,7 +287,7 @@ describe('Spades-breaking', () => {
     assert.equal(state.spadesbroken, false)
   })
 
-  it('playing a spade as a discard (void in led suit) breaks spades', () => {
+  it('playing a spade as a discard (void in led suit) breaks spades', { timeout: 2000 }, () => {
     let state = getPlayingState()
     // East has led clubs; south is void in clubs and must play their only card (a spade)
     state = {
@@ -301,7 +301,7 @@ describe('Spades-breaking', () => {
     assert.equal(state.spadesbroken, true)
   })
 
-  it('attempting to lead spades before they are broken is rejected', () => {
+  it('attempting to lead spades before they are broken is rejected', { timeout: 2000 }, () => {
     let state = getPlayingState()
     state = {
       ...state,
@@ -320,7 +320,7 @@ describe('Spades-breaking', () => {
     )
   })
 
-  it('can lead spades once they are broken', () => {
+  it('can lead spades once they are broken', { timeout: 2000 }, () => {
     let state = getPlayingState()
     state = {
       ...state,
@@ -336,7 +336,7 @@ describe('Spades-breaking', () => {
     assert.doesNotThrow(() => playCard(state, 'east', { suit: 'spades', rank: 'A' }))
   })
 
-  it('spadesbroken resets to false at the start of the next hand', () => {
+  it('spadesbroken resets to false at the start of the next hand', { timeout: 2000 }, () => {
     let state = getPlayingState()
     // Fast-forward to the final trick of a hand with spades already broken
     state = {
@@ -367,8 +367,8 @@ describe('Spades-breaking', () => {
   })
 })
 
-describe('getPlayerView', () => {
-  it('includes only the requesting player\'s hand', () => {
+describe('getPlayerView', { timeout: 2000 }, () => {
+  it('includes only the requesting player\'s hand', { timeout: 2000 }, () => {
     const state = createGame('table-1', PLAYER_IDS)
     const view = getPlayerView(state, 'north')
     assert.ok(view.myHand)
@@ -376,13 +376,13 @@ describe('getPlayerView', () => {
     assert.ok(!view.hands, 'should not expose all hands')
   })
 
-  it('does not expose other players\' hands', () => {
+  it('does not expose other players\' hands', { timeout: 2000 }, () => {
     const state = createGame('table-1', PLAYER_IDS)
     const view = getPlayerView(state, 'north')
     assert.ok(!view.hands || !view.hands.east, 'should not expose other players hands')
   })
 
-  it('strictly excludes the hands key for all 4 seats', () => {
+  it('strictly excludes the hands key for all 4 seats', { timeout: 2000 }, () => {
     const state = createGame('table-1', PLAYER_IDS)
     for (const seat of ['north', 'east', 'south', 'west']) {
       const view = getPlayerView(state, seat)
@@ -390,7 +390,7 @@ describe('getPlayerView', () => {
     }
   })
 
-  it('myHand exactly matches the dealt cards for each seat', () => {
+  it('myHand exactly matches the dealt cards for each seat', { timeout: 2000 }, () => {
     const state = createGame('table-1', PLAYER_IDS)
     for (const seat of ['north', 'east', 'south', 'west']) {
       const view = getPlayerView(state, seat)
@@ -398,7 +398,7 @@ describe('getPlayerView', () => {
     }
   })
 
-  it('each seat receives a unique hand (no two myHands share any card)', () => {
+  it('each seat receives a unique hand (no two myHands share any card)', { timeout: 2000 }, () => {
     const state = createGame('table-1', PLAYER_IDS)
     const seats = ['north', 'east', 'south', 'west']
     const hands = seats.map((seat) => getPlayerView(state, seat).myHand)
@@ -416,7 +416,7 @@ describe('getPlayerView', () => {
     }
   })
 
-  it('includes currentTrick in the view (public info)', () => {
+  it('includes currentTrick in the view (public info)', { timeout: 2000 }, () => {
     const state = createGame('table-1', PLAYER_IDS)
     // currentTrick is public — it must be present in the player view
     const view = getPlayerView(state, 'north')
@@ -424,7 +424,7 @@ describe('getPlayerView', () => {
     assert.ok(Array.isArray(view.currentTrick))
   })
 
-  it('does not expose opponent card identity through any top-level key', () => {
+  it('does not expose opponent card identity through any top-level key', { timeout: 2000 }, () => {
     const state = createGame('table-1', PLAYER_IDS)
     const northView = getPlayerView(state, 'north')
     const northHandKeys = new Set(northView.myHand.map((c) => `${c.suit}:${c.rank}`))
@@ -444,13 +444,13 @@ describe('getPlayerView', () => {
   })
 })
 
-describe('CLOCKWISE_SEATS', () => {
-  it('lists seats in clockwise order starting from north', () => {
+describe('CLOCKWISE_SEATS', { timeout: 2000 }, () => {
+  it('lists seats in clockwise order starting from north', { timeout: 2000 }, () => {
     assert.deepEqual(CLOCKWISE_SEATS, ['north', 'east', 'south', 'west'])
   })
 })
 
-describe('bag tracking — state level', () => {
+describe('bag tracking — state level', { timeout: 2000 }, () => {
   const SEATS = ['north', 'east', 'south', 'west']
 
   /**
@@ -502,7 +502,7 @@ describe('bag tracking — state level', () => {
     return state
   }
 
-  it('bags accumulate in state after a hand with overtricks', () => {
+  it('bags accumulate in state after a hand with overtricks', { timeout: 2000 }, () => {
     // After 12 tricks: NS has 9, EW has 3 (east wins 13th → EW ends at 4)
     // NS bid 7 → 9 tricks → 2 overtricks → 2 bags
     // EW bid 6 → 4 tricks → missed bid (-60), 0 bags
@@ -518,7 +518,7 @@ describe('bag tracking — state level', () => {
     assert.equal(state.scores.ew, -60, 'EW: bid 6 made 4 → -60')
   })
 
-  it('applies -100 penalty and resets bag count when bags reach 10', () => {
+  it('applies -100 penalty and resets bag count when bags reach 10', { timeout: 2000 }, () => {
     // Start with NS at 9 bags. Hand produces 2 more overtricks → total 11 → penalty fires
     const state = buildFinalTrickState(
       { ns: 100, ew: 100 },
@@ -534,7 +534,7 @@ describe('bag tracking — state level', () => {
     assert.equal(state.bags.ew, 0, 'EW bags remain 0')
   })
 
-  it('bags carry over correctly across two hands with no double-deduction', () => {
+  it('bags carry over correctly across two hands with no double-deduction', { timeout: 2000 }, () => {
     // Hand 1: NS gets 2 bags, EW gets 0
     let state = buildFinalTrickState(
       { ns: 0, ew: 0 },
@@ -599,7 +599,7 @@ describe('bag tracking — state level', () => {
   })
 })
 
-describe('dealer rotation', () => {
+describe('dealer rotation', { timeout: 2000 }, () => {
   const SEATS = ['north', 'east', 'south', 'west']
 
   function nextSeatClockwise(seat) {
@@ -660,7 +660,7 @@ describe('dealer rotation', () => {
     return s
   }
 
-  it('dealer rotates clockwise after each hand', () => {
+  it('dealer rotates clockwise after each hand', { timeout: 2000 }, () => {
     let state = createGame('table-1', PLAYER_IDS)
     const expectedDealers = ['north', 'east', 'south', 'west', 'north']
 
@@ -677,7 +677,7 @@ describe('dealer rotation', () => {
     assert.equal(state.dealerSeat, expectedDealers[4], 'dealer wraps back to north after 4 hands')
   })
 
-  it('first bidder is always to the left of the dealer', () => {
+  it('first bidder is always to the left of the dealer', { timeout: 2000 }, () => {
     let state = createGame('table-1', PLAYER_IDS)
 
     // Hand 1: north deals → east bids first
@@ -697,7 +697,7 @@ describe('dealer rotation', () => {
   })
 })
 
-describe('game over — phase transition', () => {
+describe('game over — phase transition', { timeout: 2000 }, () => {
   /**
    * Build a state one trick from hand completion with fixed bids.
    * Bidding order: east, south, west, north
@@ -740,7 +740,7 @@ describe('game over — phase transition', () => {
     return state
   }
 
-  it('transitions to game_over with winner=ns when NS score reaches 250', () => {
+  it('transitions to game_over with winner=ns when NS score reaches 250', { timeout: 2000 }, () => {
     // After hand: NS=9 tricks (north:4+south:5) vs bid 7 → +70 + 2 bags (+2 pts) = 72 → 200+72=272 ≥ 250
     //             EW=4 tricks (east:3+west:1) vs bid 6 → -60 → 100-60=40
     const state = buildNearEndState({
@@ -753,7 +753,7 @@ describe('game over — phase transition', () => {
     assert.equal(state.scores.ns, 272)
   })
 
-  it('starts next hand in bidding phase when neither team reaches a threshold', () => {
+  it('starts next hand in bidding phase when neither team reaches a threshold', { timeout: 2000 }, () => {
     // After hand: NS=9 vs bid 7 → +70 → 0+70=70 (< 250); EW=4 vs bid 6 → -60 (> -250)
     const state = buildNearEndState({
       initialScores: { ns: 0, ew: 0 },
@@ -765,7 +765,7 @@ describe('game over — phase transition', () => {
     assert.equal(state.handNumber, 2)
   })
 
-  it('transitions to game_over with winner=ew when NS score drops to -250 or below', () => {
+  it('transitions to game_over with winner=ew when NS score drops to -250 or below', { timeout: 2000 }, () => {
     // After hand: NS=3 tricks (north:1+south:2) vs bid 7 → -70 → -200-70=-270 ≤ -250
     //             EW=10 tricks (east:6+west:4) vs bid 6 → +60 + 4 bags → 100+60=160
     const state = buildNearEndState({
@@ -778,7 +778,7 @@ describe('game over — phase transition', () => {
     assert.equal(state.scores.ns, -270)
   })
 
-  it('getPlayerView in game_over state exposes winner and scores but not all hands', () => {
+  it('getPlayerView in game_over state exposes winner and scores but not all hands', { timeout: 2000 }, () => {
     const state = buildNearEndState({
       initialScores: { ns: 200, ew: 100 },
       tricksWon12: { north: 4, east: 2, south: 5, west: 1 },
@@ -800,8 +800,8 @@ const HUMAN_PLAYERS = {
   west: 'player-west',
 }
 
-describe('substitutePlayerWithBot', () => {
-  it('replaces the human player with a bot at the given seat', () => {
+describe('substitutePlayerWithBot', { timeout: 2000 }, () => {
+  it('replaces the human player with a bot at the given seat', { timeout: 2000 }, () => {
     const state = createGame('table-1', HUMAN_PLAYERS)
     const updated = substitutePlayerWithBot(state, 'east')
     assert.equal(updated.players.east, 'bot:east')
@@ -810,13 +810,13 @@ describe('substitutePlayerWithBot', () => {
     assert.equal(updated.players.west, 'player-west')
   })
 
-  it('does not mutate the original state', () => {
+  it('does not mutate the original state', { timeout: 2000 }, () => {
     const state = createGame('table-1', HUMAN_PLAYERS)
     substitutePlayerWithBot(state, 'east')
     assert.equal(state.players.east, 'player-east', 'original state must not be mutated')
   })
 
-  it('advances bot turns immediately after substitution when all remaining bidders are bots', () => {
+  it('advances bot turns immediately after substitution when all remaining bidders are bots', { timeout: 2000 }, () => {
     const allBotsExceptNorth = {
       north: 'player-north',
       east: 'bot:east',
@@ -832,8 +832,8 @@ describe('substitutePlayerWithBot', () => {
   })
 })
 
-describe('advanceBotTurns', () => {
-  it('returns state unchanged when current bidder is human', () => {
+describe('advanceBotTurns', { timeout: 2000 }, () => {
+  it('returns state unchanged when current bidder is human', { timeout: 2000 }, () => {
     const state = createGame('table-1', HUMAN_PLAYERS)
     assert.equal(state.phase, 'bidding')
     const result = advanceBotTurns(state)
@@ -841,7 +841,7 @@ describe('advanceBotTurns', () => {
     assert.equal(result.currentBidderSeat, state.currentBidderSeat)
   })
 
-  it('advances past bot bidders automatically after a human bids', () => {
+  it('advances past bot bidders automatically after a human bids', { timeout: 2000 }, () => {
     const players = {
       north: 'bot:north',
       east: 'player-east',

--- a/test/unit/game/trick.test.js
+++ b/test/unit/game/trick.test.js
@@ -2,8 +2,8 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { getLegalPlays, determineTrickWinner, isCardLegal } from '../../../server/game/trick.js'
 
-describe('getLegalPlays — leading a trick', () => {
-  it('allows any non-spade on the first trick of a hand', () => {
+describe('getLegalPlays — leading a trick', { timeout: 2000 }, () => {
+  it('allows any non-spade on the first trick of a hand', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'clubs', rank: 'A' },
       { suit: 'spades', rank: 'K' },
@@ -14,7 +14,7 @@ describe('getLegalPlays — leading a trick', () => {
     assert.ok(legal.every((c) => c.suit !== 'spades'))
   })
 
-  it('on the first trick, if a player has ONLY spades they must play spades', () => {
+  it('on the first trick, if a player has ONLY spades they must play spades', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'spades', rank: 'A' },
       { suit: 'spades', rank: '2' },
@@ -24,7 +24,7 @@ describe('getLegalPlays — leading a trick', () => {
     assert.ok(legal.every((c) => c.suit === 'spades'))
   })
 
-  it('cannot lead spades before spades are broken (and has non-spades)', () => {
+  it('cannot lead spades before spades are broken (and has non-spades)', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'clubs', rank: 'A' },
       { suit: 'spades', rank: 'K' },
@@ -34,7 +34,7 @@ describe('getLegalPlays — leading a trick', () => {
     assert.equal(legal[0].suit, 'clubs')
   })
 
-  it('can lead spades once spades are broken', () => {
+  it('can lead spades once spades are broken', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'clubs', rank: 'A' },
       { suit: 'spades', rank: 'K' },
@@ -43,7 +43,7 @@ describe('getLegalPlays — leading a trick', () => {
     assert.equal(legal.length, 2)
   })
 
-  it('can lead any card when spades not broken but player has only spades', () => {
+  it('can lead any card when spades not broken but player has only spades', { timeout: 2000 }, () => {
     const hand = [{ suit: 'spades', rank: 'A' }]
     const legal = getLegalPlays(hand, [], false, false)
     assert.equal(legal.length, 1)
@@ -51,8 +51,8 @@ describe('getLegalPlays — leading a trick', () => {
   })
 })
 
-describe('getLegalPlays — following a trick', () => {
-  it('must follow suit if possible', () => {
+describe('getLegalPlays — following a trick', { timeout: 2000 }, () => {
+  it('must follow suit if possible', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'clubs', rank: 'A' },
       { suit: 'clubs', rank: '5' },
@@ -64,7 +64,7 @@ describe('getLegalPlays — following a trick', () => {
     assert.ok(legal.every((c) => c.suit === 'clubs'))
   })
 
-  it('may play any card when unable to follow suit', () => {
+  it('may play any card when unable to follow suit', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'spades', rank: 'A' },
       { suit: 'hearts', rank: '5' },
@@ -74,7 +74,7 @@ describe('getLegalPlays — following a trick', () => {
     assert.equal(legal.length, 2)
   })
 
-  it('on the first trick, cannot play spades when unable to follow suit if non-spades exist', () => {
+  it('on the first trick, cannot play spades when unable to follow suit if non-spades exist', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'hearts', rank: '5' },
       { suit: 'spades', rank: 'A' },
@@ -86,7 +86,7 @@ describe('getLegalPlays — following a trick', () => {
     assert.equal(legal[0].suit, 'hearts')
   })
 
-  it('on the first trick, must play spades if only spades available when unable to follow suit', () => {
+  it('on the first trick, must play spades if only spades available when unable to follow suit', { timeout: 2000 }, () => {
     const hand = [{ suit: 'spades', rank: 'A' }]
     const trick = [{ seat: 'north', card: { suit: 'clubs', rank: '2' } }]
     const legal = getLegalPlays(hand, trick, false, true)
@@ -95,8 +95,8 @@ describe('getLegalPlays — following a trick', () => {
   })
 })
 
-describe('determineTrickWinner', () => {
-  it('highest card of led suit wins when no spades played', () => {
+describe('determineTrickWinner', { timeout: 2000 }, () => {
+  it('highest card of led suit wins when no spades played', { timeout: 2000 }, () => {
     const trick = [
       { seat: 'north', card: { suit: 'clubs', rank: 'A' } },
       { seat: 'east', card: { suit: 'clubs', rank: '3' } },
@@ -106,7 +106,7 @@ describe('determineTrickWinner', () => {
     assert.equal(determineTrickWinner(trick), 'north')
   })
 
-  it('spade beats highest non-spade of led suit', () => {
+  it('spade beats highest non-spade of led suit', { timeout: 2000 }, () => {
     const trick = [
       { seat: 'north', card: { suit: 'clubs', rank: 'A' } },
       { seat: 'east', card: { suit: 'spades', rank: '2' } },
@@ -116,7 +116,7 @@ describe('determineTrickWinner', () => {
     assert.equal(determineTrickWinner(trick), 'east')
   })
 
-  it('highest spade wins when multiple spades played', () => {
+  it('highest spade wins when multiple spades played', { timeout: 2000 }, () => {
     const trick = [
       { seat: 'north', card: { suit: 'clubs', rank: 'A' } },
       { seat: 'east', card: { suit: 'spades', rank: '5' } },
@@ -126,7 +126,7 @@ describe('determineTrickWinner', () => {
     assert.equal(determineTrickWinner(trick), 'south')
   })
 
-  it('off-suit cards (not spades, not led suit) never win', () => {
+  it('off-suit cards (not spades, not led suit) never win', { timeout: 2000 }, () => {
     const trick = [
       { seat: 'north', card: { suit: 'clubs', rank: '2' } },
       { seat: 'east', card: { suit: 'hearts', rank: 'A' } }, // off-suit, irrelevant
@@ -136,7 +136,7 @@ describe('determineTrickWinner', () => {
     assert.equal(determineTrickWinner(trick), 'west')
   })
 
-  it('first spade played wins if it is the only spade', () => {
+  it('first spade played wins if it is the only spade', { timeout: 2000 }, () => {
     const trick = [
       { seat: 'north', card: { suit: 'hearts', rank: 'A' } },
       { seat: 'east', card: { suit: 'spades', rank: '2' } },
@@ -147,21 +147,21 @@ describe('determineTrickWinner', () => {
   })
 })
 
-describe('isCardLegal', () => {
-  it('returns false if card not in hand', () => {
+describe('isCardLegal', { timeout: 2000 }, () => {
+  it('returns false if card not in hand', { timeout: 2000 }, () => {
     const hand = [{ suit: 'clubs', rank: 'A' }]
     assert.ok(
       !isCardLegal({ suit: 'spades', rank: 'K' }, hand, [], false, false),
     )
   })
 
-  it('returns true if card is a legal play', () => {
+  it('returns true if card is a legal play', { timeout: 2000 }, () => {
     const hand = [{ suit: 'clubs', rank: 'A' }]
     const trick = [{ seat: 'north', card: { suit: 'clubs', rank: '2' } }]
     assert.ok(isCardLegal({ suit: 'clubs', rank: 'A' }, hand, trick, false, false))
   })
 
-  it('returns false if play violates suit-following rule', () => {
+  it('returns false if play violates suit-following rule', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'clubs', rank: 'A' },
       { suit: 'spades', rank: 'K' },
@@ -171,7 +171,7 @@ describe('isCardLegal', () => {
     assert.ok(!isCardLegal({ suit: 'spades', rank: 'K' }, hand, trick, false, false))
   })
 
-  it('returns false if leading spades on first trick when non-spades available', () => {
+  it('returns false if leading spades on first trick when non-spades available', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'clubs', rank: 'A' },
       { suit: 'spades', rank: 'K' },

--- a/test/unit/lobby/table.test.js
+++ b/test/unit/lobby/table.test.js
@@ -15,30 +15,30 @@ function makeTable(overrides = {}) {
   }
 }
 
-describe('isTableFull', () => {
-  it('returns false when no seats are filled (0/4)', () => {
+describe('isTableFull', { timeout: 2000 }, () => {
+  it('returns false when no seats are filled (0/4)', { timeout: 2000 }, () => {
     const table = makeTable()
     assert.equal(isTableFull(table), false)
   })
 
-  it('returns false when 1 seat is filled (1/4)', () => {
+  it('returns false when 1 seat is filled (1/4)', { timeout: 2000 }, () => {
     const table = makeTable({ seats: { north: 'player-1', east: null, south: null, west: null } })
     assert.equal(isTableFull(table), false)
   })
 
-  it('returns false when 2 seats are filled (2/4)', () => {
+  it('returns false when 2 seats are filled (2/4)', { timeout: 2000 }, () => {
     const table = makeTable({ seats: { north: 'player-1', east: 'player-2', south: null, west: null } })
     assert.equal(isTableFull(table), false)
   })
 
-  it('returns false when 3 seats are filled (3/4)', () => {
+  it('returns false when 3 seats are filled (3/4)', { timeout: 2000 }, () => {
     const table = makeTable({
       seats: { north: 'player-1', east: 'player-2', south: 'player-3', west: null },
     })
     assert.equal(isTableFull(table), false)
   })
 
-  it('returns true when all 4 seats are filled (4/4)', () => {
+  it('returns true when all 4 seats are filled (4/4)', { timeout: 2000 }, () => {
     const table = makeTable({
       seats: {
         north: 'player-1',

--- a/test/unit/middleware/rateLimiter.test.js
+++ b/test/unit/middleware/rateLimiter.test.js
@@ -66,8 +66,8 @@ function makeMockReqRes(ip = '127.0.0.1') {
   return { req, res, next, get nextCalled() { return nextCalled } }
 }
 
-describe('createRateLimiter', () => {
-  it('calls next() when under the limit', async () => {
+describe('createRateLimiter', { timeout: 2000 }, () => {
+  it('calls next() when under the limit', { timeout: 2000 }, async () => {
     const redis = makeMockRedis()
     const limiter = createRateLimiter(redis, { keyPrefix: 'test', max: 5, windowSecs: 60 })
 
@@ -79,7 +79,7 @@ describe('createRateLimiter', () => {
     assert.equal(res.statusCode, null)
   })
 
-  it('sets X-RateLimit-* headers on each request', async () => {
+  it('sets X-RateLimit-* headers on each request', { timeout: 2000 }, async () => {
     const redis = makeMockRedis()
     const limiter = createRateLimiter(redis, { keyPrefix: 'hdr', max: 10, windowSecs: 60 })
 
@@ -91,7 +91,7 @@ describe('createRateLimiter', () => {
     assert.ok(res._headers['X-RateLimit-Reset'] !== undefined)
   })
 
-  it('decrements X-RateLimit-Remaining with each request', async () => {
+  it('decrements X-RateLimit-Remaining with each request', { timeout: 2000 }, async () => {
     const redis = makeMockRedis()
     const limiter = createRateLimiter(redis, { keyPrefix: 'rem', max: 3, windowSecs: 60 })
     const ip = '10.0.0.1'
@@ -106,7 +106,7 @@ describe('createRateLimiter', () => {
     assert.deepEqual(results, [2, 1, 0])
   })
 
-  it('returns 429 and sets Retry-After when the limit is exceeded', async () => {
+  it('returns 429 and sets Retry-After when the limit is exceeded', { timeout: 2000 }, async () => {
     const redis = makeMockRedis()
     const limiter = createRateLimiter(redis, { keyPrefix: 'block', max: 2, windowSecs: 60 })
     const ip = '10.0.0.2'
@@ -127,7 +127,7 @@ describe('createRateLimiter', () => {
     assert.ok(res._headers['Retry-After'] !== undefined, 'Retry-After header should be set')
   })
 
-  it('uses separate counters per IP', async () => {
+  it('uses separate counters per IP', { timeout: 2000 }, async () => {
     const redis = makeMockRedis()
     const limiter = createRateLimiter(redis, { keyPrefix: 'ip', max: 1, windowSecs: 60 })
 
@@ -148,7 +148,7 @@ describe('createRateLimiter', () => {
     assert.ok(bPassed, 'IP B should not be rate limited by IP A exhausting their limit')
   })
 
-  it('sets EXPIRE only on the first request (count === 1)', async () => {
+  it('sets EXPIRE only on the first request (count === 1)', { timeout: 2000 }, async () => {
     const redis = makeMockRedis()
     const limiter = createRateLimiter(redis, { keyPrefix: 'exp', max: 5, windowSecs: 60 })
     const ip = '3.3.3.3'
@@ -164,7 +164,7 @@ describe('createRateLimiter', () => {
     assert.equal(redis._ttls.size, 1, 'expire should only have been called once')
   })
 
-  it('calls next() when no redis client is provided (graceful degradation)', async () => {
+  it('calls next() when no redis client is provided (graceful degradation)', { timeout: 2000 }, async () => {
     const limiter = createRateLimiter(null, { keyPrefix: 'null', max: 5, windowSecs: 60 })
 
     let called = false
@@ -172,7 +172,7 @@ describe('createRateLimiter', () => {
     assert.ok(called, 'next() should be called when redis is null')
   })
 
-  it('uses AUTH_RATE_LIMIT_MAX and AUTH_RATE_LIMIT_WINDOW env vars as defaults', async () => {
+  it('uses AUTH_RATE_LIMIT_MAX and AUTH_RATE_LIMIT_WINDOW env vars as defaults', { timeout: 2000 }, async () => {
     const original = { ...process.env }
     process.env.AUTH_RATE_LIMIT_MAX = '3'
     process.env.AUTH_RATE_LIMIT_WINDOW = '120'

--- a/test/unit/web/api.test.js
+++ b/test/unit/web/api.test.js
@@ -13,8 +13,8 @@ function mockFetch(status, body) {
   })
 }
 
-describe('registerUser', () => {
-  it('resolves with the response body on 201', async () => {
+describe('registerUser', { timeout: 2000 }, () => {
+  it('resolves with the response body on 201', { timeout: 2000 }, async () => {
     const result = await registerUser(
       { email: 'a@b.com', username: 'alice', password: 'password123' },
       mockFetch(201, { playerId: 'uuid-123', message: 'Registration successful.' }),
@@ -22,7 +22,7 @@ describe('registerUser', () => {
     assert.equal(result.playerId, 'uuid-123')
   })
 
-  it('resolves with sessionId and username when DEV_AUTO_VERIFY is active', async () => {
+  it('resolves with sessionId and username when DEV_AUTO_VERIFY is active', { timeout: 2000 }, async () => {
     const result = await registerUser(
       { email: 'a@b.com', username: 'alice', password: 'password123' },
       mockFetch(201, { sessionId: 'sess-abc', playerId: 'uuid-123', username: 'alice' }),
@@ -32,7 +32,7 @@ describe('registerUser', () => {
     assert.equal(result.username, 'alice')
   })
 
-  it('throws with status 409 on duplicate email/username', async () => {
+  it('throws with status 409 on duplicate email/username', { timeout: 2000 }, async () => {
     await assert.rejects(
       () =>
         registerUser(
@@ -47,7 +47,7 @@ describe('registerUser', () => {
     )
   })
 
-  it('throws with status 400 on validation error', async () => {
+  it('throws with status 400 on validation error', { timeout: 2000 }, async () => {
     await assert.rejects(
       () =>
         registerUser(
@@ -61,7 +61,7 @@ describe('registerUser', () => {
     )
   })
 
-  it('throws a generic message when response body has no error field', async () => {
+  it('throws a generic message when response body has no error field', { timeout: 2000 }, async () => {
     await assert.rejects(
       () =>
         registerUser(
@@ -76,8 +76,8 @@ describe('registerUser', () => {
   })
 })
 
-describe('resendVerification', () => {
-  it('resolves on 200', async () => {
+describe('resendVerification', { timeout: 2000 }, () => {
+  it('resolves on 200', { timeout: 2000 }, async () => {
     const result = await resendVerification(
       { email: 'a@b.com' },
       mockFetch(200, { message: 'If this email is registered and unverified, a new link has been sent.' }),
@@ -85,7 +85,7 @@ describe('resendVerification', () => {
     assert.ok(result.message)
   })
 
-  it('throws on network/server error', async () => {
+  it('throws on network/server error', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => resendVerification({ email: 'a@b.com' }, mockFetch(500, { error: 'Internal server error' })),
       (err) => {
@@ -96,8 +96,8 @@ describe('resendVerification', () => {
   })
 })
 
-describe('forgotPassword', () => {
-  it('resolves on 200', async () => {
+describe('forgotPassword', { timeout: 2000 }, () => {
+  it('resolves on 200', { timeout: 2000 }, async () => {
     const result = await forgotPassword(
       { email: 'a@b.com' },
       mockFetch(200, { message: 'If that email is registered, a reset link has been sent.' }),
@@ -105,7 +105,7 @@ describe('forgotPassword', () => {
     assert.ok(result.message)
   })
 
-  it('throws on server error', async () => {
+  it('throws on server error', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => forgotPassword({ email: 'a@b.com' }, mockFetch(500, { error: 'Internal server error' })),
       (err) => {
@@ -116,8 +116,8 @@ describe('forgotPassword', () => {
   })
 })
 
-describe('resetPassword', () => {
-  it('resolves with message on 200', async () => {
+describe('resetPassword', { timeout: 2000 }, () => {
+  it('resolves with message on 200', { timeout: 2000 }, async () => {
     const result = await resetPassword(
       { token: 'valid-token', newPassword: 'newpassword123' },
       mockFetch(200, { message: 'Password reset successfully. You may now sign in.' }),
@@ -125,7 +125,7 @@ describe('resetPassword', () => {
     assert.ok(result.message)
   })
 
-  it('throws with status 400 on invalid or expired token', async () => {
+  it('throws with status 400 on invalid or expired token', { timeout: 2000 }, async () => {
     await assert.rejects(
       () =>
         resetPassword(
@@ -140,8 +140,8 @@ describe('resetPassword', () => {
   })
 })
 
-describe('logoutUser', () => {
-  it('resolves with message on 200', async () => {
+describe('logoutUser', { timeout: 2000 }, () => {
+  it('resolves with message on 200', { timeout: 2000 }, async () => {
     const result = await logoutUser(
       { sessionId: 'sess-1' },
       mockFetch(200, { message: 'Logged out successfully.' }),
@@ -149,7 +149,7 @@ describe('logoutUser', () => {
     assert.ok(result.message)
   })
 
-  it('throws on server error', async () => {
+  it('throws on server error', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => logoutUser({ sessionId: 'sess-1' }, mockFetch(500, { error: 'Internal server error' })),
       (err) => {
@@ -160,8 +160,8 @@ describe('logoutUser', () => {
   })
 })
 
-describe('loginUser', () => {
-  it('resolves with sessionId, playerId, and username on 200', async () => {
+describe('loginUser', { timeout: 2000 }, () => {
+  it('resolves with sessionId, playerId, and username on 200', { timeout: 2000 }, async () => {
     const result = await loginUser(
       { email: 'a@b.com', password: 'password123' },
       mockFetch(200, { sessionId: 'sess-1', playerId: 'uuid-1', username: 'alice' }),
@@ -171,7 +171,7 @@ describe('loginUser', () => {
     assert.equal(result.username, 'alice')
   })
 
-  it('throws with status 401 on invalid credentials', async () => {
+  it('throws with status 401 on invalid credentials', { timeout: 2000 }, async () => {
     await assert.rejects(
       () =>
         loginUser(
@@ -185,7 +185,7 @@ describe('loginUser', () => {
     )
   })
 
-  it('throws with status 403 on unverified email', async () => {
+  it('throws with status 403 on unverified email', { timeout: 2000 }, async () => {
     await assert.rejects(
       () =>
         loginUser(
@@ -199,7 +199,7 @@ describe('loginUser', () => {
     )
   })
 
-  it('throws with status 400 when fields are missing', async () => {
+  it('throws with status 400 when fields are missing', { timeout: 2000 }, async () => {
     await assert.rejects(
       () =>
         loginUser(
@@ -214,10 +214,10 @@ describe('loginUser', () => {
   })
 })
 
-describe('createTable', () => {
+describe('createTable', { timeout: 2000 }, () => {
   const auth = { sessionId: 'sess-1', playerId: 'player-1' }
 
-  it('resolves with tableId and name on 201', async () => {
+  it('resolves with tableId and name on 201', { timeout: 2000 }, async () => {
     const result = await createTable(
       { name: 'Friday Night', ...auth },
       mockFetch(201, { tableId: 'table-uuid', name: 'Friday Night' }),
@@ -226,7 +226,7 @@ describe('createTable', () => {
     assert.equal(result.name, 'Friday Night')
   })
 
-  it('resolves with null name when no name provided', async () => {
+  it('resolves with null name when no name provided', { timeout: 2000 }, async () => {
     const result = await createTable(
       { ...auth },
       mockFetch(201, { tableId: 'table-uuid', name: null }),
@@ -235,7 +235,7 @@ describe('createTable', () => {
     assert.equal(result.name, null)
   })
 
-  it('throws with status 401 when unauthenticated', async () => {
+  it('throws with status 401 when unauthenticated', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => createTable({ ...auth }, mockFetch(401, { error: 'Unauthorized.' })),
       (err) => {
@@ -245,7 +245,7 @@ describe('createTable', () => {
     )
   })
 
-  it('throws with status 400 when name is too long', async () => {
+  it('throws with status 400 when name is too long', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => createTable(
         { name: 'x'.repeat(51), ...auth },
@@ -260,10 +260,10 @@ describe('createTable', () => {
   })
 })
 
-describe('listTables', () => {
+describe('listTables', { timeout: 2000 }, () => {
   const auth = { sessionId: 'sess-1', playerId: 'player-1' }
 
-  it('resolves with tables array on 200', async () => {
+  it('resolves with tables array on 200', { timeout: 2000 }, async () => {
     const tables = [
       { tableId: 'table-1', name: 'Friday Night', seats: { north: null, east: null, south: null, west: null }, seatsAvailable: 4 },
     ]
@@ -271,12 +271,12 @@ describe('listTables', () => {
     assert.deepEqual(result.tables, tables)
   })
 
-  it('resolves with empty array when no tables', async () => {
+  it('resolves with empty array when no tables', { timeout: 2000 }, async () => {
     const result = await listTables(auth, mockFetch(200, { tables: [] }))
     assert.deepEqual(result.tables, [])
   })
 
-  it('throws with status 401 when unauthenticated', async () => {
+  it('throws with status 401 when unauthenticated', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => listTables(auth, mockFetch(401, { error: 'Unauthorized.' })),
       (err) => {
@@ -287,10 +287,10 @@ describe('listTables', () => {
   })
 })
 
-describe('sitAtTable', () => {
+describe('sitAtTable', { timeout: 2000 }, () => {
   const auth = { sessionId: 'sess-1', playerId: 'player-1' }
 
-  it('resolves on 200 with tableId and seat', async () => {
+  it('resolves on 200 with tableId and seat', { timeout: 2000 }, async () => {
     const result = await sitAtTable(
       { tableId: 'table-1', seat: 'north', ...auth },
       mockFetch(200, { tableId: 'table-1', seat: 'north' }),
@@ -299,7 +299,7 @@ describe('sitAtTable', () => {
     assert.equal(result.seat, 'north')
   })
 
-  it('throws with status 409 when seat is taken', async () => {
+  it('throws with status 409 when seat is taken', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => sitAtTable(
         { tableId: 'table-1', seat: 'north', ...auth },
@@ -312,7 +312,7 @@ describe('sitAtTable', () => {
     )
   })
 
-  it('throws with status 401 when unauthenticated', async () => {
+  it('throws with status 401 when unauthenticated', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => sitAtTable(
         { tableId: 'table-1', seat: 'north', ...auth },
@@ -326,31 +326,31 @@ describe('sitAtTable', () => {
   })
 })
 
-describe('getGameState', () => {
+describe('getGameState', { timeout: 2000 }, () => {
   const auth = { tableId: 'table-1', sessionId: 'sess-1', playerId: 'player-1' }
 
-  it('resolves with game state on 200', async () => {
+  it('resolves with game state on 200', { timeout: 2000 }, async () => {
     const gameState = { phase: 'bidding', myHand: [], scores: { ns: 0, ew: 0 }, bags: { ns: 0, ew: 0 } }
     const result = await getGameState(auth, mockFetch(200, gameState))
     assert.equal(result.phase, 'bidding')
     assert.deepEqual(result.myHand, [])
   })
 
-  it('throws with status 401 when unauthenticated', async () => {
+  it('throws with status 401 when unauthenticated', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => getGameState(auth, mockFetch(401, { error: 'Unauthorized.' })),
       (err) => { assert.equal(err.status, 401); return true },
     )
   })
 
-  it('throws with status 403 when not seated at table', async () => {
+  it('throws with status 403 when not seated at table', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => getGameState(auth, mockFetch(403, { error: 'You are not seated at this table' })),
       (err) => { assert.equal(err.status, 403); return true },
     )
   })
 
-  it('throws with status 404 when table not found', async () => {
+  it('throws with status 404 when table not found', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => getGameState(auth, mockFetch(404, { error: 'Table not found' })),
       (err) => { assert.equal(err.status, 404); return true },
@@ -358,31 +358,31 @@ describe('getGameState', () => {
   })
 })
 
-describe('placeBid', () => {
+describe('placeBid', { timeout: 2000 }, () => {
   const auth = { tableId: 'table-1', bid: 3, sessionId: 'sess-1', playerId: 'player-1' }
 
-  it('resolves with updated state on 200', async () => {
+  it('resolves with updated state on 200', { timeout: 2000 }, async () => {
     const state = { phase: 'bidding', bids: { north: null, east: 3, south: null, west: null }, currentBidderSeat: 'south' }
     const result = await placeBid(auth, mockFetch(200, state))
     assert.equal(result.bids.east, 3)
     assert.equal(result.currentBidderSeat, 'south')
   })
 
-  it('throws with status 409 when not this player\'s turn', async () => {
+  it('throws with status 409 when not this player\'s turn', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => placeBid(auth, mockFetch(409, { error: 'Not your turn to bid' })),
       (err) => { assert.equal(err.status, 409); return true },
     )
   })
 
-  it('throws with status 400 on invalid bid value', async () => {
+  it('throws with status 400 on invalid bid value', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => placeBid({ ...auth, bid: 14 }, mockFetch(400, { error: 'Invalid bid value: 14' })),
       (err) => { assert.equal(err.status, 400); return true },
     )
   })
 
-  it('throws with status 400 when not eligible for blind nil', async () => {
+  it('throws with status 400 when not eligible for blind nil', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => placeBid({ ...auth, bid: 'blind_nil' }, mockFetch(400, { error: 'Not eligible for Blind Nil' })),
       (err) => {
@@ -393,7 +393,7 @@ describe('placeBid', () => {
     )
   })
 
-  it('throws with status 401 when unauthenticated', async () => {
+  it('throws with status 401 when unauthenticated', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => placeBid(auth, mockFetch(401, { error: 'Unauthorized.' })),
       (err) => { assert.equal(err.status, 401); return true },
@@ -401,39 +401,39 @@ describe('placeBid', () => {
   })
 })
 
-describe('playCard', () => {
+describe('playCard', { timeout: 2000 }, () => {
   const card = { suit: 'spades', rank: 'A' }
   const auth = { tableId: 'table-1', card, sessionId: 'sess-1', playerId: 'player-1' }
 
-  it('resolves with updated state on 200', async () => {
+  it('resolves with updated state on 200', { timeout: 2000 }, async () => {
     const state = { phase: 'playing', currentTrick: [{ seat: 'east', card }] }
     const result = await playCard(auth, mockFetch(200, state))
     assert.equal(result.phase, 'playing')
     assert.equal(result.currentTrick.length, 1)
   })
 
-  it('throws with status 409 when not this player\'s turn', async () => {
+  it('throws with status 409 when not this player\'s turn', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => playCard(auth, mockFetch(409, { error: 'Not your turn to play' })),
       (err) => { assert.equal(err.status, 409); return true },
     )
   })
 
-  it('throws with status 400 on illegal play', async () => {
+  it('throws with status 400 on illegal play', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => playCard(auth, mockFetch(400, { error: 'Illegal play' })),
       (err) => { assert.equal(err.status, 400); return true },
     )
   })
 
-  it('throws with status 400 when card not in hand', async () => {
+  it('throws with status 400 when card not in hand', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => playCard(auth, mockFetch(400, { error: 'Card not in hand' })),
       (err) => { assert.equal(err.status, 400); return true },
     )
   })
 
-  it('throws with status 401 when unauthenticated', async () => {
+  it('throws with status 401 when unauthenticated', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => playCard(auth, mockFetch(401, { error: 'Unauthorized.' })),
       (err) => { assert.equal(err.status, 401); return true },
@@ -441,10 +441,10 @@ describe('playCard', () => {
   })
 })
 
-describe('revealHand', () => {
+describe('revealHand', { timeout: 2000 }, () => {
   const auth = { tableId: 'table-1', sessionId: 'sess-1', playerId: 'player-1' }
 
-  it('resolves with updated state including myHand on 200', async () => {
+  it('resolves with updated state including myHand on 200', { timeout: 2000 }, async () => {
     const hand = Array.from({ length: 13 }, (_, i) => ({ suit: 'spades', rank: String(i + 2) }))
     const state = { phase: 'bidding', blindNilEligible: true, myHand: hand }
     const result = await revealHand(auth, mockFetch(200, state))
@@ -452,7 +452,7 @@ describe('revealHand', () => {
     assert.equal(result.myHand.length, 13)
   })
 
-  it('throws with status 409 when player has already placed a bid', async () => {
+  it('throws with status 409 when player has already placed a bid', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => revealHand(auth, mockFetch(409, { error: 'Bid already placed' })),
       (err) => {
@@ -463,7 +463,7 @@ describe('revealHand', () => {
     )
   })
 
-  it('throws with status 400 when player is not eligible for Blind Nil', async () => {
+  it('throws with status 400 when player is not eligible for Blind Nil', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => revealHand(auth, mockFetch(400, { error: 'Not eligible for Blind Nil' })),
       (err) => {
@@ -474,7 +474,7 @@ describe('revealHand', () => {
     )
   })
 
-  it('throws with status 400 when not in bidding phase', async () => {
+  it('throws with status 400 when not in bidding phase', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => revealHand(auth, mockFetch(400, { error: 'Invalid action outside bidding phase' })),
       (err) => {
@@ -484,14 +484,14 @@ describe('revealHand', () => {
     )
   })
 
-  it('throws with status 401 when unauthenticated', async () => {
+  it('throws with status 401 when unauthenticated', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => revealHand(auth, mockFetch(401, { error: 'Unauthorized.' })),
       (err) => { assert.equal(err.status, 401); return true },
     )
   })
 
-  it('throws a generic message when response body has no error field', async () => {
+  it('throws a generic message when response body has no error field', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => revealHand(auth, mockFetch(500, {})),
       (err) => {
@@ -502,17 +502,17 @@ describe('revealHand', () => {
   })
 })
 
-describe('submitBlindNilExchange', () => {
+describe('submitBlindNilExchange', { timeout: 2000 }, () => {
   const cards = [{ suit: 'spades', rank: 'A' }, { suit: 'hearts', rank: 'K' }]
   const auth = { tableId: 'table-1', cards, sessionId: 'sess-1', playerId: 'player-1' }
 
-  it('resolves with updated state on 200', async () => {
+  it('resolves with updated state on 200', { timeout: 2000 }, async () => {
     const state = { phase: 'playing', currentPlayerSeat: 'east' }
     const result = await submitBlindNilExchange(auth, mockFetch(200, state))
     assert.equal(result.phase, 'playing')
   })
 
-  it('throws with status 400 on invalid exchange (wrong number of cards)', async () => {
+  it('throws with status 400 on invalid exchange (wrong number of cards)', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => submitBlindNilExchange({ ...auth, cards: [cards[0]] }, mockFetch(400, { error: 'Must submit exactly 2 cards' })),
       (err) => {
@@ -523,14 +523,14 @@ describe('submitBlindNilExchange', () => {
     )
   })
 
-  it('throws with status 400 when wrong player tries to exchange', async () => {
+  it('throws with status 400 when wrong player tries to exchange', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => submitBlindNilExchange(auth, mockFetch(400, { error: 'Blind Nil player must send cards first' })),
       (err) => { assert.equal(err.status, 400); return true },
     )
   })
 
-  it('throws with status 401 when unauthenticated', async () => {
+  it('throws with status 401 when unauthenticated', { timeout: 2000 }, async () => {
     await assert.rejects(
       () => submitBlindNilExchange(auth, mockFetch(401, { error: 'Unauthorized.' })),
       (err) => { assert.equal(err.status, 401); return true },

--- a/test/unit/web/bidHint.test.js
+++ b/test/unit/web/bidHint.test.js
@@ -2,52 +2,52 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { bidContributionHint } from '../../../client/web/src/screens/game.js'
 
-describe('bidContributionHint', () => {
-  it('computes yourBid as teamTotal minus partnerBid', () => {
+describe('bidContributionHint', { timeout: 2000 }, () => {
+  it('computes yourBid as teamTotal minus partnerBid', { timeout: 2000 }, () => {
     const result = bidContributionHint(7, 4)
     assert.equal(result.yourBid, 3)
   })
 
-  it('isWarning is false when teamTotal equals partnerBid (zero contribution)', () => {
+  it('isWarning is false when teamTotal equals partnerBid (zero contribution)', { timeout: 2000 }, () => {
     const result = bidContributionHint(4, 4)
     assert.equal(result.yourBid, 0)
     assert.equal(result.isWarning, false)
   })
 
-  it('isWarning is false when teamTotal is above partnerBid', () => {
+  it('isWarning is false when teamTotal is above partnerBid', { timeout: 2000 }, () => {
     const result = bidContributionHint(7, 4)
     assert.equal(result.isWarning, false)
   })
 
-  it('isWarning is true when teamTotal is below partnerBid', () => {
+  it('isWarning is true when teamTotal is below partnerBid', { timeout: 2000 }, () => {
     const result = bidContributionHint(2, 4)
     assert.equal(result.isWarning, true)
   })
 
-  it('yourBid is negative when teamTotal is below partnerBid (warns, does not clamp)', () => {
+  it('yourBid is negative when teamTotal is below partnerBid (warns, does not clamp)', { timeout: 2000 }, () => {
     const result = bidContributionHint(2, 4)
     assert.equal(result.yourBid, -2)
   })
 
-  it('works when partnerBid is 0', () => {
+  it('works when partnerBid is 0', { timeout: 2000 }, () => {
     const result = bidContributionHint(5, 0)
     assert.equal(result.yourBid, 5)
     assert.equal(result.isWarning, false)
   })
 
-  it('works when teamTotal is 0 and partnerBid is 0', () => {
+  it('works when teamTotal is 0 and partnerBid is 0', { timeout: 2000 }, () => {
     const result = bidContributionHint(0, 0)
     assert.equal(result.yourBid, 0)
     assert.equal(result.isWarning, false)
   })
 
-  it('returns both fields as an object', () => {
+  it('returns both fields as an object', { timeout: 2000 }, () => {
     const result = bidContributionHint(6, 3)
     assert.ok(Object.hasOwn(result, 'yourBid'), 'result must have yourBid')
     assert.ok(Object.hasOwn(result, 'isWarning'), 'result must have isWarning')
   })
 
-  it('handles large team total', () => {
+  it('handles large team total', { timeout: 2000 }, () => {
     const result = bidContributionHint(13, 6)
     assert.equal(result.yourBid, 7)
     assert.equal(result.isWarning, false)

--- a/test/unit/web/bidSummary.test.js
+++ b/test/unit/web/bidSummary.test.js
@@ -21,18 +21,18 @@ function makeState(bids, { teamBids = {}, biddingOrder = ['north', 'east', 'sout
 // teamBidSummaryHtml
 // ---------------------------------------------------------------------------
 
-describe('teamBidSummaryHtml', () => {
-  it('returns empty string when no team has finished bidding', () => {
+describe('teamBidSummaryHtml', { timeout: 2000 }, () => {
+  it('returns empty string when no team has finished bidding', { timeout: 2000 }, () => {
     const state = makeState({ north: null, south: null, east: null, west: null })
     assert.equal(teamBidSummaryHtml(state), '')
   })
 
-  it('returns empty string when only one player on a team has bid', () => {
+  it('returns empty string when only one player on a team has bid', { timeout: 2000 }, () => {
     const state = makeState({ north: 4, south: null, east: null, west: null })
     assert.equal(teamBidSummaryHtml(state), '')
   })
 
-  it('renders N/S summary with correct team total and individual contributions', () => {
+  it('renders N/S summary with correct team total and individual contributions', { timeout: 2000 }, () => {
     // North bids 4 (first, advisory). South enters 7 as team total (second bidder).
     // state.bids.south = 7 (team total), teamBids.ns = 7, South individual = 7 - 4 = 3.
     const state = makeState(
@@ -47,7 +47,7 @@ describe('teamBidSummaryHtml', () => {
     assert.ok(!html.match(/N\/S: 11/), 'should not show wrong total 11 (4+7)')
   })
 
-  it('renders N/S summary when South is the first bidder', () => {
+  it('renders N/S summary when South is the first bidder', { timeout: 2000 }, () => {
     // With dealer = west, biddingOrder = ['north', 'east', 'south', 'west'].
     // Use a dealer = south so biddingOrder = ['west', 'north', 'east', 'south'].
     // Here South bids last for NS — North bids first: North 5, South enters 8 as team total.
@@ -63,7 +63,7 @@ describe('teamBidSummaryHtml', () => {
     assert.ok(html.includes('South 3'), 'should show second bidder South individual 3')
   })
 
-  it('renders E/W summary once both E/W players have bid', () => {
+  it('renders E/W summary once both E/W players have bid', { timeout: 2000 }, () => {
     // East bids 5 (first for EW). West enters 8 as team total (second for EW).
     // West individual = 8 - 5 = 3.
     const state = makeState(
@@ -77,7 +77,7 @@ describe('teamBidSummaryHtml', () => {
     assert.ok(html.includes('West 3'), 'should show West individual contribution 3')
   })
 
-  it('renders both team summaries when all four players have bid', () => {
+  it('renders both team summaries when all four players have bid', { timeout: 2000 }, () => {
     // NS: North 4, South enters 7 (team total). EW: East 5, West enters 7 (team total).
     const state = makeState(
       { north: 4, south: 7, east: 5, west: 7 },
@@ -89,7 +89,7 @@ describe('teamBidSummaryHtml', () => {
     assert.ok(html.includes('bid-summary-team'), 'should use bid-summary-team class')
   })
 
-  it('wraps output in a bid-summary container', () => {
+  it('wraps output in a bid-summary container', { timeout: 2000 }, () => {
     const state = makeState(
       { north: 4, south: 7, east: null, west: null },
       { teamBids: { ns: 7 } },
@@ -98,7 +98,7 @@ describe('teamBidSummaryHtml', () => {
     assert.ok(html.includes('bid-summary'), 'should include bid-summary class')
   })
 
-  it('shows Nil bid individually and excludes it from team total', () => {
+  it('shows Nil bid individually and excludes it from team total', { timeout: 2000 }, () => {
     // North bids nil (first). South bids 4 (second, team total = 4).
     const state = makeState(
       { north: 'nil', south: 4, east: null, west: null },
@@ -110,7 +110,7 @@ describe('teamBidSummaryHtml', () => {
     assert.ok(!html.match(/N\/S: \d+ —/), 'should not show a combined numeric total when one bid is Nil')
   })
 
-  it('shows Blind Nil bid individually and excludes it from team total', () => {
+  it('shows Blind Nil bid individually and excludes it from team total', { timeout: 2000 }, () => {
     const state = makeState(
       { north: 'blind_nil', south: 4, east: null, west: null },
       { teamBids: { ns: 4 } },
@@ -120,7 +120,7 @@ describe('teamBidSummaryHtml', () => {
     assert.ok(!html.match(/N\/S: \d+ —/), 'should not show a combined numeric total when one bid is Blind Nil')
   })
 
-  it('shows both Nil bids individually with no combined total', () => {
+  it('shows both Nil bids individually with no combined total', { timeout: 2000 }, () => {
     const state = makeState(
       { north: 'nil', south: 'nil', east: null, west: null },
       { teamBids: { ns: null } },
@@ -130,7 +130,7 @@ describe('teamBidSummaryHtml', () => {
     assert.ok(!html.match(/N\/S: \d+ —/), 'should not show a combined total for two Nil bids')
   })
 
-  it('handles a zero first bid in the team total', () => {
+  it('handles a zero first bid in the team total', { timeout: 2000 }, () => {
     // North bids 0 (first). South enters 4 as team total. South individual = 4.
     const state = makeState(
       { north: 0, south: 4, east: null, west: null },
@@ -142,7 +142,7 @@ describe('teamBidSummaryHtml', () => {
     assert.ok(html.includes('South 4'), 'should show South individual of 4')
   })
 
-  it('handles maximum possible team total (13 tricks)', () => {
+  it('handles maximum possible team total (13 tricks)', { timeout: 2000 }, () => {
     // North bids 7 (first). South enters 13 as team total. South individual = 6.
     const state = makeState(
       { north: 7, south: 13, east: null, west: null },
@@ -154,7 +154,7 @@ describe('teamBidSummaryHtml', () => {
     assert.ok(html.includes('South 6'), 'should show South individual 6')
   })
 
-  it('E/W summary with one Nil bid excludes Nil from team total', () => {
+  it('E/W summary with one Nil bid excludes Nil from team total', { timeout: 2000 }, () => {
     const state = makeState(
       { north: null, south: null, east: 'nil', west: 5 },
       { teamBids: { ew: 5 } },
@@ -165,7 +165,7 @@ describe('teamBidSummaryHtml', () => {
     assert.ok(!html.match(/E\/W: \d+ —/), 'should not show a combined numeric total')
   })
 
-  it('renders correctly when teamBids is null but both players on a team have bid (mid-bidding)', () => {
+  it('renders correctly when teamBids is null but both players on a team have bid (mid-bidding)', { timeout: 2000 }, () => {
     // E/W finished bidding but N/S has not, so state.teamBids.ew is still null.
     // East bids 2 (first for EW), West enters 3 as team total (second for EW).
     // state.bids.west = 3 (team total stored as second bidder's value).
@@ -182,7 +182,7 @@ describe('teamBidSummaryHtml', () => {
     assert.ok(!html.includes('null'), 'must not render the word null')
   })
 
-  it('true partnership case: second bidder value is team total, not individual', () => {
+  it('true partnership case: second bidder value is team total, not individual', { timeout: 2000 }, () => {
     // This is the core partnership bug scenario.
     // North bids 4. South enters 7 meaning "our team bids 7 total".
     // state.bids.south = 7, but South's individual contribution is only 3.
@@ -199,7 +199,7 @@ describe('teamBidSummaryHtml', () => {
     assert.ok(!html.includes('South 7'), 'must not show second bidder raw team total as their individual bid')
   })
 
-  it('shows correct E/W summary mid-hand when teamBids not yet computed (only E/W have bid)', () => {
+  it('shows correct E/W summary mid-hand when teamBids not yet computed (only E/W have bid)', { timeout: 2000 }, () => {
     // Regression test for issue #166: "E/W: null — East 2, West -2"
     // state.teamBids is only populated after ALL 4 players bid. If only E/W have
     // finished bidding, teamBids.ew is still null. The summary must fall back to

--- a/test/unit/web/blindNilHandHiding.test.js
+++ b/test/unit/web/blindNilHandHiding.test.js
@@ -6,30 +6,30 @@ import { blindNilHandHtml, blindNilChoicePanelHtml } from '../../../client/web/s
 // blindNilHandHtml
 // ---------------------------------------------------------------------------
 
-describe('blindNilHandHtml', () => {
-  it('renders exactly 13 face-down card backs', () => {
+describe('blindNilHandHtml', { timeout: 2000 }, () => {
+  it('renders exactly 13 face-down card backs', { timeout: 2000 }, () => {
     const html = blindNilHandHtml()
     const matches = html.match(/card-back/g) || []
     assert.equal(matches.length, 13)
   })
 
-  it('each card element has both card and card-back classes', () => {
+  it('each card element has both card and card-back classes', { timeout: 2000 }, () => {
     const html = blindNilHandHtml()
     const cardBacks = html.match(/class="card card-back"/g) || []
     assert.equal(cardBacks.length, 13)
   })
 
-  it('does not include data-suit attribute (no card info leaked)', () => {
+  it('does not include data-suit attribute (no card info leaked)', { timeout: 2000 }, () => {
     const html = blindNilHandHtml()
     assert.ok(!html.includes('data-suit'), 'must not expose card suit')
   })
 
-  it('does not include data-rank attribute (no card info leaked)', () => {
+  it('does not include data-rank attribute (no card info leaked)', { timeout: 2000 }, () => {
     const html = blindNilHandHtml()
     assert.ok(!html.includes('data-rank'), 'must not expose card rank')
   })
 
-  it('returns a non-empty string', () => {
+  it('returns a non-empty string', { timeout: 2000 }, () => {
     const html = blindNilHandHtml()
     assert.ok(typeof html === 'string' && html.length > 0)
   })
@@ -39,36 +39,36 @@ describe('blindNilHandHtml', () => {
 // blindNilChoicePanelHtml
 // ---------------------------------------------------------------------------
 
-describe('blindNilChoicePanelHtml', () => {
-  it('wraps output in a blind-nil-choice-panel container', () => {
+describe('blindNilChoicePanelHtml', { timeout: 2000 }, () => {
+  it('wraps output in a blind-nil-choice-panel container', { timeout: 2000 }, () => {
     const html = blindNilChoicePanelHtml()
     assert.ok(html.includes('blind-nil-choice-panel'), 'should have choice panel container class')
   })
 
-  it('contains a Reveal Hand button with id blind-nil-reveal-btn', () => {
+  it('contains a Reveal Hand button with id blind-nil-reveal-btn', { timeout: 2000 }, () => {
     const html = blindNilChoicePanelHtml()
     assert.ok(html.includes('id="blind-nil-reveal-btn"'), 'should have reveal hand button id')
     assert.ok(html.includes('Reveal Hand'), 'should have Reveal Hand label')
   })
 
-  it('contains a Bid Blind Nil button with id blind-nil-bid-btn', () => {
+  it('contains a Bid Blind Nil button with id blind-nil-bid-btn', { timeout: 2000 }, () => {
     const html = blindNilChoicePanelHtml()
     assert.ok(html.includes('id="blind-nil-bid-btn"'), 'should have bid blind nil button id')
     assert.ok(html.includes('Bid Blind Nil'), 'should have Bid Blind Nil label')
   })
 
-  it('contains an error container with role alert for action failures', () => {
+  it('contains an error container with role alert for action failures', { timeout: 2000 }, () => {
     const html = blindNilChoicePanelHtml()
     assert.ok(html.includes('blind-nil-err'), 'should have error container class')
     assert.ok(html.includes('role="alert"'), 'error container should have alert role')
   })
 
-  it('error container has aria-live polite for screen reader announcements', () => {
+  it('error container has aria-live polite for screen reader announcements', { timeout: 2000 }, () => {
     const html = blindNilChoicePanelHtml()
     assert.ok(html.includes('aria-live="polite"'), 'error container should announce politely')
   })
 
-  it('Reveal Hand button comes before Bid Blind Nil button in markup', () => {
+  it('Reveal Hand button comes before Bid Blind Nil button in markup', { timeout: 2000 }, () => {
     const html = blindNilChoicePanelHtml()
     const revealIdx = html.indexOf('blind-nil-reveal-btn')
     const bidIdx = html.indexOf('blind-nil-bid-btn')

--- a/test/unit/web/endOfHandSummary.test.js
+++ b/test/unit/web/endOfHandSummary.test.js
@@ -30,38 +30,38 @@ function makeEntry(overrides = {}) {
 
 // ── Basic rendering ───────────────────────────────────────────────────────────
 
-describe('endOfHandSummaryHtml — basic rendering', () => {
-  it('returns a non-empty string', () => {
+describe('endOfHandSummaryHtml — basic rendering', { timeout: 2000 }, () => {
+  it('returns a non-empty string', { timeout: 2000 }, () => {
     const html = endOfHandSummaryHtml(makeEntry(), 'north')
     assert.ok(typeof html === 'string' && html.length > 0)
   })
 
-  it('includes the hand number', () => {
+  it('includes the hand number', { timeout: 2000 }, () => {
     const html = endOfHandSummaryHtml(makeEntry({ handNumber: 3 }), 'north')
     assert.ok(html.includes('3'), 'should include hand number 3')
   })
 
-  it('includes "Us" label for the viewing player\'s team', () => {
+  it('includes "Us" label for the viewing player\'s team', { timeout: 2000 }, () => {
     const html = endOfHandSummaryHtml(makeEntry(), 'north')
     assert.ok(html.includes('Us'), 'should include "Us" label')
   })
 
-  it('includes "Them" label for the opponent team', () => {
+  it('includes "Them" label for the opponent team', { timeout: 2000 }, () => {
     const html = endOfHandSummaryHtml(makeEntry(), 'north')
     assert.ok(html.includes('Them'), 'should include "Them" label')
   })
 
-  it('includes N/S label for north/south team', () => {
+  it('includes N/S label for north/south team', { timeout: 2000 }, () => {
     const html = endOfHandSummaryHtml(makeEntry(), 'north')
     assert.ok(html.includes('N/S'), 'should include N/S team label')
   })
 
-  it('includes E/W label for east/west team', () => {
+  it('includes E/W label for east/west team', { timeout: 2000 }, () => {
     const html = endOfHandSummaryHtml(makeEntry(), 'north')
     assert.ok(html.includes('E/W'), 'should include E/W team label')
   })
 
-  it('includes a continue button', () => {
+  it('includes a continue button', { timeout: 2000 }, () => {
     const html = endOfHandSummaryHtml(makeEntry(), 'north')
     assert.ok(
       html.includes('hand-summary-continue') || html.toLowerCase().includes('continue'),
@@ -69,36 +69,36 @@ describe('endOfHandSummaryHtml — basic rendering', () => {
     )
   })
 
-  it('includes scores after the hand', () => {
+  it('includes scores after the hand', { timeout: 2000 }, () => {
     const html = endOfHandSummaryHtml(makeEntry({ scoresAfter: { ns: 70, ew: 70 } }), 'north')
     assert.ok(html.includes('70'), 'should include the score value 70')
   })
 })
 
-describe('endOfHandSummaryHtml — Us/Them column orientation', () => {
-  it('Us (N/S) appears before Them (E/W) for a north player', () => {
+describe('endOfHandSummaryHtml — Us/Them column orientation', { timeout: 2000 }, () => {
+  it('Us (N/S) appears before Them (E/W) for a north player', { timeout: 2000 }, () => {
     const html = endOfHandSummaryHtml(makeEntry(), 'north')
     assert.ok(html.indexOf('N/S') < html.indexOf('E/W'), 'N/S should come before E/W for north player')
   })
 
-  it('Us (E/W) appears before Them (N/S) for an east player', () => {
+  it('Us (E/W) appears before Them (N/S) for an east player', { timeout: 2000 }, () => {
     const html = endOfHandSummaryHtml(makeEntry(), 'east')
     assert.ok(html.indexOf('E/W') < html.indexOf('N/S'), 'E/W should come before N/S for east player')
   })
 
-  it('Us (N/S) appears before Them (E/W) for a south player', () => {
+  it('Us (N/S) appears before Them (E/W) for a south player', { timeout: 2000 }, () => {
     const html = endOfHandSummaryHtml(makeEntry(), 'south')
     assert.ok(html.indexOf('N/S') < html.indexOf('E/W'), 'N/S should come before E/W for south player')
   })
 
-  it('Us (E/W) appears before Them (N/S) for a west player', () => {
+  it('Us (E/W) appears before Them (N/S) for a west player', { timeout: 2000 }, () => {
     const html = endOfHandSummaryHtml(makeEntry(), 'west')
     assert.ok(html.indexOf('E/W') < html.indexOf('N/S'), 'E/W should come before N/S for west player')
   })
 })
 
-describe('endOfHandSummaryHtml — normal hand (no nil bids)', () => {
-  it('shows bid and tricks taken for each team', () => {
+describe('endOfHandSummaryHtml — normal hand (no nil bids)', { timeout: 2000 }, () => {
+  it('shows bid and tricks taken for each team', { timeout: 2000 }, () => {
     const entry = makeEntry({
       bids: { north: 3, east: 4, south: 4, west: 3 },
       teamBids: { ns: 7, ew: 7 },
@@ -108,13 +108,13 @@ describe('endOfHandSummaryHtml — normal hand (no nil bids)', () => {
     assert.ok(html.includes('7'), 'should include team bid of 7')
   })
 
-  it('shows positive score delta as +N', () => {
+  it('shows positive score delta as +N', { timeout: 2000 }, () => {
     const entry = makeEntry({ scoreDelta: { ns: 70, ew: 70 } })
     const html = endOfHandSummaryHtml(entry, 'north')
     assert.ok(html.includes('+70') || html.includes('+70'), 'should show +70')
   })
 
-  it('shows negative score delta for missed bid', () => {
+  it('shows negative score delta for missed bid', { timeout: 2000 }, () => {
     const entry = makeEntry({
       scoreDelta: { ns: -80, ew: 70 },
       scoresAfter: { ns: -80, ew: 70 },
@@ -123,7 +123,7 @@ describe('endOfHandSummaryHtml — normal hand (no nil bids)', () => {
     assert.ok(html.includes('-80') || html.includes('−80'), 'should show negative delta')
   })
 
-  it('shows bags earned when nonzero', () => {
+  it('shows bags earned when nonzero', { timeout: 2000 }, () => {
     const entry = makeEntry({
       newBags: { ns: 2, ew: 0 },
       bagsAfter: { ns: 2, ew: 0 },
@@ -133,8 +133,8 @@ describe('endOfHandSummaryHtml — normal hand (no nil bids)', () => {
   })
 })
 
-describe('endOfHandSummaryHtml — nil bid', () => {
-  it('shows nil result for a nil bidder on the ns team', () => {
+describe('endOfHandSummaryHtml — nil bid', { timeout: 2000 }, () => {
+  it('shows nil result for a nil bidder on the ns team', { timeout: 2000 }, () => {
     const entry = makeEntry({
       bids: { north: 'nil', east: 4, south: 5, west: 3 },
       teamBids: { ns: 5, ew: 7 },
@@ -145,7 +145,7 @@ describe('endOfHandSummaryHtml — nil bid', () => {
     assert.ok(html.toLowerCase().includes('nil'), 'should include "nil" in output')
   })
 
-  it('shows "Made" when nil bidder took 0 tricks', () => {
+  it('shows "Made" when nil bidder took 0 tricks', { timeout: 2000 }, () => {
     const entry = makeEntry({
       bids: { north: 'nil', east: 4, south: 5, west: 3 },
       teamBids: { ns: 5, ew: 7 },
@@ -155,7 +155,7 @@ describe('endOfHandSummaryHtml — nil bid', () => {
     assert.ok(html.includes('Made') || html.includes('+50'), 'should show nil made result')
   })
 
-  it('shows "Failed" when nil bidder took tricks', () => {
+  it('shows "Failed" when nil bidder took tricks', { timeout: 2000 }, () => {
     const entry = makeEntry({
       bids: { north: 'nil', east: 4, south: 5, west: 3 },
       teamBids: { ns: 5, ew: 7 },
@@ -165,7 +165,7 @@ describe('endOfHandSummaryHtml — nil bid', () => {
     assert.ok(html.includes('Failed') || html.includes('-50') || html.includes('−50'), 'should show nil failed result')
   })
 
-  it('shows blind nil with ±100 points', () => {
+  it('shows blind nil with ±100 points', { timeout: 2000 }, () => {
     const entry = makeEntry({
       bids: { north: 'blind_nil', east: 4, south: 5, west: 3 },
       teamBids: { ns: 5, ew: 7 },
@@ -178,7 +178,7 @@ describe('endOfHandSummaryHtml — nil bid', () => {
     )
   })
 
-  it('shows tricks-only score in "Bid X, Took Y" row when team has a failed nil bidder', () => {
+  it('shows tricks-only score in "Bid X, Took Y" row when team has a failed nil bidder', { timeout: 2000 }, () => {
     // Bid 3, Took 3 → +30 pts from tricks. Failed nil → -50. scoreDelta = -20.
     // The "Bid X, Took Y" row must show +30, not the net -20.
     const entry = makeEntry({
@@ -192,7 +192,7 @@ describe('endOfHandSummaryHtml — nil bid', () => {
     assert.ok(!html.includes('-20'), 'should not show the net score -20 in the team row')
   })
 
-  it('shows tricks-only score in "Bid X, Took Y" row when team has a made nil bidder', () => {
+  it('shows tricks-only score in "Bid X, Took Y" row when team has a made nil bidder', { timeout: 2000 }, () => {
     // Bid 5, Took 5 → +50 pts from tricks. Made nil → +50. scoreDelta = 100.
     // The "Bid X, Took Y" row must show +50, not +100.
     const entry = makeEntry({
@@ -205,7 +205,7 @@ describe('endOfHandSummaryHtml — nil bid', () => {
     assert.ok(html.includes('+50 pts'), 'Bid X, Took Y row should show +50 pts (tricks only)')
   })
 
-  it('nil result rows include "pts" suffix', () => {
+  it('nil result rows include "pts" suffix', { timeout: 2000 }, () => {
     const entry = makeEntry({
       bids: { north: 'nil', east: 4, south: 5, west: 3 },
       teamBids: { ns: 5, ew: 7 },
@@ -216,7 +216,7 @@ describe('endOfHandSummaryHtml — nil bid', () => {
     assert.ok(html.includes('−50 pts') || html.includes('-50 pts'), 'failed nil row should include "pts" suffix')
   })
 
-  it('made nil result rows include "pts" suffix', () => {
+  it('made nil result rows include "pts" suffix', { timeout: 2000 }, () => {
     const entry = makeEntry({
       bids: { north: 'nil', east: 4, south: 5, west: 3 },
       teamBids: { ns: 5, ew: 7 },
@@ -228,8 +228,8 @@ describe('endOfHandSummaryHtml — nil bid', () => {
   })
 })
 
-describe('endOfHandSummaryHtml — double nil (both players on a team bid nil)', () => {
-  it('omits team total row when both ns players bid nil', () => {
+describe('endOfHandSummaryHtml — double nil (both players on a team bid nil)', { timeout: 2000 }, () => {
+  it('omits team total row when both ns players bid nil', { timeout: 2000 }, () => {
     const entry = makeEntry({
       bids: { north: 'nil', east: 4, south: 'nil', west: 3 },
       teamBids: { ns: null, ew: 7 },
@@ -242,7 +242,7 @@ describe('endOfHandSummaryHtml — double nil (both players on a team bid nil)',
     assert.ok(html.toLowerCase().includes('nil'), 'should include nil label')
   })
 
-  it('still shows individual nil rows for each double-nil bidder', () => {
+  it('still shows individual nil rows for each double-nil bidder', { timeout: 2000 }, () => {
     const entry = makeEntry({
       bids: { north: 'nil', east: 4, south: 'nil', west: 3 },
       teamBids: { ns: null, ew: 7 },
@@ -255,8 +255,8 @@ describe('endOfHandSummaryHtml — double nil (both players on a team bid nil)',
   })
 })
 
-describe('endOfHandSummaryHtml — bag penalty', () => {
-  it('shows bag penalty notice when bagPenalty.ns is 1 for ns player', () => {
+describe('endOfHandSummaryHtml — bag penalty', { timeout: 2000 }, () => {
+  it('shows bag penalty notice when bagPenalty.ns is 1 for ns player', { timeout: 2000 }, () => {
     const entry = makeEntry({
       bagPenalty: { ns: 1, ew: 0 },
       scoresAfter: { ns: -30, ew: 70 }, // 70 - 100 penalty = -30
@@ -268,7 +268,7 @@ describe('endOfHandSummaryHtml — bag penalty', () => {
     )
   })
 
-  it('does not show bag penalty notice when no penalty', () => {
+  it('does not show bag penalty notice when no penalty', { timeout: 2000 }, () => {
     const entry = makeEntry({ bagPenalty: { ns: 0, ew: 0 } })
     const html = endOfHandSummaryHtml(entry, 'north')
     // "penalty" text should not appear
@@ -278,7 +278,7 @@ describe('endOfHandSummaryHtml — bag penalty', () => {
     )
   })
 
-  it('shows bag penalty for the opponent team when they cross 10 bags', () => {
+  it('shows bag penalty for the opponent team when they cross 10 bags', { timeout: 2000 }, () => {
     const entry = makeEntry({
       bagPenalty: { ns: 0, ew: 1 },
       scoresAfter: { ns: 70, ew: -30 },
@@ -290,7 +290,7 @@ describe('endOfHandSummaryHtml — bag penalty', () => {
     )
   })
 
-  it('shows −200 pts when a team bags out twice in one hand', () => {
+  it('shows −200 pts when a team bags out twice in one hand', { timeout: 2000 }, () => {
     const entry = makeEntry({
       bagPenalty: { ns: 2, ew: 0 },
       scoresAfter: { ns: -130, ew: 70 }, // 70 - 200 = -130
@@ -304,21 +304,21 @@ describe('endOfHandSummaryHtml — bag penalty', () => {
   })
 })
 
-describe('endOfHandSummaryHtml — running totals', () => {
-  it('shows scoresAfter for both teams', () => {
+describe('endOfHandSummaryHtml — running totals', { timeout: 2000 }, () => {
+  it('shows scoresAfter for both teams', { timeout: 2000 }, () => {
     const entry = makeEntry({ scoresAfter: { ns: 140, ew: 70 } })
     const html = endOfHandSummaryHtml(entry, 'north')
     assert.ok(html.includes('140'), 'should show ns score 140')
     assert.ok(html.includes('70'), 'should show ew score 70')
   })
 
-  it('shows bagsAfter for both teams', () => {
+  it('shows bagsAfter for both teams', { timeout: 2000 }, () => {
     const entry = makeEntry({ bagsAfter: { ns: 3, ew: 1 } })
     const html = endOfHandSummaryHtml(entry, 'north')
     assert.ok(html.includes('3'), 'should show ns bags 3')
   })
 
-  it('shows bagsBefore next to the scores at the top', () => {
+  it('shows bagsBefore next to the scores at the top', { timeout: 2000 }, () => {
     const entry = makeEntry({
       scoresBefore: { ns: 100, ew: 50 },
       bagsBefore: { ns: 4, ew: 2 },
@@ -330,7 +330,7 @@ describe('endOfHandSummaryHtml — running totals', () => {
     assert.ok(scoresBefore.includes('2') || html.includes('2'), 'should display them bags before (2)')
   })
 
-  it('bagsAfter appear on the same line as the final score (not below)', () => {
+  it('bagsAfter appear on the same line as the final score (not below)', { timeout: 2000 }, () => {
     const entry = makeEntry({ bagsAfter: { ns: 5, ew: 0 }, scoresAfter: { ns: 127, ew: 49 } })
     const html = endOfHandSummaryHtml(entry, 'north')
     // summary-bags should be inside summary-total but not in its own separate block
@@ -343,13 +343,13 @@ describe('endOfHandSummaryHtml — running totals', () => {
   })
 })
 
-describe('endOfHandSummaryHtml — gameOverInfo (game over mode)', () => {
-  it('includes GAME OVER in the title when gameOverInfo is provided', () => {
+describe('endOfHandSummaryHtml — gameOverInfo (game over mode)', { timeout: 2000 }, () => {
+  it('includes GAME OVER in the title when gameOverInfo is provided', { timeout: 2000 }, () => {
     const html = endOfHandSummaryHtml(makeEntry(), 'north', { winner: 'ns' })
     assert.ok(html.includes('GAME OVER'), 'should include GAME OVER in title')
   })
 
-  it('shows winner announcement when gameOverInfo is provided', () => {
+  it('shows winner announcement when gameOverInfo is provided', { timeout: 2000 }, () => {
     const html = endOfHandSummaryHtml(makeEntry(), 'north', { winner: 'ns' })
     assert.ok(
       html.toLowerCase().includes('win') || html.toLowerCase().includes('north') || html.toLowerCase().includes('n/s'),
@@ -357,31 +357,31 @@ describe('endOfHandSummaryHtml — gameOverInfo (game over mode)', () => {
     )
   })
 
-  it('shows "Back to Lobby" button instead of "Continue" when gameOverInfo is provided', () => {
+  it('shows "Back to Lobby" button instead of "Continue" when gameOverInfo is provided', { timeout: 2000 }, () => {
     const html = endOfHandSummaryHtml(makeEntry(), 'north', { winner: 'ns' })
     assert.ok(html.includes('hand-summary-lobby') || html.toLowerCase().includes('back to lobby'), 'should have Back to Lobby button')
     assert.ok(!html.includes('hand-summary-continue'), 'should not have Continue button')
   })
 
-  it('still shows normal hand summary content when gameOverInfo is provided', () => {
+  it('still shows normal hand summary content when gameOverInfo is provided', { timeout: 2000 }, () => {
     const entry = makeEntry({ scoreDelta: { ns: 70, ew: 70 } })
     const html = endOfHandSummaryHtml(entry, 'north', { winner: 'ns' })
     assert.ok(html.includes('+70'), 'should still show hand score delta')
   })
 
-  it('shows "Continue" button and no GAME OVER title when gameOverInfo is null', () => {
+  it('shows "Continue" button and no GAME OVER title when gameOverInfo is null', { timeout: 2000 }, () => {
     const html = endOfHandSummaryHtml(makeEntry(), 'north', null)
     assert.ok(html.includes('hand-summary-continue') || html.toLowerCase().includes('continue'), 'should have Continue button')
     assert.ok(!html.includes('GAME OVER'), 'should not include GAME OVER')
   })
 
-  it('shows "Continue" button and no GAME OVER title when gameOverInfo is omitted', () => {
+  it('shows "Continue" button and no GAME OVER title when gameOverInfo is omitted', { timeout: 2000 }, () => {
     const html = endOfHandSummaryHtml(makeEntry(), 'north')
     assert.ok(html.includes('hand-summary-continue') || html.toLowerCase().includes('continue'), 'should have Continue button')
     assert.ok(!html.includes('GAME OVER'), 'should not include GAME OVER')
   })
 
-  it('announces winning team by label', () => {
+  it('announces winning team by label', { timeout: 2000 }, () => {
     const htmlNs = endOfHandSummaryHtml(makeEntry(), 'north', { winner: 'ns' })
     assert.ok(
       htmlNs.includes('N/S') || htmlNs.toLowerCase().includes('north'),

--- a/test/unit/web/hand.test.js
+++ b/test/unit/web/hand.test.js
@@ -26,51 +26,51 @@ function attr(spanAttrs, name) {
 // cardHtml
 // ---------------------------------------------------------------------------
 
-describe('cardHtml', () => {
-  it('renders rank and suit symbol inside a span', () => {
+describe('cardHtml', { timeout: 2000 }, () => {
+  it('renders rank and suit symbol inside a span', { timeout: 2000 }, () => {
     const html = cardHtml({ suit: 'spades', rank: 'A' }, '')
     assert.ok(html.includes('A\u2660'), 'should contain rank + ♠')
     assert.ok(html.startsWith('<span'), 'should be a span element')
   })
 
-  it('sets data-suit and data-rank attributes', () => {
+  it('sets data-suit and data-rank attributes', { timeout: 2000 }, () => {
     const html = cardHtml({ suit: 'hearts', rank: 'K' }, '')
     assert.ok(html.includes('data-suit="hearts"'))
     assert.ok(html.includes('data-rank="K"'))
   })
 
-  it('adds card-red class for red suits', () => {
+  it('adds card-red class for red suits', { timeout: 2000 }, () => {
     const hearts = cardHtml({ suit: 'hearts', rank: '2' }, '')
     const diamonds = cardHtml({ suit: 'diamonds', rank: '2' }, '')
     assert.ok(hearts.includes('card-red'), 'hearts should be red')
     assert.ok(diamonds.includes('card-red'), 'diamonds should be red')
   })
 
-  it('does not add card-red class for black suits', () => {
+  it('does not add card-red class for black suits', { timeout: 2000 }, () => {
     const spades = cardHtml({ suit: 'spades', rank: '2' }, '')
     const clubs = cardHtml({ suit: 'clubs', rank: '2' }, '')
     assert.ok(!spades.includes('card-red'), 'spades should not be red')
     assert.ok(!clubs.includes('card-red'), 'clubs should not be red')
   })
 
-  it('appends extra CSS class when provided', () => {
+  it('appends extra CSS class when provided', { timeout: 2000 }, () => {
     const html = cardHtml({ suit: 'spades', rank: 'Q' }, 'card-play')
     assert.ok(html.includes('card-play'))
   })
 
-  it('does not append extra whitespace when extraCls is empty string', () => {
+  it('does not append extra whitespace when extraCls is empty string', { timeout: 2000 }, () => {
     const html = cardHtml({ suit: 'spades', rank: 'Q' }, '')
     // class attribute should not end with a trailing space before the closing quote
     assert.ok(!html.match(/class="[^"]*\s"/), 'should have no trailing space in class')
   })
 
-  it('escapes HTML special characters in rank', () => {
+  it('escapes HTML special characters in rank', { timeout: 2000 }, () => {
     const html = cardHtml({ suit: 'spades', rank: '<script>' }, '')
     assert.ok(!html.includes('<script>'), 'raw HTML should be escaped')
     assert.ok(html.includes('&lt;script&gt;'))
   })
 
-  it('uses the correct symbol for each suit', () => {
+  it('uses the correct symbol for each suit', { timeout: 2000 }, () => {
     assert.ok(cardHtml({ suit: 'spades', rank: 'A' }, '').includes('\u2660'))
     assert.ok(cardHtml({ suit: 'hearts', rank: 'A' }, '').includes('\u2665'))
     assert.ok(cardHtml({ suit: 'diamonds', rank: 'A' }, '').includes('\u2666'))
@@ -82,12 +82,12 @@ describe('cardHtml', () => {
 // handSpreadHtml — Spread (fan) mode
 // ---------------------------------------------------------------------------
 
-describe('handSpreadHtml', () => {
-  it('returns empty string for an empty hand', () => {
+describe('handSpreadHtml', { timeout: 2000 }, () => {
+  it('returns empty string for an empty hand', { timeout: 2000 }, () => {
     assert.equal(handSpreadHtml([], noExtra), '')
   })
 
-  it('renders one span per card', () => {
+  it('renders one span per card', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'spades', rank: 'A' },
       { suit: 'hearts', rank: 'K' },
@@ -98,7 +98,7 @@ describe('handSpreadHtml', () => {
     assert.equal(spans.length, 3)
   })
 
-  it('renders cards in hand order', () => {
+  it('renders cards in hand order', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'spades', rank: 'A' },
       { suit: 'clubs', rank: '2' },
@@ -109,19 +109,19 @@ describe('handSpreadHtml', () => {
     assert.ok(sA < s2, 'Ace of spades should appear before 2 of clubs')
   })
 
-  it('forwards extra CSS class returned by extraClsFn', () => {
+  it('forwards extra CSS class returned by extraClsFn', { timeout: 2000 }, () => {
     const hand = [{ suit: 'spades', rank: 'A' }]
     const html = handSpreadHtml(hand, () => 'card-play')
     assert.ok(html.includes('card-play'))
   })
 
-  it('does not add extra class when extraClsFn returns empty string', () => {
+  it('does not add extra class when extraClsFn returns empty string', { timeout: 2000 }, () => {
     const hand = [{ suit: 'spades', rank: 'A' }]
     const html = handSpreadHtml(hand, noExtra)
     assert.ok(!html.includes('card-play'))
   })
 
-  it('marks red-suit cards with card-red', () => {
+  it('marks red-suit cards with card-red', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'hearts', rank: '5' },
       { suit: 'spades', rank: '5' },
@@ -142,12 +142,12 @@ describe('handSpreadHtml', () => {
 // handDiagramHtml — Hand Diagram mode
 // ---------------------------------------------------------------------------
 
-describe('handDiagramHtml', () => {
-  it('returns empty string for an empty hand', () => {
+describe('handDiagramHtml', { timeout: 2000 }, () => {
+  it('returns empty string for an empty hand', { timeout: 2000 }, () => {
     assert.equal(handDiagramHtml([], noExtra), '')
   })
 
-  it('creates one diagram-row div per suit present', () => {
+  it('creates one diagram-row div per suit present', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'spades', rank: 'A' },
       { suit: 'hearts', rank: 'K' },
@@ -158,7 +158,7 @@ describe('handDiagramHtml', () => {
     assert.equal(rows, 2, 'only suits with cards should produce a row')
   })
 
-  it('omits suits with no cards', () => {
+  it('omits suits with no cards', { timeout: 2000 }, () => {
     const hand = [{ suit: 'spades', rank: 'A' }]
     const html = handDiagramHtml(hand, noExtra)
     assert.ok(!html.includes('\u2665'), 'hearts symbol should not appear')
@@ -166,7 +166,7 @@ describe('handDiagramHtml', () => {
     assert.ok(!html.includes('\u2663'), 'clubs symbol should not appear')
   })
 
-  it('shows the suit symbol at the start of each row', () => {
+  it('shows the suit symbol at the start of each row', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'spades', rank: 'A' },
       { suit: 'hearts', rank: 'K' },
@@ -176,7 +176,7 @@ describe('handDiagramHtml', () => {
     assert.ok(html.includes('class="diagram-suit suit-red"'), 'hearts row should have suit-red class')
   })
 
-  it('renders all cards for a suit in a single row', () => {
+  it('renders all cards for a suit in a single row', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'spades', rank: 'A' },
       { suit: 'spades', rank: 'K' },
@@ -190,7 +190,7 @@ describe('handDiagramHtml', () => {
     assert.ok(html.includes('data-rank="2"'))
   })
 
-  it('adds card-compact class to every card in diagram mode', () => {
+  it('adds card-compact class to every card in diagram mode', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'spades', rank: 'A' },
       { suit: 'hearts', rank: 'K' },
@@ -200,13 +200,13 @@ describe('handDiagramHtml', () => {
     assert.equal(cardSpans, 2)
   })
 
-  it('forwards extra CSS class alongside card-compact', () => {
+  it('forwards extra CSS class alongside card-compact', { timeout: 2000 }, () => {
     const hand = [{ suit: 'spades', rank: 'A' }]
     const html = handDiagramHtml(hand, () => 'card-sel')
     assert.ok(html.includes('card-compact card-sel'))
   })
 
-  it('suit order is spades, hearts, diamonds, clubs', () => {
+  it('suit order is spades, hearts, diamonds, clubs', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'clubs', rank: '3' },
       { suit: 'diamonds', rank: '4' },
@@ -228,7 +228,7 @@ describe('handDiagramHtml', () => {
 // lastTrickHtml
 // ---------------------------------------------------------------------------
 
-describe('lastTrickHtml', () => {
+describe('lastTrickHtml', { timeout: 2000 }, () => {
   const rel = { me: 'south', right: 'east', across: 'north', left: 'west' }
 
   const fullTrick = {
@@ -241,7 +241,7 @@ describe('lastTrickHtml', () => {
     ],
   }
 
-  it('renders all 4 cards', () => {
+  it('renders all 4 cards', { timeout: 2000 }, () => {
     const html = lastTrickHtml(fullTrick, rel)
     assert.ok(html.includes('A\u2660'), 'should contain A♠')
     assert.ok(html.includes('2\u2663'), 'should contain 2♣')
@@ -249,25 +249,25 @@ describe('lastTrickHtml', () => {
     assert.ok(html.includes('Q\u2666'), 'should contain Q♦')
   })
 
-  it('shows "Won by You" when current player won', () => {
+  it('shows "Won by You" when current player won', { timeout: 2000 }, () => {
     const trick = { winner: 'south', plays: fullTrick.plays }
     const html = lastTrickHtml(trick, rel)
     assert.ok(html.includes('Won by You'), 'should say "Won by You"')
   })
 
-  it('shows capitalized seat name when an opponent won', () => {
+  it('shows capitalized seat name when an opponent won', { timeout: 2000 }, () => {
     const html = lastTrickHtml(fullTrick, rel)
     assert.ok(html.includes('Won by North'), 'should say "Won by North"')
   })
 
-  it('applies trick-red class to red-suit cards', () => {
+  it('applies trick-red class to red-suit cards', { timeout: 2000 }, () => {
     const html = lastTrickHtml(fullTrick, rel)
     // hearts (K) and diamonds (Q) should have trick-red
     const redCount = (html.match(/trick-red/g) || []).length
     assert.equal(redCount, 2, 'exactly 2 red-suit cards should have trick-red')
   })
 
-  it('does not apply trick-red to black-suit cards', () => {
+  it('does not apply trick-red to black-suit cards', { timeout: 2000 }, () => {
     const blackOnly = {
       winner: 'north',
       plays: [
@@ -281,7 +281,7 @@ describe('lastTrickHtml', () => {
     assert.equal((html.match(/trick-red/g) || []).length, 0)
   })
 
-  it('escapes HTML special characters in card rank', () => {
+  it('escapes HTML special characters in card rank', { timeout: 2000 }, () => {
     const trick = {
       winner: 'north',
       plays: [
@@ -296,7 +296,7 @@ describe('lastTrickHtml', () => {
     assert.ok(html.includes('&lt;b&gt;'))
   })
 
-  it('renders the overlay and modal wrapper elements', () => {
+  it('renders the overlay and modal wrapper elements', { timeout: 2000 }, () => {
     const html = lastTrickHtml(fullTrick, rel)
     assert.ok(html.includes('last-trick-overlay'), 'should include overlay element')
     assert.ok(html.includes('last-trick-modal'), 'should include modal element')

--- a/test/unit/web/inputBlock.test.js
+++ b/test/unit/web/inputBlock.test.js
@@ -2,33 +2,33 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { createInputBlocker } from '../../../client/web/src/inputBlock.js'
 
-describe('createInputBlocker', () => {
-  it('starts unblocked', () => {
+describe('createInputBlocker', { timeout: 2000 }, () => {
+  it('starts unblocked', { timeout: 2000 }, () => {
     const blocker = createInputBlocker()
     assert.equal(blocker.isBlocked(), false)
   })
 
-  it('is blocked after block()', () => {
+  it('is blocked after block()', { timeout: 2000 }, () => {
     const blocker = createInputBlocker()
     blocker.block()
     assert.equal(blocker.isBlocked(), true)
   })
 
-  it('is unblocked after unblock()', () => {
+  it('is unblocked after unblock()', { timeout: 2000 }, () => {
     const blocker = createInputBlocker()
     blocker.block()
     blocker.unblock()
     assert.equal(blocker.isBlocked(), false)
   })
 
-  it('unblock() is idempotent when already unblocked', () => {
+  it('unblock() is idempotent when already unblocked', { timeout: 2000 }, () => {
     const blocker = createInputBlocker()
     blocker.unblock()
     blocker.unblock()
     assert.equal(blocker.isBlocked(), false)
   })
 
-  it('block() does not stack — a single unblock() clears it', () => {
+  it('block() does not stack — a single unblock() clears it', { timeout: 2000 }, () => {
     const blocker = createInputBlocker()
     blocker.block()
     blocker.block()
@@ -36,7 +36,7 @@ describe('createInputBlocker', () => {
     assert.equal(blocker.isBlocked(), false)
   })
 
-  it('can be re-blocked after unblocking', () => {
+  it('can be re-blocked after unblocking', { timeout: 2000 }, () => {
     const blocker = createInputBlocker()
     blocker.block()
     blocker.unblock()
@@ -44,7 +44,7 @@ describe('createInputBlocker', () => {
     assert.equal(blocker.isBlocked(), true)
   })
 
-  it('two instances are independent', () => {
+  it('two instances are independent', { timeout: 2000 }, () => {
     const a = createInputBlocker()
     const b = createInputBlocker()
     a.block()

--- a/test/unit/web/seatBidDisplay.test.js
+++ b/test/unit/web/seatBidDisplay.test.js
@@ -18,8 +18,8 @@ function makeState(bids, { biddingOrder = ['north', 'east', 'south', 'west'], te
 // getDisplayBid
 // ---------------------------------------------------------------------------
 
-describe('getDisplayBid', () => {
-  it('returns raw bid for first bidder in a numeric partnership', () => {
+describe('getDisplayBid', { timeout: 2000 }, () => {
+  it('returns raw bid for first bidder in a numeric partnership', { timeout: 2000 }, () => {
     // North bids 4 first. South enters 7 as team total.
     // North is the first bidder — should show 4 (their advisory individual bid).
     const state = makeState(
@@ -29,7 +29,7 @@ describe('getDisplayBid', () => {
     assert.equal(getDisplayBid(state, 'north'), 4)
   })
 
-  it('returns individual contribution for second bidder in a numeric partnership', () => {
+  it('returns individual contribution for second bidder in a numeric partnership', { timeout: 2000 }, () => {
     // South is the second NS bidder, stored bid is team total 7, partner bid 4.
     // Individual contribution = 7 - 4 = 3.
     const state = makeState(
@@ -39,7 +39,7 @@ describe('getDisplayBid', () => {
     assert.equal(getDisplayBid(state, 'south'), 3)
   })
 
-  it('handles zero first bid (second bidder contribution equals team total)', () => {
+  it('handles zero first bid (second bidder contribution equals team total)', { timeout: 2000 }, () => {
     // North bids 0. South enters 4 as team total. South individual = 4 - 0 = 4.
     const state = makeState(
       { north: 0, south: 4, east: null, west: null },
@@ -48,22 +48,22 @@ describe('getDisplayBid', () => {
     assert.equal(getDisplayBid(state, 'north'), 0)
   })
 
-  it('returns null for un-bid seat', () => {
+  it('returns null for un-bid seat', { timeout: 2000 }, () => {
     const state = makeState({ north: 4, south: null, east: null, west: null })
     assert.equal(getDisplayBid(state, 'south'), null)
   })
 
-  it('returns nil string unchanged', () => {
+  it('returns nil string unchanged', { timeout: 2000 }, () => {
     const state = makeState({ north: 'nil', south: 4, east: null, west: null })
     assert.equal(getDisplayBid(state, 'north'), 'nil')
   })
 
-  it('returns blind_nil string unchanged', () => {
+  it('returns blind_nil string unchanged', { timeout: 2000 }, () => {
     const state = makeState({ north: 'blind_nil', south: 4, east: null, west: null })
     assert.equal(getDisplayBid(state, 'north'), 'blind_nil')
   })
 
-  it('second bidder with nil partner bid returns raw bid (not subtracted)', () => {
+  it('second bidder with nil partner bid returns raw bid (not subtracted)', { timeout: 2000 }, () => {
     // Partner bid is Nil (not numeric) — no contribution math applies.
     const state = makeState(
       { north: 'nil', south: 4, east: null, west: null },
@@ -72,7 +72,7 @@ describe('getDisplayBid', () => {
     assert.equal(getDisplayBid(state, 'south'), 4)
   })
 
-  it('works for E/W team — East is first bidder', () => {
+  it('works for E/W team — East is first bidder', { timeout: 2000 }, () => {
     const state = makeState(
       { north: null, south: null, east: 5, west: 8 },
       { biddingOrder: ['north', 'east', 'south', 'west'] },
@@ -81,7 +81,7 @@ describe('getDisplayBid', () => {
     assert.equal(getDisplayBid(state, 'west'), 3) // 8 - 5
   })
 
-  it('handles biddingOrder where South bids before North', () => {
+  it('handles biddingOrder where South bids before North', { timeout: 2000 }, () => {
     // Dealer = East, so order is south, west, north, east.
     // South bids first for NS (advisory 3). North enters 7 as team total. North individual = 4.
     const state = makeState(
@@ -92,7 +92,7 @@ describe('getDisplayBid', () => {
     assert.equal(getDisplayBid(state, 'north'), 4)  // second bidder: 7 - 3 = 4
   })
 
-  it('returns raw bid when partner has not yet bid (no biddingOrder context)', () => {
+  it('returns raw bid when partner has not yet bid (no biddingOrder context)', { timeout: 2000 }, () => {
     // Only one player on team has bid — no individual calculation possible.
     const state = makeState(
       { north: 4, south: null, east: null, west: null },
@@ -100,7 +100,7 @@ describe('getDisplayBid', () => {
     assert.equal(getDisplayBid(state, 'north'), 4)
   })
 
-  it('maximum total (13): second bidder shows correct individual', () => {
+  it('maximum total (13): second bidder shows correct individual', { timeout: 2000 }, () => {
     // North bids 7, South enters 13 as team total. South individual = 6.
     const state = makeState(
       { north: 7, south: 13, east: null, west: null },

--- a/test/unit/web/seatUtils.test.js
+++ b/test/unit/web/seatUtils.test.js
@@ -14,8 +14,8 @@ import { relSeats } from '../../../client/web/src/seatUtils.js'
 //
 // CW order: north → east → south → west → north
 
-describe('relSeats', () => {
-  it('south: left=west (clockwise), right=east, across=north', () => {
+describe('relSeats', { timeout: 2000 }, () => {
+  it('south: left=west (clockwise), right=east, across=north', { timeout: 2000 }, () => {
     const rel = relSeats('south')
     assert.equal(rel.me, 'south')
     assert.equal(rel.left, 'west',  'clockwise from south is west — to south\'s left')
@@ -23,7 +23,7 @@ describe('relSeats', () => {
     assert.equal(rel.right, 'east', 'counter-clockwise from south is east — to south\'s right')
   })
 
-  it('north: left=east (clockwise), right=west, across=south', () => {
+  it('north: left=east (clockwise), right=west, across=south', { timeout: 2000 }, () => {
     const rel = relSeats('north')
     assert.equal(rel.me, 'north')
     assert.equal(rel.left, 'east',  'clockwise from north is east — to north\'s left')
@@ -31,7 +31,7 @@ describe('relSeats', () => {
     assert.equal(rel.right, 'west', 'counter-clockwise from north is west — to north\'s right')
   })
 
-  it('east: left=south (clockwise), right=north, across=west', () => {
+  it('east: left=south (clockwise), right=north, across=west', { timeout: 2000 }, () => {
     const rel = relSeats('east')
     assert.equal(rel.me, 'east')
     assert.equal(rel.left, 'south', 'clockwise from east is south — to east\'s left')
@@ -39,7 +39,7 @@ describe('relSeats', () => {
     assert.equal(rel.right, 'north', 'counter-clockwise from east is north — to east\'s right')
   })
 
-  it('west: left=north (clockwise), right=south, across=east', () => {
+  it('west: left=north (clockwise), right=south, across=east', { timeout: 2000 }, () => {
     const rel = relSeats('west')
     assert.equal(rel.me, 'west')
     assert.equal(rel.left, 'north', 'clockwise from west is north — to west\'s left')
@@ -47,7 +47,7 @@ describe('relSeats', () => {
     assert.equal(rel.right, 'south', 'counter-clockwise from west is south — to west\'s right')
   })
 
-  it('play order passes left: me → left → across → right → me', () => {
+  it('play order passes left: me → left → across → right → me', { timeout: 2000 }, () => {
     // Starting from each seat, four left-turns should return to the same seat
     for (const start of ['north', 'east', 'south', 'west']) {
       let seat = start

--- a/test/unit/web/trickHold.test.js
+++ b/test/unit/web/trickHold.test.js
@@ -6,16 +6,16 @@ import { HOLD_DURATIONS, detectCompletedTrick, isHandTransition, trickHoldHtml }
 // HOLD_DURATIONS
 // ---------------------------------------------------------------------------
 
-describe('HOLD_DURATIONS', () => {
-  it('exports slow duration of 2500 ms', () => {
+describe('HOLD_DURATIONS', { timeout: 2000 }, () => {
+  it('exports slow duration of 2500 ms', { timeout: 2000 }, () => {
     assert.equal(HOLD_DURATIONS.slow, 2500)
   })
 
-  it('exports normal duration of 1500 ms', () => {
+  it('exports normal duration of 1500 ms', { timeout: 2000 }, () => {
     assert.equal(HOLD_DURATIONS.normal, 1500)
   })
 
-  it('exports fast duration of 800 ms', () => {
+  it('exports fast duration of 800 ms', { timeout: 2000 }, () => {
     assert.equal(HOLD_DURATIONS.fast, 800)
   })
 })
@@ -24,30 +24,30 @@ describe('HOLD_DURATIONS', () => {
 // isHandTransition
 // ---------------------------------------------------------------------------
 
-describe('isHandTransition', () => {
-  it('returns false when prevState is null', () => {
+describe('isHandTransition', { timeout: 2000 }, () => {
+  it('returns false when prevState is null', { timeout: 2000 }, () => {
     const next = { handHistory: [{}], phase: 'bidding' }
     assert.equal(isHandTransition(null, next), false)
   })
 
-  it('returns false when nextState is null', () => {
+  it('returns false when nextState is null', { timeout: 2000 }, () => {
     assert.equal(isHandTransition({ handHistory: [] }, null), false)
   })
 
-  it('returns false when handHistory length is unchanged', () => {
+  it('returns false when handHistory length is unchanged', { timeout: 2000 }, () => {
     const prev = { handHistory: [{}], phase: 'playing' }
     const next = { handHistory: [{}], phase: 'playing' }
     assert.equal(isHandTransition(prev, next), false)
   })
 
-  it('returns false when game_over even if handHistory grew', () => {
+  it('returns false when game_over even if handHistory grew', { timeout: 2000 }, () => {
     // game_over: completedTricks preserved, state is safe to render during hold
     const prev = { handHistory: [], phase: 'playing' }
     const next = { handHistory: [{}], phase: 'game_over' }
     assert.equal(isHandTransition(prev, next), false)
   })
 
-  it('returns true when handHistory grew and phase is bidding (non-final hand transition)', () => {
+  it('returns true when handHistory grew and phase is bidding (non-final hand transition)', { timeout: 2000 }, () => {
     // 13th trick scored: server moved to next hand's bidding phase;
     // client must keep prevState during hold to avoid showing next hand context
     const prev = { handHistory: [], phase: 'playing' }
@@ -55,13 +55,13 @@ describe('isHandTransition', () => {
     assert.equal(isHandTransition(prev, next), true)
   })
 
-  it('returns true when handHistory grew and phase is playing (bots already played tricks of new hand)', () => {
+  it('returns true when handHistory grew and phase is playing (bots already played tricks of new hand)', { timeout: 2000 }, () => {
     const prev = { handHistory: [{}], phase: 'playing' }
     const next = { handHistory: [{}, {}], phase: 'playing' }
     assert.equal(isHandTransition(prev, next), true)
   })
 
-  it('handles missing handHistory arrays gracefully', () => {
+  it('handles missing handHistory arrays gracefully', { timeout: 2000 }, () => {
     const prev = {}
     const next = { phase: 'bidding' }
     assert.equal(isHandTransition(prev, next), false)
@@ -72,7 +72,7 @@ describe('isHandTransition', () => {
 // detectCompletedTrick
 // ---------------------------------------------------------------------------
 
-describe('detectCompletedTrick', () => {
+describe('detectCompletedTrick', { timeout: 2000 }, () => {
   const baseTrick = {
     winner: 'north',
     plays: [
@@ -83,36 +83,36 @@ describe('detectCompletedTrick', () => {
     ],
   }
 
-  it('returns null when prevState is null', () => {
+  it('returns null when prevState is null', { timeout: 2000 }, () => {
     const next = { completedTricks: [baseTrick], currentTrick: [] }
     assert.equal(detectCompletedTrick(null, next), null)
   })
 
-  it('returns null when nextState has no completedTricks array', () => {
+  it('returns null when nextState has no completedTricks array', { timeout: 2000 }, () => {
     const prev = { completedTricks: [] }
     assert.equal(detectCompletedTrick(prev, {}), null)
   })
 
-  it('returns null when the completedTricks length is unchanged', () => {
+  it('returns null when the completedTricks length is unchanged', { timeout: 2000 }, () => {
     const prev = { completedTricks: [baseTrick] }
     const next = { completedTricks: [baseTrick] }
     assert.equal(detectCompletedTrick(prev, next), null)
   })
 
-  it('returns null when prevState has no completedTricks and next also has none', () => {
+  it('returns null when prevState has no completedTricks and next also has none', { timeout: 2000 }, () => {
     const prev = { completedTricks: [] }
     const next = { completedTricks: [] }
     assert.equal(detectCompletedTrick(prev, next), null)
   })
 
-  it('returns the newly completed trick when completedTricks grows by one', () => {
+  it('returns the newly completed trick when completedTricks grows by one', { timeout: 2000 }, () => {
     const prev = { completedTricks: [], currentTrick: [{ seat: 'north', card: baseTrick.plays[0].card }] }
     const next = { completedTricks: [baseTrick], currentTrick: [] }
     const result = detectCompletedTrick(prev, next)
     assert.deepEqual(result, baseTrick)
   })
 
-  it('returns the last trick when multiple tricks complete in one transition', () => {
+  it('returns the last trick when multiple tricks complete in one transition', { timeout: 2000 }, () => {
     const trick2 = { winner: 'south', plays: baseTrick.plays }
     const prev = { completedTricks: [], currentTrick: [] }
     const next = { completedTricks: [baseTrick, trick2], currentTrick: [] }
@@ -120,13 +120,13 @@ describe('detectCompletedTrick', () => {
     assert.deepEqual(result, trick2)
   })
 
-  it('handles prevState with missing completedTricks gracefully', () => {
+  it('handles prevState with missing completedTricks gracefully', { timeout: 2000 }, () => {
     const next = { completedTricks: [baseTrick] }
     const result = detectCompletedTrick({}, next)
     assert.deepEqual(result, baseTrick)
   })
 
-  it('returns lastTrick from handHistory when the 13th trick resets completedTricks for a new hand', () => {
+  it('returns lastTrick from handHistory when the 13th trick resets completedTricks for a new hand', { timeout: 2000 }, () => {
     const lastTrick = {
       winner: 'east',
       plays: [
@@ -145,7 +145,7 @@ describe('detectCompletedTrick', () => {
     assert.deepEqual(result, lastTrick)
   })
 
-  it('returns null when handHistory grew but lastTrick is absent from the new entry', () => {
+  it('returns null when handHistory grew but lastTrick is absent from the new entry', { timeout: 2000 }, () => {
     const prev = { completedTricks: Array(12).fill(baseTrick), handHistory: [] }
     const next = {
       completedTricks: [],
@@ -154,7 +154,7 @@ describe('detectCompletedTrick', () => {
     assert.equal(detectCompletedTrick(prev, next), null)
   })
 
-  it('still detects via completedTricks for game_over (completedTricks preserved)', () => {
+  it('still detects via completedTricks for game_over (completedTricks preserved)', { timeout: 2000 }, () => {
     const lastTrick = { winner: 'west', plays: baseTrick.plays }
     const prev = { completedTricks: Array(12).fill(baseTrick), handHistory: [] }
     const next = {
@@ -171,7 +171,7 @@ describe('detectCompletedTrick', () => {
 // trickHoldHtml
 // ---------------------------------------------------------------------------
 
-describe('trickHoldHtml', () => {
+describe('trickHoldHtml', { timeout: 2000 }, () => {
   const rel = { me: 'south', right: 'east', across: 'north', left: 'west' }
 
   const trick = {
@@ -184,7 +184,7 @@ describe('trickHoldHtml', () => {
     ],
   }
 
-  it('renders all 4 cards', () => {
+  it('renders all 4 cards', { timeout: 2000 }, () => {
     const html = trickHoldHtml(trick, rel)
     assert.ok(html.includes('A\u2660'), 'should contain A♠')
     assert.ok(html.includes('2\u2663'), 'should contain 2♣')
@@ -192,35 +192,35 @@ describe('trickHoldHtml', () => {
     assert.ok(html.includes('Q\u2666'), 'should contain Q♦')
   })
 
-  it('shows "Won by You" when the current player is the winner', () => {
+  it('shows "Won by You" when the current player is the winner', { timeout: 2000 }, () => {
     const t = { winner: 'south', plays: trick.plays }
     const html = trickHoldHtml(t, rel)
     assert.ok(html.includes('Won by You'), 'should say "Won by You"')
   })
 
-  it('shows capitalized seat name when an opponent won', () => {
+  it('shows capitalized seat name when an opponent won', { timeout: 2000 }, () => {
     const html = trickHoldHtml(trick, rel)
     assert.ok(html.includes('Won by North'), 'should say "Won by North"')
   })
 
-  it('includes trick-area--hold modifier class to signal hold state', () => {
+  it('includes trick-area--hold modifier class to signal hold state', { timeout: 2000 }, () => {
     const html = trickHoldHtml(trick, rel)
     assert.ok(html.includes('trick-area--hold'), 'should include hold modifier class')
   })
 
-  it('includes the trick-winner-banner element', () => {
+  it('includes the trick-winner-banner element', { timeout: 2000 }, () => {
     const html = trickHoldHtml(trick, rel)
     assert.ok(html.includes('trick-winner-banner'), 'should include winner banner element')
   })
 
-  it('applies trick-red to red-suit cards only', () => {
+  it('applies trick-red to red-suit cards only', { timeout: 2000 }, () => {
     const html = trickHoldHtml(trick, rel)
     // hearts (K) and diamonds (Q) should have trick-red — spades and clubs should not
     const redCount = (html.match(/trick-red/g) || []).length
     assert.equal(redCount, 2, 'exactly 2 red-suit cards should have trick-red')
   })
 
-  it('does not apply trick-red to black-suit cards', () => {
+  it('does not apply trick-red to black-suit cards', { timeout: 2000 }, () => {
     const blackOnly = {
       winner: 'north',
       plays: [
@@ -234,7 +234,7 @@ describe('trickHoldHtml', () => {
     assert.equal((html.match(/trick-red/g) || []).length, 0, 'no red class for black suits')
   })
 
-  it('escapes HTML special characters in card ranks', () => {
+  it('escapes HTML special characters in card ranks', { timeout: 2000 }, () => {
     const xssTrick = {
       winner: 'north',
       plays: [
@@ -249,12 +249,12 @@ describe('trickHoldHtml', () => {
     assert.ok(html.includes('&lt;b&gt;'), 'should contain escaped version')
   })
 
-  it('renders the trick-area wrapper element', () => {
+  it('renders the trick-area wrapper element', { timeout: 2000 }, () => {
     const html = trickHoldHtml(trick, rel)
     assert.ok(html.includes('class="trick-area'), 'should include trick-area element')
   })
 
-  it('renders positional rows for across, left, right, and me', () => {
+  it('renders positional rows for across, left, right, and me', { timeout: 2000 }, () => {
     const html = trickHoldHtml(trick, rel)
     assert.ok((html.match(/trick-row/g) || []).length >= 2, 'should have at least two trick-row elements')
     assert.ok(html.includes('trick-middle'), 'should include trick-middle row')

--- a/test/unit/web/validation.test.js
+++ b/test/unit/web/validation.test.js
@@ -5,46 +5,46 @@ import {
   validateLoginForm,
 } from '../../../client/web/src/validation.js'
 
-describe('validateRegisterForm', () => {
-  it('returns null for valid inputs', () => {
+describe('validateRegisterForm', { timeout: 2000 }, () => {
+  it('returns null for valid inputs', { timeout: 2000 }, () => {
     assert.equal(
       validateRegisterForm({ email: 'alice@example.com', username: 'alice', password: 'password123' }),
       null,
     )
   })
 
-  it('returns an error when email is missing', () => {
+  it('returns an error when email is missing', { timeout: 2000 }, () => {
     assert.ok(validateRegisterForm({ email: '', username: 'alice', password: 'password123' }))
   })
 
-  it('returns an error when email has no @', () => {
+  it('returns an error when email has no @', { timeout: 2000 }, () => {
     assert.ok(validateRegisterForm({ email: 'notanemail', username: 'alice', password: 'password123' }))
   })
 
-  it('returns an error when username is missing', () => {
+  it('returns an error when username is missing', { timeout: 2000 }, () => {
     assert.ok(validateRegisterForm({ email: 'alice@example.com', username: '', password: 'password123' }))
   })
 
-  it('returns an error when username is too short (1 char)', () => {
+  it('returns an error when username is too short (1 char)', { timeout: 2000 }, () => {
     assert.ok(validateRegisterForm({ email: 'alice@example.com', username: 'a', password: 'password123' }))
   })
 
-  it('returns null when username is exactly 2 chars', () => {
+  it('returns null when username is exactly 2 chars', { timeout: 2000 }, () => {
     assert.equal(
       validateRegisterForm({ email: 'alice@example.com', username: 'al', password: 'password123' }),
       null,
     )
   })
 
-  it('returns an error when password is missing', () => {
+  it('returns an error when password is missing', { timeout: 2000 }, () => {
     assert.ok(validateRegisterForm({ email: 'alice@example.com', username: 'alice', password: '' }))
   })
 
-  it('returns an error when password is fewer than 8 characters', () => {
+  it('returns an error when password is fewer than 8 characters', { timeout: 2000 }, () => {
     assert.ok(validateRegisterForm({ email: 'alice@example.com', username: 'alice', password: 'short' }))
   })
 
-  it('returns null when password is exactly 8 characters', () => {
+  it('returns null when password is exactly 8 characters', { timeout: 2000 }, () => {
     assert.equal(
       validateRegisterForm({ email: 'alice@example.com', username: 'alice', password: '12345678' }),
       null,
@@ -52,20 +52,20 @@ describe('validateRegisterForm', () => {
   })
 })
 
-describe('validateLoginForm', () => {
-  it('returns null for valid inputs', () => {
+describe('validateLoginForm', { timeout: 2000 }, () => {
+  it('returns null for valid inputs', { timeout: 2000 }, () => {
     assert.equal(validateLoginForm({ email: 'alice@example.com', password: 'password123' }), null)
   })
 
-  it('returns an error when email is missing', () => {
+  it('returns an error when email is missing', { timeout: 2000 }, () => {
     assert.ok(validateLoginForm({ email: '', password: 'password123' }))
   })
 
-  it('returns an error when email has no @', () => {
+  it('returns an error when email has no @', { timeout: 2000 }, () => {
     assert.ok(validateLoginForm({ email: 'notanemail', password: 'password123' }))
   })
 
-  it('returns an error when password is missing', () => {
+  it('returns an error when password is missing', { timeout: 2000 }, () => {
     assert.ok(validateLoginForm({ email: 'alice@example.com', password: '' }))
   })
 })

--- a/test/ws/connection.test.js
+++ b/test/ws/connection.test.js
@@ -175,7 +175,7 @@ describe('WebSocket server', { skip }, () => {
       // wsOut never joins any room
 
       let outsiderReceived = false
-      wsOut.on('message', { timeout: 15000 }, () => { outsiderReceived = true })
+      wsOut.on('message', () => { outsiderReceived = true })
 
       wss.broadcast('table-in', 'CARD_PLAYED', { seat: 'east', card: { suit: 'hearts', rank: '2' } })
 

--- a/test/ws/connection.test.js
+++ b/test/ws/connection.test.js
@@ -75,6 +75,9 @@ describe('WebSocket server', { skip }, () => {
   })
 
   after(async () => {
+    // Force-terminate any connections left open by failed tests; wss.close()
+    // waits for all clients to drain, so orphaned sockets cause an infinite hang.
+    for (const client of wss.clients) client.terminate()
     await new Promise((resolve) => wss.close(resolve))
     await new Promise((resolve) => httpServer.close(resolve))
 
@@ -218,6 +221,7 @@ describe('WebSocket server', { skip }, () => {
     })
 
     after(async () => {
+      for (const client of wss2.clients) client.terminate()
       await new Promise((resolve) => wss2.close(resolve))
       await new Promise((resolve) => httpServer2.close(resolve))
 

--- a/test/ws/connection.test.js
+++ b/test/ws/connection.test.js
@@ -89,8 +89,8 @@ describe('WebSocket server', { skip }, () => {
 
   // ── Authentication ──────────────────────────────────────────────────────────
 
-  describe('authentication', () => {
-    it('rejects upgrade when x-session-id header is missing', async () => {
+  describe('authentication', { timeout: 15000 }, () => {
+    it('rejects upgrade when x-session-id header is missing', { timeout: 15000 }, async () => {
       const err = await wsConnect(httpServer).then(
         () => { throw new Error('expected rejection') },
         (e) => e,
@@ -98,7 +98,7 @@ describe('WebSocket server', { skip }, () => {
       assert.ok(err.statusCode === 401 || err.message.includes('401'), `got: ${err.message}`)
     })
 
-    it('rejects upgrade when x-session-id is invalid', async () => {
+    it('rejects upgrade when x-session-id is invalid', { timeout: 15000 }, async () => {
       const err = await wsConnect(httpServer, { 'x-session-id': 'bad-session' }).then(
         () => { throw new Error('expected rejection') },
         (e) => e,
@@ -106,7 +106,7 @@ describe('WebSocket server', { skip }, () => {
       assert.ok(err.statusCode === 401 || err.message.includes('401'), `got: ${err.message}`)
     })
 
-    it('accepts upgrade with a valid x-session-id', async () => {
+    it('accepts upgrade with a valid x-session-id', { timeout: 15000 }, async () => {
       const ws = await wsConnect(httpServer, { 'x-session-id': 'valid-session-1' })
       assert.equal(ws.readyState, WebSocket.OPEN)
       ws.close()
@@ -116,8 +116,8 @@ describe('WebSocket server', { skip }, () => {
 
   // ── Room management ─────────────────────────────────────────────────────────
 
-  describe('room management', () => {
-    it('sends JOINED ack when client sends JOIN with a tableId', async () => {
+  describe('room management', { timeout: 15000 }, () => {
+    it('sends JOINED ack when client sends JOIN with a tableId', { timeout: 15000 }, async () => {
       const ws = await wsConnect(httpServer, { 'x-session-id': 'valid-session-1' })
 
       ws.send(JSON.stringify({ type: 'JOIN', payload: { tableId: 'table-abc' } }))
@@ -130,7 +130,7 @@ describe('WebSocket server', { skip }, () => {
       await waitClose(ws)
     })
 
-    it('sends LEFT ack when client sends LEAVE', async () => {
+    it('sends LEFT ack when client sends LEAVE', { timeout: 15000 }, async () => {
       const ws = await wsConnect(httpServer, { 'x-session-id': 'valid-session-1' })
 
       ws.send(JSON.stringify({ type: 'JOIN', payload: { tableId: 'table-xyz' } }))
@@ -146,7 +146,7 @@ describe('WebSocket server', { skip }, () => {
       await waitClose(ws)
     })
 
-    it('broadcast() delivers an event to all clients in a table room', async () => {
+    it('broadcast() delivers an event to all clients in a table room', { timeout: 15000 }, async () => {
       const ws1 = await wsConnect(httpServer, { 'x-session-id': 'valid-session-1' })
       const ws2 = await wsConnect(httpServer, { 'x-session-id': 'valid-session-1' })
 
@@ -166,7 +166,7 @@ describe('WebSocket server', { skip }, () => {
       await Promise.all([waitClose(ws1), waitClose(ws2)])
     })
 
-    it('broadcast() does NOT deliver to clients not in that room', async () => {
+    it('broadcast() does NOT deliver to clients not in that room', { timeout: 15000 }, async () => {
       const wsIn = await wsConnect(httpServer, { 'x-session-id': 'valid-session-1' })
       const wsOut = await wsConnect(httpServer, { 'x-session-id': 'valid-session-1' })
 
@@ -175,7 +175,7 @@ describe('WebSocket server', { skip }, () => {
       // wsOut never joins any room
 
       let outsiderReceived = false
-      wsOut.on('message', () => { outsiderReceived = true })
+      wsOut.on('message', { timeout: 15000 }, () => { outsiderReceived = true })
 
       wss.broadcast('table-in', 'CARD_PLAYED', { seat: 'east', card: { suit: 'hearts', rank: '2' } })
 
@@ -187,7 +187,7 @@ describe('WebSocket server', { skip }, () => {
       await Promise.all([waitClose(wsIn), waitClose(wsOut)])
     })
 
-    it('sendToPlayer() delivers only to the target player', async () => {
+    it('sendToPlayer() delivers only to the target player', { timeout: 15000 }, async () => {
       const ws = await wsConnect(httpServer, { 'x-session-id': 'valid-session-1' })
 
       const msgPromise = nextMessage(ws)
@@ -203,7 +203,7 @@ describe('WebSocket server', { skip }, () => {
 
   // ── JOIN authorization ──────────────────────────────────────────────────────
 
-  describe('JOIN authorization', () => {
+  describe('JOIN authorization', { timeout: 15000 }, () => {
     let httpServer2, wss2
 
     before(async () => {
@@ -226,7 +226,7 @@ describe('WebSocket server', { skip }, () => {
       await redis.del('table:table-private')
     })
 
-    it('sends JOIN_DENIED when player is not seated at the table', async () => {
+    it('sends JOIN_DENIED when player is not seated at the table', { timeout: 15000 }, async () => {
       const ws = await wsConnect(httpServer2, { 'x-session-id': 'session-p2' })
       ws.send(JSON.stringify({ type: 'JOIN', payload: { tableId: 'table-private' } }))
       const msg = await nextMessage(ws)
@@ -236,7 +236,7 @@ describe('WebSocket server', { skip }, () => {
       await waitClose(ws)
     })
 
-    it('sends JOIN_DENIED when table does not exist in Redis', async () => {
+    it('sends JOIN_DENIED when table does not exist in Redis', { timeout: 15000 }, async () => {
       const ws = await wsConnect(httpServer2, { 'x-session-id': 'session-p1' })
       ws.send(JSON.stringify({ type: 'JOIN', payload: { tableId: 'nonexistent-table' } }))
       const msg = await nextMessage(ws)
@@ -246,7 +246,7 @@ describe('WebSocket server', { skip }, () => {
       await waitClose(ws)
     })
 
-    it('sends JOINED when player is seated at the table', async () => {
+    it('sends JOINED when player is seated at the table', { timeout: 15000 }, async () => {
       const ws = await wsConnect(httpServer2, { 'x-session-id': 'session-p1' })
       ws.send(JSON.stringify({ type: 'JOIN', payload: { tableId: 'table-private' } }))
       const msg = await nextMessage(ws)
@@ -259,8 +259,8 @@ describe('WebSocket server', { skip }, () => {
 
   // ── Heartbeat ───────────────────────────────────────────────────────────────
 
-  describe('heartbeat', () => {
-    it('server sends a ping to connected clients', async () => {
+  describe('heartbeat', { timeout: 15000 }, () => {
+    it('server sends a ping to connected clients', { timeout: 15000 }, async () => {
       const ws = await wsConnect(httpServer, { 'x-session-id': 'valid-session-1' })
 
       const pingReceived = await new Promise((resolve) => {
@@ -273,7 +273,7 @@ describe('WebSocket server', { skip }, () => {
       await waitClose(ws)
     })
 
-    it('server terminates connection when pong is not received within pongTimeoutMs', async () => {
+    it('server terminates connection when pong is not received within pongTimeoutMs', { timeout: 15000 }, async () => {
       // autoPong: false prevents the ws library from automatically replying to pings
       const ws = await wsConnect(httpServer, { 'x-session-id': 'valid-session-1' }, { autoPong: false })
 

--- a/test/ws/pubsub.test.js
+++ b/test/ws/pubsub.test.js
@@ -78,6 +78,8 @@ describe('WebSocket Redis pub/sub fan-out', { skip }, () => {
   })
 
   after(async () => {
+    for (const client of wss1.clients) client.terminate()
+    for (const client of wss2.clients) client.terminate()
     await Promise.all([
       new Promise((resolve) => wss1.close(resolve)),
       new Promise((resolve) => wss2.close(resolve)),

--- a/test/ws/pubsub.test.js
+++ b/test/ws/pubsub.test.js
@@ -96,7 +96,7 @@ describe('WebSocket Redis pub/sub fan-out', { skip }, () => {
 
   // ── Table room pub/sub fan-out ─────────────────────────────────────────────
 
-  it('broadcast() on instance 2 delivers to client on instance 1 via Redis pub/sub', { timeout: 10000 }, async () => {
+  it('broadcast() on instance 2 delivers to client on instance 1 via Redis pub/sub', { timeout: 15000 }, async () => {
     const ws = await wsConnect(httpServer1, { 'x-session-id': 'pubsub-s1' })
 
     ws.send(JSON.stringify({ type: 'JOIN', payload: { tableId: 'fanout-table' } }))
@@ -114,7 +114,7 @@ describe('WebSocket Redis pub/sub fan-out', { skip }, () => {
     await waitClose(ws)
   })
 
-  it('broadcast() on instance 1 delivers to client on instance 2 via Redis pub/sub', { timeout: 10000 }, async () => {
+  it('broadcast() on instance 1 delivers to client on instance 2 via Redis pub/sub', { timeout: 15000 }, async () => {
     const ws = await wsConnect(httpServer2, { 'x-session-id': 'pubsub-s1' })
 
     ws.send(JSON.stringify({ type: 'JOIN', payload: { tableId: 'fanout-table' } }))
@@ -132,7 +132,7 @@ describe('WebSocket Redis pub/sub fan-out', { skip }, () => {
     await waitClose(ws)
   })
 
-  it('broadcast() delivers to clients on both instances simultaneously', { timeout: 10000 }, async () => {
+  it('broadcast() delivers to clients on both instances simultaneously', { timeout: 15000 }, async () => {
     const ws1 = await wsConnect(httpServer1, { 'x-session-id': 'pubsub-s1' })
     const ws2 = await wsConnect(httpServer2, { 'x-session-id': 'pubsub-s2' })
 
@@ -154,7 +154,7 @@ describe('WebSocket Redis pub/sub fan-out', { skip }, () => {
 
   // ── Lobby channel ────────────────────────────────────────────────────────────
 
-  it('JOIN_LOBBY receives JOINED_LOBBY ack', { timeout: 10000 }, async () => {
+  it('JOIN_LOBBY receives JOINED_LOBBY ack', { timeout: 15000 }, async () => {
     const ws = await wsConnect(httpServer1, { 'x-session-id': 'pubsub-s1' })
 
     ws.send(JSON.stringify({ type: 'JOIN_LOBBY', payload: {} }))
@@ -166,7 +166,7 @@ describe('WebSocket Redis pub/sub fan-out', { skip }, () => {
     await waitClose(ws)
   })
 
-  it('LEAVE_LOBBY receives LEFT_LOBBY ack', { timeout: 10000 }, async () => {
+  it('LEAVE_LOBBY receives LEFT_LOBBY ack', { timeout: 15000 }, async () => {
     const ws = await wsConnect(httpServer1, { 'x-session-id': 'pubsub-s1' })
 
     ws.send(JSON.stringify({ type: 'JOIN_LOBBY', payload: {} }))
@@ -181,7 +181,7 @@ describe('WebSocket Redis pub/sub fan-out', { skip }, () => {
     await waitClose(ws)
   })
 
-  it('broadcastLobby() on instance 2 delivers to lobby subscriber on instance 1', { timeout: 10000 }, async () => {
+  it('broadcastLobby() on instance 2 delivers to lobby subscriber on instance 1', { timeout: 15000 }, async () => {
     const ws = await wsConnect(httpServer1, { 'x-session-id': 'pubsub-s1' })
 
     ws.send(JSON.stringify({ type: 'JOIN_LOBBY', payload: {} }))
@@ -198,7 +198,7 @@ describe('WebSocket Redis pub/sub fan-out', { skip }, () => {
     await waitClose(ws)
   })
 
-  it('broadcastLobby() delivers to lobby subscribers on both instances', { timeout: 10000 }, async () => {
+  it('broadcastLobby() delivers to lobby subscribers on both instances', { timeout: 15000 }, async () => {
     const ws1 = await wsConnect(httpServer1, { 'x-session-id': 'pubsub-s1' })
     const ws2 = await wsConnect(httpServer2, { 'x-session-id': 'pubsub-s2' })
 

--- a/test/ws/startup.test.js
+++ b/test/ws/startup.test.js
@@ -65,7 +65,8 @@ describe('app.js WS_PORT startup branching', { skip }, () => {
     })
 
     after(async () => {
-      wss.close()
+      for (const client of wss.clients) client.terminate()
+      await new Promise((resolve) => wss.close(resolve))
       await new Promise((resolve) => httpServer.close(resolve))
     })
 
@@ -105,7 +106,8 @@ describe('app.js WS_PORT startup branching', { skip }, () => {
     })
 
     after(async () => {
-      wss.close()
+      for (const client of wss.clients) client.terminate()
+      await new Promise((resolve) => wss.close(resolve))
       await Promise.all([
         new Promise((resolve) => httpServer.close(resolve)),
         new Promise((resolve) => wsHttpServer.close(resolve)),

--- a/test/ws/startup.test.js
+++ b/test/ws/startup.test.js
@@ -7,7 +7,7 @@ import { getRedis, closeRedis } from '../../server/redis.js'
 
 const skip = !process.env.REDIS_URL ? 'REDIS_URL must be set' : false
 
-const TEST_TIMEOUT_MS = 5000
+const TEST_TIMEOUT_MS = 15000
 
 function wsConnect(server, headers = {}, timeoutMs = TEST_TIMEOUT_MS) {
   const { port } = server.address()


### PR DESCRIPTION
Add timeouts to all 38 test files as required by CLAUDE.md:

- Unit tests: `timeout: 2000` (25 files)
- Integration tests: `timeout: 10000` (8 files)
- `fullgame.test.js`: `timeout: 30000` (complex E2E plays up to 5 hands)
- WebSocket tests: `timeout: 15000` (3 files)

Also fixed existing incorrect timeouts:
- `pubsub.test.js`: updated stale 10000ms timeouts to 15000ms
- `startup.test.js`: updated `TEST_TIMEOUT_MS` constant from 5000 to 15000ms

Closes #229

Generated with [Claude Code](https://claude.ai/code)