### PR TITLE
docs: add test/unit/web/ to documented test locations in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,7 @@ The following are coding-specific gotchas that are easy to misimplement even whe
 - Test locations:
   - `test/unit/game/` — pure game logic (scoring, bidding, trick resolution, bag counting)
   - `test/unit/anticheat/` — move validation logic
+  - `test/unit/web/` — client-side web UI logic (React components, socket handling, utilities)
   - `test/integration/` — API routes and Redis behaviour
   - `test/ws/` — WebSocket event flow
 - Every new API route must have at least one integration test


### PR DESCRIPTION
Add `test/unit/web/` as a documented test location in CLAUDE.md, covering client-side web UI logic tests.

CLAUDE.md previously listed only four test locations and omitted `test/unit/web/`, which already contains 15 test files.

Closes #263

Generated with [Claude Code](https://claude.ai/code)