### PR TITLE
fix: emit TABLE_UPDATED on logout and re-sync lobby on WS connect

### DIFF
--- a/client/web/src/screens/lobby.js
+++ b/client/web/src/screens/lobby.js
@@ -114,8 +114,20 @@ export async function renderLobbyScreen(container) {
   // Subscribe to the lobby WebSocket channel for real-time updates
   const lobbySocket = createLobbySocket({
     wsUrl: buildWsUrl(sessionId),
-    onOpen: () => {
+    onOpen: async () => {
       console.log('Lobby WebSocket connected')
+      // Re-sync table list now that the WebSocket is subscribed, to close the race window
+      // between the initial fetch and when JOIN_LOBBY is acknowledged by the server.
+      try {
+        const { tables: freshTables } = await listTables({ sessionId, playerId })
+        tables = {}
+        for (const t of freshTables) {
+          tables[t.tableId] = t
+        }
+        renderTableList()
+      } catch (err) {
+        console.log('Failed to sync tables on WebSocket connect:', { error: err.message })
+      }
     },
     onEvent: (event) => {
       console.log('Lobby event:', { type: event.type, tableId: event.payload?.tableId })

--- a/server/lobby/table.js
+++ b/server/lobby/table.js
@@ -188,6 +188,7 @@ export async function saveGameState(redis, tableId, gameState) {
  */
 export async function removePlayerFromTables(redis, playerId) {
   const raw = await redis.hGetAll('lobby:tables')
+  const updatedTables = []
   for (const json of Object.values(raw)) {
     const entry = JSON.parse(json)
     if (entry.status !== 'waiting') continue
@@ -198,8 +199,10 @@ export async function removePlayerFromTables(redis, playerId) {
     const [seat] = seatEntry
     const updated = { ...table, seats: { ...table.seats, [seat]: null } }
     await saveTable(redis, updated)
+    updatedTables.push(updated)
     console.log('Player removed from table on logout:', { tableId: table.tableId, playerId, seat })
   }
+  return updatedTables
 }
 
 /**

--- a/server/server.js
+++ b/server/server.js
@@ -382,7 +382,10 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
       const redis = await getRedis()
       const session = await getSession(redis, sessionId)
       if (session) {
-        await removePlayerFromTables(redis, session.playerId)
+        const updatedTables = await removePlayerFromTables(redis, session.playerId)
+        for (const table of updatedTables) {
+          emitLobbyTableUpdated(wss, table)
+        }
       }
       await deleteSession(redis, sessionId)
       sendJSON(res, 200, { message: 'Logged out successfully.' })

--- a/test/ws/lobbyEvents.test.js
+++ b/test/ws/lobbyEvents.test.js
@@ -310,6 +310,60 @@ describe('Lobby WebSocket events for Public tables', { skip }, () => {
     await waitClose(ws)
   })
 
+  it('TABLE_UPDATED is emitted to the lobby channel when a seated player logs out', { timeout: 15000 }, async () => {
+    // Create a waiting table
+    const createRes = await apiRequest(
+      server.baseUrl,
+      'POST',
+      '/api/tables',
+      { name: 'Logout Test Table' },
+      { 'x-session-id': SESSION_A, 'x-player-id': PLAYER_A },
+    )
+    assert.equal(createRes.status, 201)
+    const { tableId } = createRes.body
+
+    // PLAYER_A sits at the table
+    await apiRequest(
+      server.baseUrl,
+      'POST',
+      `/api/tables/${tableId}/sit`,
+      { seat: 'north' },
+      { 'x-session-id': SESSION_A, 'x-player-id': PLAYER_A },
+    )
+
+    // PLAYER_B subscribes to the lobby
+    const ws = await wsConnect(server, { 'x-session-id': SESSION_B })
+    ws.send(JSON.stringify({ type: 'JOIN_LOBBY', payload: {} }))
+    await waitForType(ws, 'JOINED_LOBBY')
+
+    const msgPromise = waitForType(ws, 'TABLE_UPDATED')
+
+    // PLAYER_A logs out — seat should be freed and TABLE_UPDATED emitted
+    const logoutRes = await apiRequest(
+      server.baseUrl,
+      'POST',
+      '/api/auth/logout',
+      null,
+      { 'x-session-id': SESSION_A, 'x-player-id': PLAYER_A },
+    )
+    assert.equal(logoutRes.status, 200)
+
+    const [msg] = await msgPromise
+    assert.equal(msg.type, 'TABLE_UPDATED')
+    assert.equal(msg.payload.tableId, tableId)
+    assert.equal(msg.payload.seats.north, null, 'north seat should be freed after logout')
+
+    // Re-seed session for cleanup (session was deleted by logout)
+    await redis.set(`session:${SESSION_A}`, JSON.stringify({ playerId: PLAYER_A, username: 'LobbyEvtHostA' }))
+
+    // Cleanup
+    await redis.del(`table:${tableId}`)
+    await redis.hDel('lobby:tables', tableId)
+
+    ws.close()
+    await waitClose(ws)
+  })
+
   it('TABLE_REMOVED is emitted when last human leaves an in-progress game (table auto-terminates)', { timeout: 15000 }, async () => {
     // Seed a table directly in Redis with all-bot seats (so player leaving terminates it)
     const tableId = 'lobby-evt-terminate-test'


### PR DESCRIPTION
Two bugs prevented real-time seat-count updates in the lobby:

1. `removePlayerFromTables` (called on `POST /api/auth/logout`) updated seat state in Redis but never called `emitLobbyTableUpdated`. When a player logged out while seated at a waiting table, other lobby viewers only saw the freed seat on manual refresh.

2. The lobby client called `listTables` before establishing the WebSocket connection. Any `TABLE_UPDATED` event that fired in the window between the initial fetch and when `JOIN_LOBBY` was acknowledged was silently dropped. Fixed by re-syncing in the `onOpen` callback.

Adds integration test: seated player logs out → TABLE_UPDATED with freed seat is received by lobby subscriber.

Closes #257

Generated with [Claude Code](https://claude.ai/code)