### PR TITLE
feat: add Leave Game button to in-game screen (#271)

### DIFF
--- a/client/web/index.html
+++ b/client/web/index.html
@@ -170,6 +170,51 @@
         color: #81c784;
       }
 
+      .btn-danger {
+        padding: 0.75rem;
+        background: #c62828;
+        color: #fff;
+        border: none;
+        border-radius: 4px;
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.15s;
+      }
+
+      .btn-danger:hover:not(:disabled) {
+        background: #d32f2f;
+      }
+
+      .btn-danger:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+
+      .btn-sm {
+        padding: 0.35rem 0.75rem;
+        font-size: 0.8rem;
+        font-weight: 500;
+      }
+
+      /* In-game controls bar (leave + host terminate) */
+      .game-controls {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 0.5rem;
+        padding: 0.5rem 0.75rem;
+        border-top: 1px solid #2a2a2a;
+        max-width: 640px;
+        width: 100%;
+        margin: 0 auto;
+      }
+
+      .game-controls .btn-secondary {
+        width: auto;
+        margin-bottom: 0;
+      }
+
       .auth-resend {
         margin-bottom: 0.75rem;
       }

--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -62,6 +62,14 @@ export const DELTA_EVENTS = new Set([
 export const GAME_REFRESH_EVENTS = new Set([...FULL_REFRESH_EVENTS, ...DELTA_EVENTS])
 
 /**
+ * Returns the HTML for the in-game Leave Game button.
+ * Exported for unit testing.
+ */
+export function leaveGameButtonHtml() {
+  return `<button class="btn-secondary btn-sm" id="leave-game-btn">Leave Game</button>`
+}
+
+/**
  * Apply a WebSocket delta event payload directly to the current game state,
  * returning a new state object. For events whose payload does not carry enough
  * data to update state (e.g. old server without delta fields), the original
@@ -721,7 +729,10 @@ export function renderGameScreen(container) {
           ? lastTrickHtml(state.completedTricks[state.completedTricks.length - 1], rel)
           : ''}
 
-        ${state.isHost ? '<div class="host-controls"><button class="btn-danger btn-sm" id="terminate-btn">Terminate Game</button></div>' : ''}
+        <div class="game-controls">
+          ${state.isHost ? '<button class="btn-danger btn-sm" id="terminate-btn">Terminate Game</button>' : ''}
+          ${leaveGameButtonHtml()}
+        </div>
       </div>`
 
     // Mode toggle
@@ -758,6 +769,23 @@ export function renderGameScreen(container) {
       } catch (err) {
         btn.disabled = false
         console.log('Terminate failed:', { error: err.message })
+      }
+    })
+
+    // Leave game button (all players, in-game)
+    container.querySelector('#leave-game-btn')?.addEventListener('click', async () => {
+      if (!confirm('Leave the game? A bot will take your place until the game ends.')) return
+      const btn = container.querySelector('#leave-game-btn')
+      btn.disabled = true
+      btn.textContent = 'Leaving\u2026'
+      try {
+        await apiLeaveTable({ tableId, sessionId, playerId })
+        cleanup()
+        navigate('#/lobby')
+      } catch (err) {
+        btn.disabled = false
+        btn.textContent = 'Leave Game'
+        console.log('Leave game failed:', { error: err.message })
       }
     })
 

--- a/test/unit/web/leaveGameButton.test.js
+++ b/test/unit/web/leaveGameButton.test.js
@@ -1,0 +1,19 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { leaveGameButtonHtml } from '../../../client/web/src/screens/game.js'
+
+describe('leaveGameButtonHtml', { timeout: 2000 }, () => {
+  it('returns a string', { timeout: 2000 }, () => {
+    assert.equal(typeof leaveGameButtonHtml(), 'string')
+  })
+
+  it('contains a button with id leave-game-btn', { timeout: 2000 }, () => {
+    const html = leaveGameButtonHtml()
+    assert.ok(html.includes('id="leave-game-btn"'), 'should include leave-game-btn id')
+  })
+
+  it('contains "Leave Game" text', { timeout: 2000 }, () => {
+    const html = leaveGameButtonHtml()
+    assert.ok(html.includes('Leave Game'), 'should include "Leave Game" text')
+  })
+})


### PR DESCRIPTION
Adds a Leave Game button to the active in-game screen so players can exit mid-game. The button is visible to all players and positioned at the bottom-right of the game screen via a new game-controls bar. A confirmation dialog warns the player that a bot will take their seat.

Also adds missing CSS for btn-danger and btn-sm classes which were referenced in game.js but undefined.

Closes #271

Generated with [Claude Code](https://claude.ai/code)