### PR TITLE
feat: 4-color suit scheme matching bridge-scorer app

### DIFF
--- a/client/web/index.html
+++ b/client/web/index.html
@@ -572,10 +572,10 @@
       }
 
       /* 4-color scheme for trick cards */
-      .trick-card.trick-spades  { color: #1a1a1a; }
-      .trick-card.trick-hearts  { color: #c62828; }
-      .trick-card.trick-diamonds{ color: #1565c0; }
-      .trick-card.trick-clubs   { color: #2e7d32; }
+      .trick-card.trick-spades  { color: #222; }
+      .trick-card.trick-hearts  { color: #cc3333; }
+      .trick-card.trick-diamonds{ color: #e08c10; }
+      .trick-card.trick-clubs   { color: #2e9944; }
 
       /* Status bar */
       .game-status-bar {
@@ -779,10 +779,10 @@
       }
 
       /* 4-color suit scheme */
-      .card-spades  { color: #1a1a1a; }
-      .card-hearts  { color: #c62828; }
-      .card-diamonds{ color: #1565c0; }
-      .card-clubs   { color: #2e7d32; }
+      .card-spades  { color: #222; }
+      .card-hearts  { color: #cc3333; }
+      .card-diamonds{ color: #e08c10; }
+      .card-clubs   { color: #2e9944; }
 
       /* Valid card to play — highlighted with green border */
       .card.card-valid {
@@ -860,10 +860,10 @@
         color: #1a1a1a;
       }
 
-      .diagram-suit.suit-spades  { color: #1a1a1a; }
-      .diagram-suit.suit-hearts  { color: #c62828; }
-      .diagram-suit.suit-diamonds{ color: #1565c0; }
-      .diagram-suit.suit-clubs   { color: #2e7d32; }
+      .diagram-suit.suit-spades  { color: #222; }
+      .diagram-suit.suit-hearts  { color: #cc3333; }
+      .diagram-suit.suit-diamonds{ color: #e08c10; }
+      .diagram-suit.suit-clubs   { color: #2e9944; }
 
       /* Game over screen */
       .game-over-card {


### PR DESCRIPTION
Updates suit colors to match dantonel's bridge-scorer app (per issue #251).

- ♠ Spades: near-black (#222)
- ♥ Hearts: red (#cc3333)
- ♦ Diamonds: amber (#e08c10)
- ♣ Clubs: green (#2e9944)

Closes #251

Generated with [Claude Code](https://claude.ai/code)