### PR TITLE
fix: add reconnect logic to createLobbySocket

### DIFF
--- a/client/web/src/gameSocket.js
+++ b/client/web/src/gameSocket.js
@@ -170,60 +170,108 @@ export function createGameSocket({
  * TABLE_CREATED, TABLE_UPDATED, and TABLE_REMOVED events are forwarded to onEvent.
  * All other handshake messages (JOINED_LOBBY, LEFT_LOBBY) are consumed internally.
  *
+ * Reconnect behaviour
+ * -------------------
+ * If the connection drops unexpectedly the socket automatically reconnects with
+ * exponential backoff. On a successful reconnect the JOINED_LOBBY ack triggers
+ * `onReconnect` (not `onOpen`).
+ *
  * @param {object} opts
  * @param {string} opts.wsUrl              - Full WS/WSS URL with `sessionId` query param
  * @param {function} [opts.onEvent]        - Called with each lobby event `{ type, payload }`
- * @param {function} [opts.onOpen]         - Called once JOINED_LOBBY is received
- * @param {function} [opts.onClose]        - Called when the socket closes
+ * @param {function} [opts.onOpen]         - Called once the initial JOINED_LOBBY is received
+ * @param {function} [opts.onReconnect]    - Called when JOINED_LOBBY is received after reconnect
+ * @param {function} [opts.onClose]        - Called when all reconnect attempts are exhausted
+ *                                           or after an intentional close
  * @param {function} [opts.onError]        - Called on WebSocket error
+ * @param {number}   [opts.maxReconnectAttempts=5] - Max automatic reconnect attempts
  * @param {typeof WebSocket} [opts.WebSocketClass] - Injected for testing; defaults to globalThis.WebSocket
+ * @param {function} [opts.setTimeoutFn]   - Injected for testing; defaults to globalThis.setTimeout
+ * @param {function} [opts.clearTimeoutFn] - Injected for testing; defaults to globalThis.clearTimeout
  * @returns {{ close: function }}
  */
 export function createLobbySocket({
   wsUrl,
   onEvent,
   onOpen,
+  onReconnect,
   onClose,
   onError,
+  maxReconnectAttempts = 5,
   WebSocketClass = globalThis.WebSocket,
+  setTimeoutFn = globalThis.setTimeout,
+  clearTimeoutFn = globalThis.clearTimeout,
 }) {
-  const ws = new WebSocketClass(wsUrl)
+  let intentionalClose = false
+  let reconnectAttempts = 0
+  let reconnectTimer = null
+  let ws = null
 
-  ws.onopen = () => {
-    ws.send(JSON.stringify({ type: 'JOIN_LOBBY', payload: {} }))
-  }
+  function connect() {
+    ws = new WebSocketClass(wsUrl)
+    const isReconnect = reconnectAttempts > 0
 
-  ws.onmessage = (event) => {
-    let msg
-    try {
-      msg = JSON.parse(typeof event.data === 'string' ? event.data : event.data.toString())
-    } catch {
-      return
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ type: 'JOIN_LOBBY', payload: {} }))
     }
 
-    const { type } = msg
+    ws.onmessage = (event) => {
+      let msg
+      try {
+        msg = JSON.parse(typeof event.data === 'string' ? event.data : event.data.toString())
+      } catch {
+        return
+      }
 
-    if (type === 'JOINED_LOBBY') {
-      onOpen?.()
-      return
+      const { type } = msg
+
+      if (type === 'JOINED_LOBBY') {
+        reconnectAttempts = 0
+        if (isReconnect) {
+          onReconnect?.()
+        } else {
+          onOpen?.()
+        }
+        return
+      }
+
+      if (type === 'LEFT_LOBBY') {
+        return
+      }
+
+      onEvent?.(msg)
     }
 
-    if (type === 'LEFT_LOBBY') {
-      return
+    ws.onclose = () => {
+      if (intentionalClose) {
+        onClose?.()
+        return
+      }
+
+      if (reconnectAttempts >= maxReconnectAttempts) {
+        onClose?.()
+        return
+      }
+
+      // Exponential backoff: 1s, 2s, 4s, 8s, 16s, capped at 30s
+      const delay = Math.min(1000 * Math.pow(2, reconnectAttempts), 30000)
+      reconnectAttempts++
+      reconnectTimer = setTimeoutFn(connect, delay)
     }
 
-    onEvent?.(msg)
+    ws.onerror = (err) => {
+      onError?.(err)
+    }
   }
 
-  ws.onclose = () => {
-    onClose?.()
-  }
-
-  ws.onerror = (err) => {
-    onError?.(err)
-  }
+  connect()
 
   function close() {
+    intentionalClose = true
+    if (reconnectTimer !== null) {
+      clearTimeoutFn(reconnectTimer)
+      reconnectTimer = null
+    }
     if (ws.readyState === 1 /* OPEN */) {
       ws.send(JSON.stringify({ type: 'LEAVE_LOBBY', payload: {} }))
     }

--- a/client/web/src/screens/lobby.js
+++ b/client/web/src/screens/lobby.js
@@ -111,24 +111,28 @@ export async function renderLobbyScreen(container) {
   }
   renderTableList()
 
+  // Re-sync the full table list and re-render. Called on initial connect and on reconnect
+  // to close the race window between the initial fetch and when the server acks the join,
+  // and to catch up on any events missed during a reconnect.
+  async function syncTableList(label) {
+    console.log(`Lobby WebSocket ${label}`)
+    try {
+      const { tables: freshTables } = await listTables({ sessionId, playerId })
+      tables = {}
+      for (const t of freshTables) {
+        tables[t.tableId] = t
+      }
+      renderTableList()
+    } catch (err) {
+      console.log(`Failed to sync tables on WebSocket ${label}:`, { error: err.message })
+    }
+  }
+
   // Subscribe to the lobby WebSocket channel for real-time updates
   const lobbySocket = createLobbySocket({
     wsUrl: buildWsUrl(sessionId),
-    onOpen: async () => {
-      console.log('Lobby WebSocket connected')
-      // Re-sync table list now that the WebSocket is subscribed, to close the race window
-      // between the initial fetch and when JOIN_LOBBY is acknowledged by the server.
-      try {
-        const { tables: freshTables } = await listTables({ sessionId, playerId })
-        tables = {}
-        for (const t of freshTables) {
-          tables[t.tableId] = t
-        }
-        renderTableList()
-      } catch (err) {
-        console.log('Failed to sync tables on WebSocket connect:', { error: err.message })
-      }
-    },
+    onOpen: () => syncTableList('connected'),
+    onReconnect: () => syncTableList('reconnected'),
     onEvent: (event) => {
       console.log('Lobby event:', { type: event.type, tableId: event.payload?.tableId })
       applyLobbyEvent(tables, event)

--- a/test/unit/web/gameSocket.test.js
+++ b/test/unit/web/gameSocket.test.js
@@ -572,21 +572,133 @@ describe('createLobbySocket', { timeout: 2000 }, () => {
   it('close() is safe to call when connection is already closed', { timeout: 2000 }, () => {
     const { close } = createLobbySocket({
       wsUrl: 'ws://localhost?sessionId=s1',
+      maxReconnectAttempts: 0,
       WebSocketClass: MockWebSocket,
+      setTimeoutFn: () => {},
+      clearTimeoutFn: () => {},
     })
     MockWebSocket.lastInstance._close()
     assert.doesNotThrow(() => close())
   })
 
-  it('calls onClose when the socket closes', { timeout: 2000 }, () => {
+  it('calls onClose when the socket closes with maxReconnectAttempts=0', { timeout: 2000 }, () => {
     let closed = false
     createLobbySocket({
       wsUrl: 'ws://localhost?sessionId=s1',
       onClose: () => { closed = true },
+      maxReconnectAttempts: 0,
       WebSocketClass: MockWebSocket,
+      setTimeoutFn: () => {},
+      clearTimeoutFn: () => {},
     })
     MockWebSocket.lastInstance._close()
     assert.equal(closed, true)
+  })
+
+  it('does not call onClose immediately on unexpected close — schedules reconnect instead', { timeout: 2000 }, () => {
+    let closed = false
+    const timers = []
+    createLobbySocket({
+      wsUrl: 'ws://localhost?sessionId=s1',
+      onClose: () => { closed = true },
+      maxReconnectAttempts: 1,
+      WebSocketClass: MockWebSocket,
+      setTimeoutFn: (fn, delay) => { timers.push({ fn, delay }); return timers.length },
+      clearTimeoutFn: () => {},
+    })
+    MockWebSocket.lastInstance._close()
+    assert.equal(closed, false, 'onClose should not fire before reconnect attempts exhausted')
+    assert.equal(timers.length, 1, 'a reconnect timer should be scheduled')
+  })
+
+  it('calls onClose after maxReconnectAttempts are exhausted', { timeout: 2000 }, () => {
+    let closed = false
+    const timers = []
+    const noop = () => {}
+    createLobbySocket({
+      wsUrl: 'ws://localhost?sessionId=s1',
+      onClose: () => { closed = true },
+      maxReconnectAttempts: 2,
+      WebSocketClass: MockWebSocket,
+      setTimeoutFn: (fn) => { timers.push(fn); return timers.length },
+      clearTimeoutFn: noop,
+    })
+    // First drop — schedules reconnect #1
+    MockWebSocket.lastInstance._close()
+    assert.equal(closed, false)
+    // Fire reconnect #1 — creates new WebSocket, drop it — schedules reconnect #2
+    timers[0]()
+    MockWebSocket.lastInstance._close()
+    assert.equal(closed, false)
+    // Fire reconnect #2 — creates new WebSocket, drop it — attempts exhausted
+    timers[1]()
+    MockWebSocket.lastInstance._close()
+    assert.equal(closed, true)
+  })
+
+  it('calls onReconnect (not onOpen) when JOINED_LOBBY is received after reconnect', { timeout: 2000 }, () => {
+    let opens = 0
+    let reconnects = 0
+    const timers = []
+    createLobbySocket({
+      wsUrl: 'ws://localhost?sessionId=s1',
+      onOpen: () => { opens++ },
+      onReconnect: () => { reconnects++ },
+      maxReconnectAttempts: 5,
+      WebSocketClass: MockWebSocket,
+      setTimeoutFn: (fn) => { timers.push(fn); return timers.length },
+      clearTimeoutFn: () => {},
+    })
+    const firstWs = MockWebSocket.lastInstance
+    firstWs._open()
+    firstWs._receive({ type: 'JOINED_LOBBY', payload: {} })
+    assert.equal(opens, 1)
+    assert.equal(reconnects, 0)
+
+    // Unexpected drop → reconnect timer scheduled
+    firstWs._close()
+
+    // Fire the reconnect timer
+    timers[0]()
+    const secondWs = MockWebSocket.lastInstance
+    secondWs._open()
+    secondWs._receive({ type: 'JOINED_LOBBY', payload: {} })
+    assert.equal(opens, 1, 'onOpen should not fire again on reconnect')
+    assert.equal(reconnects, 1, 'onReconnect should fire once')
+  })
+
+  it('intentional close does not trigger reconnect', { timeout: 2000 }, () => {
+    let closed = false
+    const timers = []
+    const { close } = createLobbySocket({
+      wsUrl: 'ws://localhost?sessionId=s1',
+      onClose: () => { closed = true },
+      maxReconnectAttempts: 5,
+      WebSocketClass: MockWebSocket,
+      setTimeoutFn: (fn) => { timers.push(fn); return timers.length },
+      clearTimeoutFn: () => {},
+    })
+    const ws = MockWebSocket.lastInstance
+    ws._open()
+    close()
+    ws._close()
+    assert.equal(timers.length, 0, 'no reconnect timer should be scheduled')
+    assert.equal(closed, true, 'onClose should fire for intentional close')
+  })
+
+  it('close() during reconnect window cancels the pending timer', { timeout: 2000 }, () => {
+    let cleared = false
+    let timerHandle = null
+    const { close } = createLobbySocket({
+      wsUrl: 'ws://localhost?sessionId=s1',
+      maxReconnectAttempts: 5,
+      WebSocketClass: MockWebSocket,
+      setTimeoutFn: (fn, delay) => { timerHandle = 42; return 42 },
+      clearTimeoutFn: (id) => { if (id === timerHandle) cleared = true },
+    })
+    MockWebSocket.lastInstance._close() // unexpected → schedules reconnect
+    close()
+    assert.equal(cleared, true, 'reconnect timer should be cancelled on close()')
   })
 
   it('calls onError when the WebSocket fires an error', { timeout: 2000 }, () => {


### PR DESCRIPTION
createLobbySocket had no reconnect logic while createGameSocket did. If the lobby WebSocket failed on initial connect or was dropped, the client permanently lost real-time table updates with no error shown.

Adds exponential-backoff reconnect (up to 5 attempts, 1s/2s/4s/8s/16s/30s cap) and an onReconnect callback so lobby.js re-syncs the table list after reconnect.

Includes 6 new regression tests.

Closes #273

Generated with [Claude Code](https://claude.ai/code)