### PR TITLE
fix: inject WS_URL env var into index.html at serve time

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ npm start
 | `REDIS_URL` | Yes | — | Redis connection string |
 | `PORT` | No | `3000` | HTTP server port |
 | `WS_PORT` | No | Same as `PORT` | WebSocket server port. Defaults to sharing the HTTP server. Set to a different port to run WebSocket on a dedicated server (requires a reverse proxy to route WebSocket upgrades from the HTTP port). |
+| `WS_URL` | No | Derived from request origin | Full WebSocket base URL (e.g. `wss://my-app.up.railway.app`). Set this in split-host deployments where the WebSocket server is on a different host than the frontend (e.g. Vercel + Railway). The server injects this as `window.__WS_URL__` in the served HTML so the client connects to the correct host. |
 | `NODE_ENV` | No | — | Environment name (`development`, `production`) |
 | `APP_URL` | No | `http://localhost:3000` | Public base URL (used in verification emails) |
 | `EMAIL_HOST` | No | — | SMTP host. If unset, verification emails are logged to stdout |

--- a/client/web/src/gameSocket.js
+++ b/client/web/src/gameSocket.js
@@ -284,17 +284,28 @@ export function createLobbySocket({
 }
 
 /**
- * Build the WebSocket URL for the current origin, appending the session token
- * as a query parameter.
+ * Build the WebSocket URL, appending the session token as a query parameter.
  *
- * Derives the host from `window.location` so it works regardless of port.
- * Falls back to `localhost` when running outside a browser (e.g. during tests
- * that call this function directly).
+ * Resolution order:
+ *   1. `window.__WS_URL__` — injected by the server from the `WS_URL` env var.
+ *      Used in split-host deployments where the WebSocket server is on a
+ *      different host than the web frontend (e.g. Railway backend + Vercel
+ *      frontend).
+ *   2. `window.location.host` — falls back to the current origin for local /
+ *      single-host deployments.
+ *
+ * Falls back to `localhost` when running outside a browser (e.g. unit tests).
  *
  * @param {string} sessionId
  * @returns {string}
  */
 export function buildWsUrl(sessionId) {
+  const wsBase = globalThis.__WS_URL__
+  if (wsBase) {
+    // __WS_URL__ is already a full base URL (e.g. "wss://my-app.up.railway.app")
+    // Strip any trailing slash before appending the query string.
+    return `${wsBase.replace(/\/$/, '')}?sessionId=${encodeURIComponent(sessionId)}`
+  }
   const protocol = globalThis.location?.protocol === 'https:' ? 'wss:' : 'ws:'
   const host = globalThis.location?.host ?? 'localhost'
   return `${protocol}//${host}?sessionId=${encodeURIComponent(sessionId)}`

--- a/server/app.js
+++ b/server/app.js
@@ -1,5 +1,6 @@
 import express from 'express'
 import { createServer } from 'http'
+import { readFileSync } from 'fs'
 import { fileURLToPath } from 'url'
 import { dirname, join } from 'path'
 import { handler } from './server.js'
@@ -34,8 +35,27 @@ app.use((req, res, next) => {
 
 const redis = process.env.REDIS_URL ? await getRedis() : null
 
-// Serve the web client as static files
-app.use(express.static(join(__dirname, '..', 'client', 'web')))
+// Serve index.html dynamically so the server can inject window.__WS_URL__ from
+// the WS_URL environment variable.  This allows split-host deployments (e.g.
+// Vercel frontend + Railway WebSocket server) to configure the WebSocket URL
+// via an environment variable rather than hardcoding it in the source.
+const indexPath = join(__dirname, '..', 'client', 'web', 'index.html')
+const rawIndex = readFileSync(indexPath, 'utf-8')
+
+app.get('/', (req, res) => {
+  const wsUrl = process.env.WS_URL
+  const html = wsUrl
+    ? rawIndex.replace(
+        '</head>',
+        `  <script>window.__WS_URL__ = ${JSON.stringify(wsUrl)};</script>\n  </head>`,
+      )
+    : rawIndex
+  res.setHeader('Content-Type', 'text/html')
+  res.send(html)
+})
+
+// Serve remaining static assets (JS, CSS, images, etc.)
+app.use(express.static(join(__dirname, '..', 'client', 'web'), { index: false }))
 
 const httpServer = createServer(app)
 

--- a/test/unit/web/gameSocket.test.js
+++ b/test/unit/web/gameSocket.test.js
@@ -447,6 +447,34 @@ describe('buildWsUrl', { timeout: 2000 }, () => {
     const url = buildWsUrl('session with spaces')
     assert.ok(!url.includes(' '), 'URL should not contain unencoded spaces')
   })
+
+  it('uses window.__WS_URL__ as the base when set', { timeout: 2000 }, () => {
+    globalThis.__WS_URL__ = 'wss://my-app.up.railway.app'
+    try {
+      const url = buildWsUrl('sess-1')
+      assert.equal(url, 'wss://my-app.up.railway.app?sessionId=sess-1')
+    } finally {
+      delete globalThis.__WS_URL__
+    }
+  })
+
+  it('strips trailing slash from __WS_URL__ before appending query string', { timeout: 2000 }, () => {
+    globalThis.__WS_URL__ = 'wss://my-app.up.railway.app/'
+    try {
+      const url = buildWsUrl('sess-2')
+      assert.equal(url, 'wss://my-app.up.railway.app?sessionId=sess-2')
+    } finally {
+      delete globalThis.__WS_URL__
+    }
+  })
+
+  it('falls back to window.location.host when __WS_URL__ is not set', { timeout: 2000 }, () => {
+    // Ensure __WS_URL__ is absent (default test environment state)
+    delete globalThis.__WS_URL__
+    const url = buildWsUrl('sess-3')
+    assert.ok(url.startsWith('ws:') || url.startsWith('wss:'), `expected ws/wss URL, got: ${url}`)
+    assert.ok(url.includes('sessionId=sess-3'), `expected sessionId in URL, got: ${url}`)
+  })
 })
 
 // --- createLobbySocket -------------------------------------------------------


### PR DESCRIPTION
Rather than hardcoding window.__WS_URL__ in index.html, the Express server now reads the WS_URL environment variable and injects it as a script tag when serving index.html. This lets split-host deployments (Vercel frontend + Railway WebSocket server) configure the WebSocket URL entirely through a Vercel environment variable.

Closes #273

Generated with [Claude Code](https://claude.ai/code)