### PR TITLE
fix: serve WS_URL from env via /config.js instead of hardcoding in index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ npm start
 | `REDIS_URL` | Yes | — | Redis connection string |
 | `PORT` | No | `3000` | HTTP server port |
 | `WS_PORT` | No | Same as `PORT` | WebSocket server port. Defaults to sharing the HTTP server. Set to a different port to run WebSocket on a dedicated server (requires a reverse proxy to route WebSocket upgrades from the HTTP port). |
+| `WS_URL` | No | — | Full WebSocket base URL (e.g. `wss://my-app.up.railway.app`). Set this in your host's environment settings (e.g. Vercel) when the WebSocket server is on a different host than the HTTP server. The client reads this via `/config.js` at runtime — do not hardcode it in `index.html`. |
 | `NODE_ENV` | No | — | Environment name (`development`, `production`) |
 | `APP_URL` | No | `http://localhost:3000` | Public base URL (used in verification emails) |
 | `EMAIL_HOST` | No | — | SMTP host. If unset, verification emails are logged to stdout |

--- a/client/web/index.html
+++ b/client/web/index.html
@@ -1374,6 +1374,10 @@
   </head>
   <body>
     <div id="app"></div>
+    <!-- Runtime config: sets window.__WS_URL__ from the WS_URL environment variable.
+         Configure WS_URL in your host's env settings (e.g. Vercel) — do not hardcode it here.
+         Required for split-host deployments (e.g. frontend on Vercel, WebSocket on Railway). -->
+    <script src="/config.js"></script>
     <script type="module" src="src/main.js"></script>
   </body>
 </html>

--- a/client/web/src/gameSocket.js
+++ b/client/web/src/gameSocket.js
@@ -284,17 +284,25 @@ export function createLobbySocket({
 }
 
 /**
- * Build the WebSocket URL for the current origin, appending the session token
- * as a query parameter.
+ * Build the WebSocket URL, appending the session token as a query parameter.
  *
- * Derives the host from `window.location` so it works regardless of port.
- * Falls back to `localhost` when running outside a browser (e.g. during tests
- * that call this function directly).
+ * If `window.__WS_URL__` is set (injected by `/config.js` from the `WS_URL`
+ * environment variable), that base URL is used. This supports split-host
+ * deployments where the WebSocket server lives on a different host than the
+ * HTTP server (e.g. frontend on Vercel, WebSocket on Railway).
+ *
+ * Falls back to deriving the host from `window.location` for local /
+ * single-host deployments.
  *
  * @param {string} sessionId
  * @returns {string}
  */
 export function buildWsUrl(sessionId) {
+  const base = globalThis.__WS_URL__ || ''
+  if (base) {
+    const separator = base.includes('?') ? '&' : '?'
+    return `${base}${separator}sessionId=${encodeURIComponent(sessionId)}`
+  }
   const protocol = globalThis.location?.protocol === 'https:' ? 'wss:' : 'ws:'
   const host = globalThis.location?.host ?? 'localhost'
   return `${protocol}//${host}?sessionId=${encodeURIComponent(sessionId)}`

--- a/server/app.js
+++ b/server/app.js
@@ -37,6 +37,17 @@ const redis = process.env.REDIS_URL ? await getRedis() : null
 // Serve the web client as static files
 app.use(express.static(join(__dirname, '..', 'client', 'web')))
 
+// Inject runtime configuration as a JS file so client-side code can read
+// environment-specific values (e.g. WS_URL for split-host deployments where
+// the WebSocket server lives on a different host than the HTTP server).
+// Configure WS_URL in Vercel (or your host's env settings) — do not hardcode it.
+app.get('/config.js', (req, res) => {
+  const wsUrl = process.env.WS_URL || ''
+  res.setHeader('Content-Type', 'application/javascript')
+  res.setHeader('Cache-Control', 'no-store')
+  res.send(`window.__WS_URL__ = ${JSON.stringify(wsUrl)};`)
+})
+
 const httpServer = createServer(app)
 
 let wss

--- a/test/unit/web/gameSocket.test.js
+++ b/test/unit/web/gameSocket.test.js
@@ -447,6 +447,36 @@ describe('buildWsUrl', { timeout: 2000 }, () => {
     const url = buildWsUrl('session with spaces')
     assert.ok(!url.includes(' '), 'URL should not contain unencoded spaces')
   })
+
+  it('uses window.__WS_URL__ as base when set', { timeout: 2000 }, () => {
+    globalThis.__WS_URL__ = 'wss://my-app.up.railway.app'
+    try {
+      const url = buildWsUrl('sess-1')
+      assert.ok(url.startsWith('wss://my-app.up.railway.app'), `expected Railway base, got: ${url}`)
+      assert.ok(url.includes('sessionId=sess-1'), `expected sessionId in URL, got: ${url}`)
+    } finally {
+      delete globalThis.__WS_URL__
+    }
+  })
+
+  it('falls back to window.location when __WS_URL__ is not set', { timeout: 2000 }, () => {
+    delete globalThis.__WS_URL__
+    const url = buildWsUrl('sess-2')
+    assert.ok(url.startsWith('ws:') || url.startsWith('wss:'), `expected ws/wss URL, got: ${url}`)
+    assert.ok(url.includes('sessionId=sess-2'), `expected sessionId in URL, got: ${url}`)
+  })
+
+  it('handles __WS_URL__ that already has a query string', { timeout: 2000 }, () => {
+    globalThis.__WS_URL__ = 'wss://my-app.up.railway.app?foo=bar'
+    try {
+      const url = buildWsUrl('sess-3')
+      assert.ok(url.includes('foo=bar'), 'should preserve existing query params')
+      assert.ok(url.includes('sessionId=sess-3'), `expected sessionId in URL, got: ${url}`)
+      assert.ok(!url.includes('??'), 'should not double up on ?')
+    } finally {
+      delete globalThis.__WS_URL__
+    }
+  })
 })
 
 // --- createLobbySocket -------------------------------------------------------


### PR DESCRIPTION
Adds a /config.js route to the Express server that injects the WS_URL environment variable as window.__WS_URL__ at runtime. The Railway WebSocket URL is configured in Vercel's environment settings — never in the codebase.

- server/app.js: add GET /config.js route (returns window.__WS_URL__ from WS_URL env var)
- client/web/index.html: load /config.js before the module script
- client/web/src/gameSocket.js: buildWsUrl() checks window.__WS_URL__ first, falls back to window.location.host
- test/unit/web/gameSocket.test.js: 3 new tests for window.__WS_URL__ behaviour
- README.md: document WS_URL env var

Closes #273

Generated with [Claude Code](https://claude.ai/code)