### PR TITLE
docs: add hostSeat to GET /api/tables/:tableId/state response docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,12 +404,12 @@ Returns a player-specific view of the game. Cards in other players' hands are ne
 
 | Status | Meaning |
 |---|---|
-| `200` | Body: game state view (see below), or `{ status: "waiting", seats, isHost }` if the game has not started yet |
+| `200` | Body: game state view (see below), or `{ status: "waiting", seats, isHost, hostSeat }` if the game has not started yet |
 | `401` | Missing or invalid session |
 | `403` | Player is not seated at this table |
 | `404` | Table not found |
 
-The game state view includes: `phase`, `hand` (own cards only), `bids`, `tricks`, `scores`, `bags`, `currentPlayerSeat`, `currentBidderSeat`, `isHost`, and other phase-specific fields. It never includes another player's hand.
+The game state view includes: `phase`, `hand` (own cards only), `bids`, `tricks`, `scores`, `bags`, `currentPlayerSeat`, `currentBidderSeat`, `isHost`, `hostSeat`, and other phase-specific fields. It never includes another player's hand.
 
 During the `playing` phase, when it is the requesting player's turn to play, the response also includes `validCards`: an array of card objects representing the legal plays available to that player (computed server-side via `getLegalPlays`). This field is omitted when it is not the player's turn. Clients may use it to highlight or restrict UI affordances, but the server re-validates every play regardless.
 


### PR DESCRIPTION
Add `hostSeat` to the README.md documentation for the `GET /api/tables/:tableId/state` endpoint response shape, keeping it in sync with the implementation in server.js.

Closes #262

Generated with [Claude Code](https://claude.ai/code)