### PR TITLE
feat: UI pass — 4-color suits, valid card highlighting, team bid/tricks bar

### DIFF
--- a/client/web/index.html
+++ b/client/web/index.html
@@ -361,27 +361,84 @@
       }
 
       .score-team-label {
-        font-size: 0.75rem;
+        font-size: 0.8rem;
         font-weight: 700;
         text-transform: uppercase;
-        color: #888;
+        color: #aaa;
       }
 
       .score-pts {
-        font-size: 1.2rem;
+        font-size: 1.4rem;
         font-weight: 700;
         color: #fff;
       }
 
       .score-bags {
-        font-size: 0.75rem;
-        color: #777;
+        font-size: 0.78rem;
+        color: #888;
       }
 
       .score-meta {
-        font-size: 0.8rem;
-        color: #666;
+        font-size: 0.82rem;
+        color: #777;
         text-align: center;
+      }
+
+      /* Team bid + tricks bar — shown during playing phase */
+      .bid-tricks-bar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        background: #0e1e0e;
+        border-bottom: 1px solid #2a3a2a;
+        padding: 0.4rem 1.25rem;
+        flex-shrink: 0;
+      }
+
+      .bid-tricks-team {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+      }
+
+      .bid-tricks-label {
+        font-size: 0.78rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        color: #888;
+        letter-spacing: 0.05em;
+        min-width: 28px;
+      }
+
+      .bid-tricks-target {
+        font-size: 0.9rem;
+        color: #b0b0b0;
+      }
+
+      .bid-tricks-target strong {
+        color: #e8e8e8;
+        font-size: 1rem;
+      }
+
+      .bid-tricks-count {
+        font-size: 0.9rem;
+        color: #b0b0b0;
+      }
+
+      .bid-tricks-count strong {
+        color: #e8e8e8;
+        font-size: 1rem;
+      }
+
+      .bid-tricks-count.bid-tricks--met strong {
+        color: #66bb6a;
+      }
+
+      .bid-tricks-sep {
+        width: 1px;
+        height: 28px;
+        background: #2a3a2a;
+        flex-shrink: 0;
       }
 
       /* Game table layout */
@@ -420,8 +477,8 @@
         background: #1e2e1e;
         border: 1px solid #2e3e2e;
         border-radius: 6px;
-        padding: 0.4rem 0.75rem;
-        min-width: 90px;
+        padding: 0.5rem 0.875rem;
+        min-width: 100px;
         text-align: center;
       }
 
@@ -437,11 +494,11 @@
 
       .seat-name {
         display: block;
-        font-size: 0.7rem;
+        font-size: 0.8rem;
         font-weight: 700;
         text-transform: uppercase;
-        color: #888;
-        margin-bottom: 0.2rem;
+        color: #aaa;
+        margin-bottom: 0.25rem;
         letter-spacing: 0.05em;
       }
 
@@ -449,8 +506,8 @@
         display: flex;
         gap: 0.5rem;
         justify-content: center;
-        font-size: 0.75rem;
-        color: #b0b0b0;
+        font-size: 0.875rem;
+        color: #d0d0d0;
       }
 
       /* Trick area */
@@ -505,18 +562,20 @@
 
       .trick-card {
         background: #fff;
-        color: #222;
+        color: #1a1a1a;
         border-radius: 4px;
-        padding: 3px 5px;
-        font-size: 0.95rem;
+        padding: 4px 7px;
+        font-size: 1.05rem;
         font-weight: 700;
         white-space: nowrap;
         box-shadow: 0 1px 3px rgba(0,0,0,0.4);
       }
 
