### PR TITLE
fix: lobby layout — table list above actions, remove redundant join button, add scroll

### DIFF
--- a/client/web/index.html
+++ b/client/web/index.html
@@ -174,11 +174,29 @@
         margin-bottom: 0.75rem;
       }
 
+      .lobby-tables {
+        margin: 1.25rem 0 1rem;
+      }
+
+      .lobby-tables-title {
+        font-size: 0.8rem;
+        font-weight: 600;
+        color: #888;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin-bottom: 0.5rem;
+      }
+
+      .table-list-scroll {
+        max-height: 300px;
+        overflow-y: auto;
+      }
+
       .lobby-actions {
         display: flex;
         flex-direction: column;
         gap: 0.75rem;
-        margin-top: 1.5rem;
+        margin-top: 1rem;
       }
 
       .field-optional {

--- a/client/web/src/screens/lobby.js
+++ b/client/web/src/screens/lobby.js
@@ -47,26 +47,21 @@ export async function renderLobbyScreen(container) {
     <div class="auth-card">
       <h1 class="auth-title">Lobby</h1>
       <p class="auth-message">Welcome back, <strong>${escapeHtml(username)}</strong>!</p>
-      <div class="lobby-actions">
-        <button id="create-table-btn" class="btn-primary">Create Table</button>
-        <button id="join-table-btn" class="btn-secondary">Join Table</button>
-        <button id="logout-btn" class="btn-link">Log out</button>
-      </div>
       <div class="lobby-tables">
         <h2 class="lobby-tables-title">Open Tables</h2>
-        <div id="table-list" class="table-list">
+        <div id="table-list" class="table-list table-list-scroll">
           <p class="table-list-empty">Loading tables\u2026</p>
         </div>
+      </div>
+      <div class="lobby-actions">
+        <button id="create-table-btn" class="btn-primary">Create Table</button>
+        <button id="logout-btn" class="btn-link">Log out</button>
       </div>
     </div>
   `
 
   container.querySelector('#create-table-btn').addEventListener('click', () => {
     navigate('#/create-table')
-  })
-
-  container.querySelector('#join-table-btn').addEventListener('click', () => {
-    navigate('#/join')
   })
 
   container.querySelector('#logout-btn').addEventListener('click', async () => {


### PR DESCRIPTION
Fix lobby UI issues reported in #247:

- Move table list above the action buttons so tables are no longer displayed below the logout button
- Remove the "Join Table" button — each table row already has a per-row Join button, making the global one redundant
- Add max-height + overflow-y:auto so the list scrolls cleanly when there are many tables

Closes #247

Generated with [Claude Code](https://claude.ai/code)