### PR TITLE
fix: default WS_PORT to PORT so WebSocket shares HTTP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Real-time multiplayer Spades card game — web and mobile.
 | Layer | Technology |
 |---|---|
 | Server | Node.js + Express (ES Modules, no build step) |
-| Real-time | WebSocket (WS_PORT, defaults to 3001) |
+| Real-time | WebSocket (shares HTTP server by default; configurable via WS_PORT) |
 | Session / Lobby / Presence | Redis |
 | Persistent storage | PostgreSQL |
 | Mobile | React Native / Flutter (iOS 15+, Android 10+) |
@@ -46,7 +46,7 @@ npm start
 | `DATABASE_URL` | Yes | — | PostgreSQL connection string |
 | `REDIS_URL` | Yes | — | Redis connection string |
 | `PORT` | No | `3000` | HTTP server port |
-| `WS_PORT` | No | `3001` | WebSocket server port (can share with HTTP) |
+| `WS_PORT` | No | Same as `PORT` | WebSocket server port. Defaults to sharing the HTTP server. Set to a different port to run WebSocket on a dedicated server (requires a reverse proxy to route WebSocket upgrades from the HTTP port). |
 | `NODE_ENV` | No | — | Environment name (`development`, `production`) |
 | `APP_URL` | No | `http://localhost:3000` | Public base URL (used in verification emails) |
 | `EMAIL_HOST` | No | — | SMTP host. If unset, verification emails are logged to stdout |
@@ -498,7 +498,7 @@ Card format: rank + suit initial (e.g. `AS` = Ace of Spades, `KH` = King of Hear
 
 ## Real-Time (WebSocket)
 
-The WebSocket server runs on its own port (configurable via `WS_PORT`, default `3001`). Set `WS_PORT` to the same value as `PORT` to share the HTTP server instead.
+The WebSocket server shares the HTTP server by default (same port as `PORT`). Set `WS_PORT` to a different port to run it on a dedicated server — in that case a reverse proxy must route WebSocket upgrades from the public HTTP port to `WS_PORT`.
 
 ### Connection & Authentication
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -94,8 +94,8 @@
 ### Web Client
 
 - [x] `P0` Establish authenticated WSS connection on game screen mount; tear down on unmount
-- [ ] `P0` Remove `schedulePoll()` timeout loop from `client/web/src/screens/game.js`; re-render on incoming WebSocket events instead
-- [ ] `P0` On reconnect: call `GET /api/tables/:tableId/state` to re-hydrate, then resume WS event listener
+- [x] `P0` Remove `schedulePoll()` timeout loop from `client/web/src/screens/game.js`; re-render on incoming WebSocket events instead
+- [x] `P0` On reconnect: call `GET /api/tables/:tableId/state` to re-hydrate, then resume WS event listener
 - [x] `P1` Subscribe to lobby channel on lobby screen mount; update table list on `TABLE_CREATED`, `TABLE_UPDATED`, `TABLE_REMOVED` — eliminating the manual-refresh requirement for Public tables (Friends-Only table events arrive on the personal notification channel added in Slice 3) (issue #122)
 
 ### Testing

--- a/server/app.js
+++ b/server/app.js
@@ -10,7 +10,11 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 
 const app = express()
 const PORT = parseInt(process.env.PORT || '3000', 10)
-const WS_PORT = parseInt(process.env.WS_PORT || '3001', 10)
+// Default WS_PORT to PORT so the WebSocket server shares the HTTP server by default.
+// The client's buildWsUrl() connects to window.location.host (the HTTP port), so they
+// must match unless a reverse proxy is routing WebSocket upgrades to a separate port.
+// Set WS_PORT explicitly to a different value to run WebSocket on a dedicated server.
+const WS_PORT = process.env.WS_PORT ? parseInt(process.env.WS_PORT, 10) : PORT
 
 app.use(express.json())
 


### PR DESCRIPTION
Fix all three pre-game UI update regressions by correcting the default WS_PORT configuration.

## Root Cause

`WS_PORT` defaulted to 3001 while `PORT` defaulted to 3000. The WebSocket upgrade handler was attached to a separate HTTP server on port 3001, but the client’s `buildWsUrl()` always connects to `window.location.host` (the HTTP port). In any default local deployment all WebSocket connections silently failed, so no real-time events were ever delivered:

- Lobby not showing new tables → TABLE_CREATED never delivered
- Waiting screen not updating seats → SEAT_TAKEN/SEAT_VACATED never delivered
- Fill-with-Bots not transitioning to game → GAME_STARTED never delivered

## Changes

- `server/app.js`: default WS_PORT to PORT so WebSocket shares the HTTP server
- `README.md`: update WS_PORT documentation
- `docs/TASKS.md`: mark two completed Slice 2 tasks as done

Closes #273

Generated with [Claude Code](https://claude.ai/code)