-      .trick-card.trick-red {
-        color: #c62828;
-      }
+      /* 4-color scheme for trick cards */
+      .trick-card.trick-spades  { color: #1a1a1a; }
+      .trick-card.trick-hearts  { color: #c62828; }
+      .trick-card.trick-diamonds{ color: #1565c0; }
+      .trick-card.trick-clubs   { color: #2e7d32; }
 
       /* Status bar */
       .game-status-bar {
@@ -709,28 +768,48 @@
         background: #fff;
         color: #222;
         border-radius: 4px;
-        padding: 0.3rem 0.45rem;
-        font-size: 0.875rem;
+        padding: 0.4rem 0.6rem;
+        font-size: 1rem;
         font-weight: 700;
         white-space: nowrap;
         user-select: none;
         border: 2px solid transparent;
-        box-shadow: 0 1px 3px rgba(0,0,0,0.35);
-        transition: transform 0.1s, border-color 0.1s;
+        box-shadow: 0 1px 4px rgba(0,0,0,0.35);
+        transition: transform 0.1s, border-color 0.1s, opacity 0.1s;
       }
 
-      .card.card-red {
-        color: #c62828;
+      /* 4-color suit scheme */
+      .card-spades  { color: #1a1a1a; }
+      .card-hearts  { color: #c62828; }
+      .card-diamonds{ color: #1565c0; }
+      .card-clubs   { color: #2e7d32; }
+
+      /* Valid card to play — highlighted with green border */
+      .card.card-valid {
+        cursor: pointer;
+        border-color: #4caf50;
+        box-shadow: 0 0 6px rgba(76, 175, 80, 0.35), 0 1px 4px rgba(0,0,0,0.35);
       }
 
-      /* Card that can be played */
+      .card.card-valid:hover {
+        transform: translateY(-6px);
+        border-color: #66bb6a;
+      }
+
+      /* Invalid card — dimmed and not clickable */
+      .card.card-invalid {
+        opacity: 0.35;
+        cursor: not-allowed;
+      }
+
+      /* Card that can be played (legacy fallback when validCards not available) */
       .card.card-play {
         cursor: pointer;
         border-color: #4caf50;
       }
 
       .card.card-play:hover {
-        transform: translateY(-5px);
+        transform: translateY(-6px);
         border-color: #66bb6a;
       }
 
@@ -755,35 +834,36 @@
 
       /* Compact cards for diagram mode */
       .card.card-compact {
-        padding: 0.15rem 0.3rem;
-        font-size: 0.8rem;
+        padding: 0.2rem 0.35rem;
+        font-size: 0.9rem;
       }
 
       /* Diagram hand layout */
       .hand-diagram {
         display: flex;
         flex-direction: column;
-        gap: 0.4rem;
+        gap: 0.5rem;
         width: 100%;
       }
 
       .diagram-row {
         display: flex;
         align-items: center;
-        gap: 0.3rem;
+        gap: 0.35rem;
         flex-wrap: wrap;
       }
 
       .diagram-suit {
-        width: 18px;
-        font-size: 1rem;
+        width: 20px;
+        font-size: 1.1rem;
         flex-shrink: 0;
-        color: #e8e8e8;
+        color: #1a1a1a;
       }
 
-      .diagram-suit.suit-red {
-        color: #ef5350;
-      }
+      .diagram-suit.suit-spades  { color: #1a1a1a; }
+      .diagram-suit.suit-hearts  { color: #c62828; }
+      .diagram-suit.suit-diamonds{ color: #1565c0; }
+      .diagram-suit.suit-clubs   { color: #2e7d32; }
 
       /* Game over screen */
       .game-over-card {

--- a/client/web/src/hand.js
+++ b/client/web/src/hand.js
@@ -1,5 +1,5 @@
 const SUIT_SYMBOL = { spades: '\u2660', hearts: '\u2665', diamonds: '\u2666', clubs: '\u2663' }
-const RED_SUIT = new Set(['hearts', 'diamonds'])
+const SUIT_COLOR_CLASS = { spades: 'card-spades', hearts: 'card-hearts', diamonds: 'card-diamonds', clubs: 'card-clubs' }
 
 function esc(s) {
   return String(s ?? '')
@@ -19,9 +19,9 @@ function esc(s) {
  */
 export function cardHtml(card, extraCls) {
   const s = SUIT_SYMBOL[card.suit]
-  const red = RED_SUIT.has(card.suit) ? ' card-red' : ''
+  const colorCls = SUIT_COLOR_CLASS[card.suit] ? ` ${SUIT_COLOR_CLASS[card.suit]}` : ''
   const cls = extraCls ? ` ${extraCls}` : ''
-  return `<span class="card${red}${cls}" data-suit="${esc(card.suit)}" data-rank="${esc(card.rank)}">${esc(card.rank)}${s}</span>`
+  return `<span class="card${colorCls}${cls}" data-suit="${esc(card.suit)}" data-rank="${esc(card.rank)}">${esc(card.rank)}${s}</span>`
 }
 
 /**
@@ -54,8 +54,8 @@ export function lastTrickHtml(lastTrick, rel) {
     const card = bySeats[seat]
     if (!card) return '<div class="trick-slot"></div>'
     const s = SUIT_SYMBOL[card.suit]
-    const red = RED_SUIT.has(card.suit) ? ' trick-red' : ''
-    return `<div class="trick-slot"><div class="trick-card${red}">${esc(card.rank)}${s}</div></div>`
+    const colorCls = card.suit ? ` trick-${card.suit}` : ''
+    return `<div class="trick-slot"><div class="trick-card${colorCls}">${esc(card.rank)}${s}</div></div>`
   }
 
   const winnerLabel = lastTrick.winner === rel.me
@@ -99,7 +99,7 @@ export function handDiagramHtml(hand, extraClsFn) {
     .filter(([, cards]) => cards.length > 0)
     .map(([suit, cards]) => {
       const s = SUIT_SYMBOL[suit]
-      const red = RED_SUIT.has(suit) ? ' suit-red' : ''
+      const suitCls = suit ? ` suit-${suit}` : ''
       const extra = extraClsFn
       const cardsHtml = cards
         .map((card) => {
@@ -107,7 +107,7 @@ export function handDiagramHtml(hand, extraClsFn) {
           return cardHtml(card, `card-compact${cls ? ' ' + cls : ''}`)
         })
         .join('')
-      return `<div class="diagram-row"><span class="diagram-suit${red}">${s}</span>${cardsHtml}</div>`
+      return `<div class="diagram-row"><span class="diagram-suit${suitCls}">${s}</span>${cardsHtml}</div>`
     })
     .join('')
 }

--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -18,7 +18,6 @@ import { endOfHandSummaryHtml } from '../endOfHandSummary.js'
 import { BAG_ICON } from '../icons.js'
 
 const SUIT_SYMBOL = { spades: '\u2660', hearts: '\u2665', diamonds: '\u2666', clubs: '\u2663' }
-const RED_SUIT = new Set(['hearts', 'diamonds'])
 const PARTNER = { north: 'south', south: 'north', east: 'west', west: 'east' }
 
 /**
@@ -155,6 +154,35 @@ export function applyDelta(state, msg, playerId) {
   }
 }
 const TEAM = { north: 'ns', south: 'ns', east: 'ew', west: 'ew' }
+
+/**
+ * Render the team bid target and current tricks bar shown below the scoreboard during play.
+ * Provides a quick at-a-glance view: each team's bid target vs. tricks taken this hand.
+ * @param {object} state
+ * @returns {string} HTML string
+ */
+function teamBidTricksHtml(state) {
+  const teams = [
+    { label: 'N/S', key: 'ns', seats: ['north', 'south'] },
+    { label: 'E/W', key: 'ew', seats: ['east', 'west'] },
+  ]
+
+  const cols = teams.map(({ label, key, seats }) => {
+    const bid = state.teamBids?.[key]
+    const tricks = (state.tricksWon?.[seats[0]] ?? 0) + (state.tricksWon?.[seats[1]] ?? 0)
+    const bidDisplay = bid !== null && bid !== undefined ? bid : '–'
+    const needsMore = typeof bid === 'number' && tricks < bid
+    const metBid = typeof bid === 'number' && tricks >= bid
+    const tricksCls = metBid ? ' bid-tricks--met' : (needsMore ? '' : '')
+    return `<div class="bid-tricks-team">
+      <span class="bid-tricks-label">${esc(label)}</span>
+      <span class="bid-tricks-target">Bid <strong>${bidDisplay}</strong></span>
+      <span class="bid-tricks-count${tricksCls}">Tricks <strong>${tricks}</strong></span>
+    </div>`
+  })
+
+  return `<div class="bid-tricks-bar">${cols.join('<div class="bid-tricks-sep"></div>')}</div>`
+}
 
 function esc(s) {
   return String(s ?? '')
@@ -320,8 +348,8 @@ function trickHtml(state, rel) {
     const card = bySeats[seat]
     if (!card) return '<div class="trick-slot"></div>'
     const s = SUIT_SYMBOL[card.suit]
-    const red = RED_SUIT.has(card.suit) ? ' trick-red' : ''
-    return `<div class="trick-slot"><div class="trick-card${red}">${esc(card.rank)}${s}</div></div>`
+    const colorCls = card.suit ? ` trick-${card.suit}` : ''
+    return `<div class="trick-slot"><div class="trick-card${colorCls}">${esc(card.rank)}${s}</div></div>`
   }
 
   return `
@@ -549,8 +577,14 @@ export function renderGameScreen(container) {
 
     function cardExtraCls(card) {
       const key = `${card.suit}-${card.rank}`
-      if (isMyPlayTurn && !inputBlocker.isBlocked()) return 'card-play'
       if (isMyExchangeTurn) return selectedSet.has(key) ? 'card-sel' : 'card-exch'
+      if (isMyPlayTurn && !inputBlocker.isBlocked()) {
+        if (state.validCards) {
+          const isValid = state.validCards.some((c) => `${c.suit}-${c.rank}` === key)
+          return isValid ? 'card-valid' : 'card-invalid'
+        }
+        return 'card-play'  // fallback when server hasn't sent validCards
+      }
       return ''
     }
 
@@ -640,6 +674,7 @@ export function renderGameScreen(container) {
           </div>
         </div>
         ${teamBidSummaryHtml(state)}
+        ${state.phase === 'playing' || state.phase === 'blind_nil_exchange' ? teamBidTricksHtml(state) : ''}
 
         <div class="game-table">
           <div class="table-top">
@@ -758,6 +793,11 @@ export function renderGameScreen(container) {
 
           if (isMyPlayTurn) {
             if (acting || inputBlocker.isBlocked()) return
+            // Silently block clicks on cards that are not legal plays
+            if (state.validCards) {
+              const isValid = state.validCards.some((c) => c.suit === card.suit && c.rank === card.rank)
+              if (!isValid) return
+            }
             acting = true
             inputBlocker.block()
             const prevState = state

--- a/client/web/src/trickHold.js
+++ b/client/web/src/trickHold.js
@@ -1,5 +1,4 @@
 const SUIT_SYMBOL = { spades: '\u2660', hearts: '\u2665', diamonds: '\u2666', clubs: '\u2663' }
-const RED_SUIT = new Set(['hearts', 'diamonds'])
 
 function esc(s) {
   return String(s ?? '')
@@ -83,8 +82,8 @@ export function trickHoldHtml(trick, rel) {
     const card = bySeats[seat]
     if (!card) return '<div class="trick-slot"></div>'
     const s = SUIT_SYMBOL[card.suit]
-    const red = RED_SUIT.has(card.suit) ? ' trick-red' : ''
-    return `<div class="trick-slot"><div class="trick-card${red}">${esc(card.rank)}${s}</div></div>`
+    const colorCls = card.suit ? ` trick-${card.suit}` : ''
+    return `<div class="trick-slot"><div class="trick-card${colorCls}">${esc(card.rank)}${s}</div></div>`
   }
 
   const winnerLabel = trick.winner === rel.me

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -9,6 +9,8 @@
 
 ## ✅ Completed
 
+- [x] `P1` UI pass (issue #251): 4-color suit scheme (♠ black, ♥ red, ♦ blue, ♣ green) as default; larger cards and seat-info elements; team bid target + tricks-taken bar during play; valid-card highlighting — server computes `validCards` via `getLegalPlays` in `getPlayerView`, client dims invalid cards and blocks clicks on them; stable hover (only valid playable cards lift on hover); `teamBidTricksHtml` panel shows N/S and E/W bid vs tricks inline below scoreboard.
+
 - [x] `P1` Refactor WebSocket events to carry delta payloads (hybrid approach): split `GAME_REFRESH_EVENTS` into `FULL_REFRESH_EVENTS` (structural transitions) and `DELTA_EVENTS` (in-flight game events). Delta events (`CARD_PLAYED`, `BID_PLACED`, `TRICK_COMPLETE`, `TURN_CHANGED`, `HAND_REVEALED`, `BLIND_NIL_EXCHANGE_PROMPT`, `PLAYER_DISCONNECTED`, `PLAYER_RECONNECTED`) are applied directly to client state via `applyDelta()` without an HTTP round-trip. Server emitters updated to include delta fields (`currentTrick`, `nextPlayerSeat`, `spadesBroken` on `CARD_PLAYED`; `bid` on numeric `BID_PLACED`; `step`/`currentBlindNilSeat` on `BLIND_NIL_EXCHANGE_PROMPT`; `seat` on `HAND_REVEALED`). Reduces per-trick HTTP round-trips from 52 to 0 for a full 13-trick hand. Reconnect re-hydration path preserved (issue #239).
 
 - [x] `BUG` Fix play/bid order appearing counterclockwise in the web UI: `relSeats()` in `client/web/src/screens/game.js` had `left` and `right` swapped, making each player's clockwise neighbour appear on the wrong side of the screen. Extracted `relSeats` and `CW` to `client/web/src/seatUtils.js` and added unit tests. Server engine was unaffected.

--- a/server/game/state.js
+++ b/server/game/state.js
@@ -514,10 +514,20 @@ export function getPlayerView(state, seat) {
     }
   }
 
+  const myHand = hands[seat]
+
+  // Compute valid cards when it is this player's turn to play.
+  // The client uses this for highlighting — the server still validates every play.
+  let validCards
+  if (state.phase === 'playing' && state.currentPlayerSeat === seat) {
+    validCards = getLegalPlays(myHand, state.currentTrick, state.spadesbroken, state.isFirstTrick)
+  }
+
   return {
     ...rest,
     blindNilEligible: false,
-    myHand: hands[seat],
+    myHand,
+    ...(validCards !== undefined ? { validCards } : {}),
     // Include played cards from the current trick (visible to all)
     // Do NOT include other players' unplayed hands
   }

--- a/test/unit/game/state.test.js
+++ b/test/unit/game/state.test.js
@@ -854,3 +854,56 @@ describe('advanceBotTurns', { timeout: 2000 }, () => {
     assert.notEqual(result.phase, 'bidding', 'all bot bids should be resolved')
   })
 })
+
+describe('getPlayerView — validCards', { timeout: 2000 }, () => {
+  // Helper: bid all seats with the given bid to reach playing phase
+  function bidAllToPlay(state, bid = 3) {
+    for (const seat of state.biddingOrder) {
+      state = placeBid(state, seat, bid)
+    }
+    return state
+  }
+
+  it('includes validCards for the active player during playing phase', { timeout: 2000 }, () => {
+    let state = createGame('table-1', PLAYER_IDS)
+    state = bidAllToPlay(state)
+    assert.equal(state.phase, 'playing')
+    const activeSeat = state.currentPlayerSeat
+    const view = getPlayerView(state, activeSeat)
+    assert.ok(Array.isArray(view.validCards), 'validCards should be an array')
+    assert.ok(view.validCards.length > 0, 'active player should have at least one valid card')
+  })
+
+  it('does not include validCards for inactive players', { timeout: 2000 }, () => {
+    let state = createGame('table-1', PLAYER_IDS)
+    state = bidAllToPlay(state)
+    assert.equal(state.phase, 'playing')
+    const activeSeat = state.currentPlayerSeat
+    const otherSeats = CLOCKWISE_SEATS.filter((s) => s !== activeSeat)
+    for (const seat of otherSeats) {
+      const view = getPlayerView(state, seat)
+      assert.equal(view.validCards, undefined, `${seat} should not receive validCards`)
+    }
+  })
+
+  it('validCards does not include spades on the first trick when spades are not broken', { timeout: 2000 }, () => {
+    let state = createGame('table-1', PLAYER_IDS)
+    state = bidAllToPlay(state)
+    assert.equal(state.isFirstTrick, true)
+    const activeSeat = state.currentPlayerSeat
+    const hand = state.hands[activeSeat]
+    // Only test this if the active player actually has non-spade cards
+    const hasNonSpades = hand.some((c) => c.suit !== 'spades')
+    if (hasNonSpades) {
+      const view = getPlayerView(state, activeSeat)
+      assert.ok(view.validCards.every((c) => c.suit !== 'spades'), 'no spades should be valid on the first trick')
+    }
+  })
+
+  it('does not include validCards during bidding phase', { timeout: 2000 }, () => {
+    const state = createGame('table-1', PLAYER_IDS)
+    assert.equal(state.phase, 'bidding')
+    const view = getPlayerView(state, state.currentBidderSeat)
+    assert.equal(view.validCards, undefined, 'validCards should not appear during bidding')
+  })
+})

--- a/test/unit/web/hand.test.js
+++ b/test/unit/web/hand.test.js
@@ -39,18 +39,22 @@ describe('cardHtml', { timeout: 2000 }, () => {
     assert.ok(html.includes('data-rank="K"'))
   })
 
-  it('adds card-red class for red suits', { timeout: 2000 }, () => {
+  it('adds suit-specific color class for each suit', { timeout: 2000 }, () => {
     const hearts = cardHtml({ suit: 'hearts', rank: '2' }, '')
     const diamonds = cardHtml({ suit: 'diamonds', rank: '2' }, '')
-    assert.ok(hearts.includes('card-red'), 'hearts should be red')
-    assert.ok(diamonds.includes('card-red'), 'diamonds should be red')
-  })
-
-  it('does not add card-red class for black suits', { timeout: 2000 }, () => {
     const spades = cardHtml({ suit: 'spades', rank: '2' }, '')
     const clubs = cardHtml({ suit: 'clubs', rank: '2' }, '')
-    assert.ok(!spades.includes('card-red'), 'spades should not be red')
-    assert.ok(!clubs.includes('card-red'), 'clubs should not be red')
+    assert.ok(hearts.includes('card-hearts'), 'hearts should have card-hearts class')
+    assert.ok(diamonds.includes('card-diamonds'), 'diamonds should have card-diamonds class')
+    assert.ok(spades.includes('card-spades'), 'spades should have card-spades class')
+    assert.ok(clubs.includes('card-clubs'), 'clubs should have card-clubs class')
+  })
+
+  it('does not mix up suit color classes', { timeout: 2000 }, () => {
+    const spades = cardHtml({ suit: 'spades', rank: '2' }, '')
+    const clubs = cardHtml({ suit: 'clubs', rank: '2' }, '')
+    assert.ok(!spades.includes('card-hearts'), 'spades should not have card-hearts class')
+    assert.ok(!clubs.includes('card-diamonds'), 'clubs should not have card-diamonds class')
   })
 
   it('appends extra CSS class when provided', { timeout: 2000 }, () => {
@@ -121,20 +125,21 @@ describe('handSpreadHtml', { timeout: 2000 }, () => {
     assert.ok(!html.includes('card-play'))
   })
 
-  it('marks red-suit cards with card-red', { timeout: 2000 }, () => {
+  it('marks suit cards with suit-specific color class', { timeout: 2000 }, () => {
     const hand = [
       { suit: 'hearts', rank: '5' },
       { suit: 'spades', rank: '5' },
     ]
     const html = handSpreadHtml(hand, noExtra)
-    // Only the hearts card should get card-red
+    // Hearts card should get card-hearts; spades card should get card-spades
     const heartsIdx = html.indexOf('data-suit="hearts"')
     const spadesIdx = html.indexOf('data-suit="spades"')
     // Grab the class attributes from each span block
     const heartsSpan = html.slice(html.lastIndexOf('<span', heartsIdx), heartsIdx)
     const spadesSpan = html.slice(html.lastIndexOf('<span', spadesIdx), spadesIdx)
-    assert.ok(heartsSpan.includes('card-red'))
-    assert.ok(!spadesSpan.includes('card-red'))
+    assert.ok(heartsSpan.includes('card-hearts'))
+    assert.ok(!spadesSpan.includes('card-hearts'))
+    assert.ok(spadesSpan.includes('card-spades'))
   })
 })
 
@@ -172,8 +177,8 @@ describe('handDiagramHtml', { timeout: 2000 }, () => {
       { suit: 'hearts', rank: 'K' },
     ]
     const html = handDiagramHtml(hand, noExtra)
-    assert.ok(html.includes('class="diagram-suit"'), 'spades row should have diagram-suit class')
-    assert.ok(html.includes('class="diagram-suit suit-red"'), 'hearts row should have suit-red class')
+    assert.ok(html.includes('class="diagram-suit suit-spades"'), 'spades row should have suit-spades class')
+    assert.ok(html.includes('class="diagram-suit suit-hearts"'), 'hearts row should have suit-hearts class')
   })
 
   it('renders all cards for a suit in a single row', { timeout: 2000 }, () => {
@@ -260,14 +265,16 @@ describe('lastTrickHtml', { timeout: 2000 }, () => {
     assert.ok(html.includes('Won by North'), 'should say "Won by North"')
   })
 
-  it('applies trick-red class to red-suit cards', { timeout: 2000 }, () => {
+  it('applies suit-specific trick class to each card', { timeout: 2000 }, () => {
     const html = lastTrickHtml(fullTrick, rel)
-    // hearts (K) and diamonds (Q) should have trick-red
-    const redCount = (html.match(/trick-red/g) || []).length
-    assert.equal(redCount, 2, 'exactly 2 red-suit cards should have trick-red')
+    // each suit should have its own trick-<suit> class
+    assert.ok(html.includes('trick-hearts'), 'hearts card should have trick-hearts class')
+    assert.ok(html.includes('trick-diamonds'), 'diamonds card should have trick-diamonds class')
+    assert.ok(html.includes('trick-spades'), 'spades card should have trick-spades class')
+    assert.ok(html.includes('trick-clubs'), 'clubs card should have trick-clubs class')
   })
 
-  it('does not apply trick-red to black-suit cards', { timeout: 2000 }, () => {
+  it('does not mix up suit trick classes', { timeout: 2000 }, () => {
     const blackOnly = {
       winner: 'north',
       plays: [
@@ -278,7 +285,8 @@ describe('lastTrickHtml', { timeout: 2000 }, () => {
       ],
     }
     const html = lastTrickHtml(blackOnly, rel)
-    assert.equal((html.match(/trick-red/g) || []).length, 0)
+    assert.equal((html.match(/trick-hearts/g) || []).length, 0, 'no trick-hearts for black-only trick')
+    assert.equal((html.match(/trick-diamonds/g) || []).length, 0, 'no trick-diamonds for black-only trick')
   })
 
   it('escapes HTML special characters in card rank', { timeout: 2000 }, () => {

--- a/test/unit/web/trickHold.test.js
+++ b/test/unit/web/trickHold.test.js
@@ -213,14 +213,16 @@ describe('trickHoldHtml', { timeout: 2000 }, () => {
     assert.ok(html.includes('trick-winner-banner'), 'should include winner banner element')
   })
 
-  it('applies trick-red to red-suit cards only', { timeout: 2000 }, () => {
+  it('applies suit-specific trick class to each card', { timeout: 2000 }, () => {
     const html = trickHoldHtml(trick, rel)
-    // hearts (K) and diamonds (Q) should have trick-red — spades and clubs should not
-    const redCount = (html.match(/trick-red/g) || []).length
-    assert.equal(redCount, 2, 'exactly 2 red-suit cards should have trick-red')
+    // each suit gets its own trick-<suit> class
+    assert.ok(html.includes('trick-hearts'), 'hearts card should have trick-hearts class')
+    assert.ok(html.includes('trick-diamonds'), 'diamonds card should have trick-diamonds class')
+    assert.ok(html.includes('trick-spades'), 'spades card should have trick-spades class')
+    assert.ok(html.includes('trick-clubs'), 'clubs card should have trick-clubs class')
   })
 
-  it('does not apply trick-red to black-suit cards', { timeout: 2000 }, () => {
+  it('does not apply hearts/diamonds trick class to black-suit cards', { timeout: 2000 }, () => {
     const blackOnly = {
       winner: 'north',
       plays: [
@@ -231,7 +233,8 @@ describe('trickHoldHtml', { timeout: 2000 }, () => {
       ],
     }
     const html = trickHoldHtml(blackOnly, rel)
-    assert.equal((html.match(/trick-red/g) || []).length, 0, 'no red class for black suits')
+    assert.equal((html.match(/trick-hearts/g) || []).length, 0, 'no trick-hearts for black-only trick')
+    assert.equal((html.match(/trick-diamonds/g) || []).length, 0, 'no trick-diamonds for black-only trick')
   })
 
   it('escapes HTML special characters in card ranks', { timeout: 2000 }, () => {


### PR DESCRIPTION
closes #251

## Summary

- Backend: `getPlayerView` now includes `validCards` (computed via `getLegalPlays` in `server/game/trick.js`) when it is the requesting player's turn to play. Client highlights legal cards; server still validates every play (defense in depth).
- 4-color suit scheme: ♠ black, ♥ red, ♦ blue, ♣ green — applies to hand cards, trick cards, and diagram suit symbols.
- Valid-card highlighting: legal cards get a green border + lift on hover (`card-valid`); illegal cards are dimmed and unclickable (`card-invalid`).
- Team bid + tricks bar: `bid-tricks-bar` panel shown during play displaying each team's bid target vs. current tricks taken.
- Larger elements: cards (1rem), trick cards (1.05rem), seat stats (0.875rem).
- Stable hover: only valid/playable cards lift; no transform on non-playable cards.

Generated with [Claude Code](https://claude.ai/code)