### PR TITLE
fix: crown icon spacing and asymmetry (#264)

### DIFF
--- a/client/web/index.html
+++ b/client/web/index.html
@@ -506,6 +506,7 @@
         display: inline-flex;
         align-items: center;
         margin-left: 4px;
+        margin-right: 4px;
         opacity: 0.9;
       }
 

--- a/client/web/src/icons.js
+++ b/client/web/src/icons.js
@@ -47,7 +47,7 @@ export const DUNCE_CAP_ICON = [
 export const CROWN_ICON = [
   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" style="vertical-align:-1px">',
   // Crown points — five-point crown shape
-  '<path d="M2 18h20l2.5-10L17 12 12 2 7 12 1.5 8z" fill="#ffd54f" stroke="#b8860b" stroke-width="1" stroke-linejoin="round"/>',
+  '<path d="M2 18h20l0.5-10L17 12 12 2 7 12 1.5 8z" fill="#ffd54f" stroke="#b8860b" stroke-width="1" stroke-linejoin="round"/>',
   // Base bar
   '<rect x="2" y="18.5" width="20" height="2.5" rx="1.25" fill="#ffd54f" stroke="#b8860b" stroke-width="0.75"/>',
   '</svg>',


### PR DESCRIPTION
Fix spacing between Crown icon and seat name, and correct the asymmetric crown shape.

- Add `margin-right: 4px` to `.seat-host-crown` so there is space between the crown and seat name in the waiting room view
- Fix the asymmetric SVG crown path: right outer point corrected from x=24.5 to x=22.5 to mirror the left point at x=1.5

Closes #264

Generated with [Claude Code](https://claude.ai/code)