### PR TITLE
feat: table seating updates (#258)

### DIFF
--- a/client/web/src/api.js
+++ b/client/web/src/api.js
@@ -335,6 +335,31 @@ export async function leaveTable({ tableId, sessionId, playerId }, fetchFn = glo
 }
 
 /**
+ * Change the player's seat to a different empty seat (waiting tables only).
+ * @param {{ tableId: string, seat: string, sessionId: string, playerId: string }} data
+ * @param {typeof fetch} [fetchFn]
+ * @returns {Promise<{ tableId: string, seat: string }>}
+ */
+export async function changeSeat({ tableId, seat, sessionId, playerId }, fetchFn = globalThis.fetch) {
+  const res = await fetchFn(`/api/tables/${tableId}/change-seat`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-session-id': sessionId,
+      'x-player-id': playerId,
+    },
+    body: JSON.stringify({ seat }),
+  })
+  const body = await res.json()
+  if (!res.ok) {
+    const err = new Error(body.error || 'Failed to change seat.')
+    err.status = res.status
+    throw err
+  }
+  return body
+}
+
+/**
  * Terminate a game (host only). Works in both waiting and playing phases.
  * @param {{ tableId: string, sessionId: string, playerId: string }} data
  * @param {typeof fetch} [fetchFn]

--- a/client/web/src/screens/createTable.js
+++ b/client/web/src/screens/createTable.js
@@ -66,7 +66,8 @@ export async function renderCreateTableScreen(container) {
     try {
       const { tableId } = await createTable({ name: name || null, sessionId, playerId })
       console.log('Table created:', { tableId, name: name || null })
-      navigate(`#/join?tableId=${tableId}`)
+      sessionStorage.setItem('currentTableId', tableId)
+      navigate(`#/table?tableId=${tableId}`)
     } catch (err) {
       errorEl.textContent = err.message
       btn.disabled = false

--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -5,7 +5,7 @@ import {
   submitBlindNilExchange as apiExchange,
   addBotToTable as apiAddBot,
   revealHand as apiRevealHand,
-  terminateGame as apiTerminate,
+  changeSeat as apiChangeSeat,
   leaveTable as apiLeaveTable,
 } from '../api.js'
 import { createGameSocket, buildWsUrl } from '../gameSocket.js'
@@ -448,12 +448,13 @@ export function renderGameScreen(container) {
       return `<div class="${cls}"><span>${crownHtml}${esc(label)}</span><span class="waiting-seat-status">${status}</span></div>`
     }).join('')
 
-    const fillBotsBtn = state.isHost && emptySeats.length > 0
-      ? `<button class="btn-primary" id="fill-bots-btn">Fill with Bots (${emptySeats.length} seat${emptySeats.length !== 1 ? 's' : ''})</button>`
+    const mySeat = Object.entries(state.seats).find(([, id]) => id === playerId)?.[0]
+    const changeSeatBtns = mySeat
+      ? emptySeats.map((s) => `<button class="btn-secondary btn-sm change-seat-btn" data-seat="${s}">Move to ${s.charAt(0).toUpperCase() + s.slice(1)}</button>`).join('')
       : ''
 
-    const terminateBtn = state.isHost
-      ? `<button class="btn-danger" id="terminate-btn">Terminate Game</button>`
+    const fillBotsBtn = state.isHost && emptySeats.length > 0
+      ? `<button class="btn-primary" id="fill-bots-btn">Fill with Bots (${emptySeats.length} seat${emptySeats.length !== 1 ? 's' : ''})</button>`
       : ''
 
     container.innerHTML = `
@@ -462,11 +463,30 @@ export function renderGameScreen(container) {
           <h2 class="waiting-title">Waiting for players\u2026</h2>
           <div class="waiting-seats">${rows}</div>
           <div class="form-error waiting-err" role="alert" aria-live="polite"></div>
+          ${changeSeatBtns}
           ${fillBotsBtn}
-          ${terminateBtn}
           <button class="btn-secondary" id="leave-table-btn">Leave Table</button>
         </div>
       </div>`
+
+    container.querySelectorAll('.change-seat-btn').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const newSeat = btn.dataset.seat
+        const errEl = container.querySelector('.waiting-err')
+        errEl.textContent = ''
+        container.querySelectorAll('.change-seat-btn').forEach((b) => { b.disabled = true })
+        btn.textContent = 'Moving\u2026'
+        try {
+          await apiChangeSeat({ tableId, seat: newSeat, sessionId, playerId })
+          state = await getGameState({ tableId, sessionId, playerId })
+          render()
+        } catch (err) {
+          errEl.textContent = err.message || 'Failed to change seat.'
+          container.querySelectorAll('.change-seat-btn').forEach((b) => { b.disabled = false })
+          btn.textContent = `Move to ${newSeat.charAt(0).toUpperCase() + newSeat.slice(1)}`
+        }
+      })
+    })
 
     container.querySelector('#fill-bots-btn')?.addEventListener('click', async () => {
       const btn = container.querySelector('#fill-bots-btn')
@@ -485,21 +505,6 @@ export function renderGameScreen(container) {
         errEl.textContent = err.message || 'Failed to add bots.'
         btn.disabled = false
         btn.textContent = `Fill with Bots (${emptySeats.length} seat${emptySeats.length !== 1 ? 's' : ''})`
-      }
-    })
-
-    container.querySelector('#terminate-btn')?.addEventListener('click', async () => {
-      if (!confirm('Are you sure you want to terminate this game? This cannot be undone.')) return
-      const btn = container.querySelector('#terminate-btn')
-      const errEl = container.querySelector('.waiting-err')
-      btn.disabled = true
-      try {
-        await apiTerminate({ tableId, sessionId, playerId })
-        cleanup()
-        navigate('#/lobby')
-      } catch (err) {
-        errEl.textContent = err.message || 'Failed to terminate game.'
-        btn.disabled = false
       }
     })
 
@@ -730,7 +735,6 @@ export function renderGameScreen(container) {
           : ''}
 
         <div class="game-controls">
-          ${state.isHost ? '<button class="btn-danger btn-sm" id="terminate-btn">Terminate Game</button>' : ''}
           ${leaveGameButtonHtml()}
         </div>
       </div>`
@@ -754,21 +758,6 @@ export function renderGameScreen(container) {
       if (e.target.id === 'last-trick-overlay' || e.target.id === 'last-trick-close') {
         showLastTrick = false
         render()
-      }
-    })
-
-    // Terminate game button (host only, in-game)
-    container.querySelector('#terminate-btn')?.addEventListener('click', async () => {
-      if (!confirm('Are you sure you want to terminate this game? This cannot be undone.')) return
-      const btn = container.querySelector('#terminate-btn')
-      btn.disabled = true
-      try {
-        await apiTerminate({ tableId, sessionId, playerId })
-        cleanup()
-        navigate('#/lobby')
-      } catch (err) {
-        btn.disabled = false
-        console.log('Terminate failed:', { error: err.message })
       }
     })
 

--- a/server/lobby/table.js
+++ b/server/lobby/table.js
@@ -90,13 +90,17 @@ export async function sitAtTable(redis, tableId, playerId, seat) {
   if (table.status === 'playing') {
     throw Object.assign(new Error('Game already in progress'), { code: 'GAME_IN_PROGRESS' })
   }
+  // Check idempotent same-seat before checking seat occupancy
+  const currentSeat = Object.entries(table.seats).find(([, id]) => id === playerId)?.[0]
+  if (currentSeat === seat) {
+    // Already at this exact seat — no-op, return current state
+    return table
+  }
+  if (currentSeat) {
+    throw Object.assign(new Error('Player is already seated at this table'), { code: 'ALREADY_SEATED' })
+  }
   if (table.seats[seat] !== null) {
     throw Object.assign(new Error('Seat is already taken'), { code: 'SEAT_TAKEN' })
-  }
-  // Check player isn't already seated
-  const alreadySeated = Object.values(table.seats).includes(playerId)
-  if (alreadySeated) {
-    throw Object.assign(new Error('Player is already seated at this table'), { code: 'ALREADY_SEATED' })
   }
 
   const updated = {
@@ -189,6 +193,7 @@ export async function saveGameState(redis, tableId, gameState) {
 export async function removePlayerFromTables(redis, playerId) {
   const raw = await redis.hGetAll('lobby:tables')
   const updatedTables = []
+  const terminatedTables = []
   for (const json of Object.values(raw)) {
     const entry = JSON.parse(json)
     if (entry.status !== 'waiting') continue
@@ -197,12 +202,25 @@ export async function removePlayerFromTables(redis, playerId) {
     const seatEntry = Object.entries(table.seats).find(([, id]) => id === playerId)
     if (!seatEntry) continue
     const [seat] = seatEntry
-    const updated = { ...table, seats: { ...table.seats, [seat]: null } }
+    const updatedSeats = { ...table.seats, [seat]: null }
+
+    // If no human players remain, terminate the table
+    const remainingHuman = Object.values(updatedSeats).find((id) => id && !id.startsWith('bot:'))
+    if (!remainingHuman) {
+      terminatedTables.push(table)
+      await terminateTable(redis, table.tableId)
+      console.log('Table terminated on logout — no human players remain:', { tableId: table.tableId, playerId, seat })
+      continue
+    }
+
+    // Transfer host if the departing player was the host
+    const newHostId = table.hostPlayerId === playerId ? remainingHuman : table.hostPlayerId
+    const updated = { ...table, seats: updatedSeats, hostPlayerId: newHostId }
     await saveTable(redis, updated)
     updatedTables.push(updated)
     console.log('Player removed from table on logout:', { tableId: table.tableId, playerId, seat })
   }
-  return updatedTables
+  return { updated: updatedTables, terminated: terminatedTables }
 }
 
 /**
@@ -237,7 +255,24 @@ export async function leaveTable(redis, tableId, playerId) {
     return { table: updated, seat, wasPlaying: true }
   }
 
-  const updated = { ...table, seats: { ...table.seats, [seat]: null } }
+  const updatedSeats = { ...table.seats, [seat]: null }
+
+  // If no human players remain after this seat is vacated, terminate the table
+  const remainingHuman = Object.values(updatedSeats).find((id) => id && !id.startsWith('bot:'))
+  if (!remainingHuman) {
+    await terminateTable(redis, tableId)
+    console.log('Table terminated — no human players remain:', { tableId, playerId, seat })
+    return { terminated: true, seat }
+  }
+
+  // If the departing player was the host, transfer host to the next seated human
+  let newHostId = table.hostPlayerId
+  if (table.hostPlayerId === playerId) {
+    newHostId = remainingHuman
+    console.log('Host left table, transferring host:', { tableId, oldHost: playerId, newHost: newHostId })
+  }
+
+  const updated = { ...table, seats: updatedSeats, hostPlayerId: newHostId }
   await saveTable(redis, updated)
   console.log('Player left waiting table:', { tableId, playerId, seat })
   return { table: updated, seat, wasPlaying: false }
@@ -324,6 +359,49 @@ export async function findTableForPlayer(redis, playerId) {
     return entry.tableId
   }
   return null
+}
+
+/**
+ * Move a seated player from their current seat to a different empty seat.
+ * Only allowed while the table is in 'waiting' status.
+ *
+ * @param {import('redis').RedisClientType} redis
+ * @param {string} tableId
+ * @param {string} playerId
+ * @param {'north'|'east'|'south'|'west'} newSeat
+ * @returns {Promise<{ table: TableState, oldSeat: string, newSeat: string }>}
+ * @throws {Error} If the table is not found, game already started, new seat is taken, or player not seated
+ */
+export async function changeSeat(redis, tableId, playerId, newSeat) {
+  const validSeats = ['north', 'east', 'south', 'west']
+  if (!validSeats.includes(newSeat)) {
+    throw Object.assign(new Error(`Invalid seat: ${newSeat}`), { code: 'INVALID_SEAT' })
+  }
+
+  const table = await getTable(redis, tableId)
+  if (!table) {
+    throw Object.assign(new Error('Table not found'), { code: 'NOT_FOUND' })
+  }
+  if (table.status === 'playing') {
+    throw Object.assign(new Error('Cannot change seats once the game has started'), { code: 'GAME_IN_PROGRESS' })
+  }
+
+  const currentSeat = Object.entries(table.seats).find(([, id]) => id === playerId)?.[0]
+  if (!currentSeat) {
+    throw Object.assign(new Error('You are not seated at this table'), { code: 'NOT_SEATED' })
+  }
+  if (currentSeat === newSeat) {
+    return { table, oldSeat: currentSeat, newSeat }
+  }
+  if (table.seats[newSeat] !== null) {
+    throw Object.assign(new Error('Seat is already taken'), { code: 'SEAT_TAKEN' })
+  }
+
+  const updatedSeats = { ...table.seats, [currentSeat]: null, [newSeat]: playerId }
+  const updated = { ...table, seats: updatedSeats }
+  await saveTable(redis, updated)
+  console.log('Player changed seat:', { tableId, playerId, oldSeat: currentSeat, newSeat })
+  return { table: updated, oldSeat: currentSeat, newSeat }
 }
 
 /**

--- a/server/server.js
+++ b/server/server.js
@@ -22,6 +22,7 @@ import {
   findTableForPlayer,
   leaveTable,
   leaveInProgressGame,
+  changeSeat,
 } from './lobby/table.js'
 import { createGame, placeBid, playCard, submitBlindNilExchange, revealHand, getPlayerView, substitutePlayerWithBot } from './game/state.js'
 import { getSeatForPlayer, validateCardPlay, validateBidTurn } from './anticheat/validate.js'
@@ -382,9 +383,12 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
       const redis = await getRedis()
       const session = await getSession(redis, sessionId)
       if (session) {
-        const updatedTables = await removePlayerFromTables(redis, session.playerId)
-        for (const table of updatedTables) {
+        const { updated, terminated } = await removePlayerFromTables(redis, session.playerId)
+        for (const table of updated) {
           emitLobbyTableUpdated(wss, table)
+        }
+        for (const table of terminated) {
+          emitLobbyTableRemoved(wss, table)
         }
       }
       await deleteSession(redis, sessionId)
@@ -440,7 +444,9 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
       const session = await validateAuthHeaders(redisClient, req)
       const resolvedName = (typeof name === 'string' && name.trim()) ? name.trim() : null
       const table = await createTable(redisClient, { hostPlayerId: session.playerId, name: resolvedName })
-      emitLobbyTableCreated(wss, table)
+      // Auto-seat the host at north
+      const seatedTable = await sitAtTable(redisClient, table.tableId, session.playerId, 'north')
+      emitLobbyTableCreated(wss, seatedTable)
       sendJSON(res, 201, { tableId: table.tableId, name: table.name })
     } catch (err) {
       if (err.code === 'UNAUTHORIZED') return sendJSON(res, 401, { error: err.message })
@@ -583,9 +589,14 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
         return sendJSON(res, 200, { message: 'Left game. A bot has taken your place.' })
       }
 
-      const leftTable = await leaveTable(redisClient, tableId, session.playerId)
-      emitLobbyTableUpdated(wss, leftTable.table)
-      if (wss) wss.broadcast(tableId, 'SEAT_VACATED', { seat: leftTable.seat })
+      const leftResult = await leaveTable(redisClient, tableId, session.playerId)
+      if (leftResult.terminated) {
+        emitLobbyTableRemoved(wss, table)
+        console.log('Player left waiting table, table terminated:', { tableId, playerId: session.playerId })
+        return sendJSON(res, 200, { message: 'Left table. No players remain — table deleted.' })
+      }
+      emitLobbyTableUpdated(wss, leftResult.table)
+      if (wss) wss.broadcast(tableId, 'SEAT_VACATED', { seat: leftResult.seat })
       console.log('Player left table:', { tableId, playerId: session.playerId })
       sendJSON(res, 200, { message: 'Left table.' })
     } catch (err) {
@@ -593,6 +604,32 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
       if (err.code === 'NOT_FOUND') return sendJSON(res, 404, { error: err.message })
       if (err.code === 'NOT_SEATED') return sendJSON(res, 409, { error: err.message })
       console.error('Leave table error:', { tableId, error: err.message })
+      sendJSON(res, 500, { error: 'Internal server error' })
+    }
+  })
+
+  // POST /api/tables/:tableId/change-seat — move to a different empty seat (waiting only)
+  app.post('/api/tables/:tableId/change-seat', async (req, res) => {
+    const { tableId } = req.params
+    const { seat } = req.body ?? {}
+    try {
+      const redisClient = await getRedis()
+      const session = await validateAuthHeaders(redisClient, req)
+      const result = await changeSeat(redisClient, tableId, session.playerId, seat)
+      emitLobbyTableUpdated(wss, result.table)
+      if (wss) {
+        wss.broadcast(tableId, 'SEAT_VACATED', { seat: result.oldSeat })
+        wss.broadcast(tableId, 'SEAT_TAKEN', { seat: result.newSeat })
+      }
+      sendJSON(res, 200, { tableId, seat: result.newSeat })
+    } catch (err) {
+      if (err.code === 'UNAUTHORIZED') return sendJSON(res, 401, { error: err.message })
+      if (err.code === 'NOT_FOUND') return sendJSON(res, 404, { error: err.message })
+      if (err.code === 'GAME_IN_PROGRESS') return sendJSON(res, 409, { error: err.message })
+      if (err.code === 'NOT_SEATED') return sendJSON(res, 409, { error: err.message })
+      if (err.code === 'SEAT_TAKEN') return sendJSON(res, 409, { error: err.message })
+      if (err.code === 'INVALID_SEAT') return sendJSON(res, 400, { error: err.message })
+      console.error('Change seat error:', { tableId, error: err.message })
       sendJSON(res, 500, { error: 'Internal server error' })
     }
   })

--- a/test/integration/game/hostSeat.test.js
+++ b/test/integration/game/hostSeat.test.js
@@ -180,23 +180,18 @@ describe('GET /api/tables/:tableId/state — hostSeat field', { skip }, () => {
     await redis.hDel('lobby:tables', tableId)
   })
 
-  it('hostSeat is null when host has not yet taken a seat', { timeout: 10000 }, async () => {
+  it('host is auto-seated at north on creation — hostSeat is north immediately', { timeout: 10000 }, async () => {
     const { sessionId, playerId } = await loginPlayer(
       server.baseUrl,
       'hs_player1@hstest.spades.invalid',
       'password123',
     )
     const { tableId } = await createTableApi(server.baseUrl, sessionId, playerId)
-    // Seat a different player (not the host) so we can query the state
-    const guest = await loginPlayer(server.baseUrl, 'hs_player2@hstest.spades.invalid', 'password123')
-    await sitAtTable(server.baseUrl, tableId, 'east', guest.sessionId, guest.playerId)
 
-    // Host hasn't sat yet — but we can only query if seated. Seat the host too.
-    await sitAtTable(server.baseUrl, tableId, 'south', sessionId, playerId)
-
+    // Host is already seated at north after creation
     const state = await getGameStateApi(server.baseUrl, tableId, sessionId, playerId)
-    // Host is at south
-    assert.equal(state.hostSeat, 'south')
+    assert.equal(state.status, 'waiting')
+    assert.equal(state.hostSeat, 'north', 'host should be auto-seated at north')
 
     // Cleanup
     await redis.del(`table:${tableId}`)

--- a/test/integration/game/seatChange.test.js
+++ b/test/integration/game/seatChange.test.js
@@ -1,0 +1,269 @@
+/**
+ * Integration tests for table seating updates:
+ *   - Host is auto-seated at north on table creation
+ *   - Table is deleted when no players remain
+ *   - Host is transferred when host leaves a waiting table
+ *   - POST /api/tables/:tableId/change-seat
+ *
+ * Requires a real Redis instance (REDIS_URL) and database (DATABASE_URL).
+ * Tests are skipped when either is not set.
+ */
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import express from 'express'
+import bcrypt from 'bcryptjs'
+import { handler } from '../../../server/server.js'
+import { getDb, closeDb } from '../../../server/db.js'
+import { getRedis, closeRedis } from '../../../server/redis.js'
+
+const skip =
+  !process.env.DATABASE_URL || !process.env.REDIS_URL
+    ? 'DATABASE_URL and REDIS_URL must both be set'
+    : false
+
+async function startTestServer() {
+  const app = express()
+  app.use(express.json())
+  handler(app)
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address()
+      resolve({
+        baseUrl: `http://127.0.0.1:${port}`,
+        close: () => new Promise((res) => server.close(res)),
+      })
+    })
+  })
+}
+
+async function ensurePlayersTable(db) {
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS players (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      email VARCHAR(255) UNIQUE NOT NULL,
+      username VARCHAR(50) UNIQUE NOT NULL,
+      password_hash VARCHAR(255) NOT NULL,
+      is_verified BOOLEAN NOT NULL DEFAULT FALSE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `)
+  await db.query(`DELETE FROM players WHERE email LIKE '%@sctest.spades.invalid'`)
+}
+
+async function insertVerifiedPlayer(db, { email, username, password }) {
+  const hash = await bcrypt.hash(password, 4)
+  const result = await db.query(
+    `INSERT INTO players (email, username, password_hash, is_verified)
+     VALUES ($1, $2, $3, TRUE) RETURNING id`,
+    [email, username, hash],
+  )
+  return result.rows[0].id
+}
+
+async function loginPlayer(baseUrl, email, password) {
+  const res = await fetch(`${baseUrl}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  })
+  return res.json()
+}
+
+async function createTableApi(baseUrl, sessionId, playerId) {
+  const res = await fetch(`${baseUrl}/api/tables`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-session-id': sessionId, 'x-player-id': playerId },
+  })
+  return { status: res.status, body: await res.json() }
+}
+
+async function getStateApi(baseUrl, tableId, sessionId, playerId) {
+  const res = await fetch(`${baseUrl}/api/tables/${tableId}/state`, {
+    headers: { 'x-session-id': sessionId, 'x-player-id': playerId },
+  })
+  return { status: res.status, body: await res.json() }
+}
+
+async function leaveTableApi(baseUrl, tableId, sessionId, playerId) {
+  const res = await fetch(`${baseUrl}/api/tables/${tableId}/leave`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-session-id': sessionId, 'x-player-id': playerId },
+  })
+  return { status: res.status, body: await res.json() }
+}
+
+async function changeSeatApi(baseUrl, tableId, seat, sessionId, playerId) {
+  const res = await fetch(`${baseUrl}/api/tables/${tableId}/change-seat`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-session-id': sessionId, 'x-player-id': playerId },
+    body: JSON.stringify({ seat }),
+  })
+  return { status: res.status, body: await res.json() }
+}
+
+async function sitAtTableApi(baseUrl, tableId, seat, sessionId, playerId) {
+  const res = await fetch(`${baseUrl}/api/tables/${tableId}/sit`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-session-id': sessionId, 'x-player-id': playerId },
+    body: JSON.stringify({ seat }),
+  })
+  return { status: res.status, body: await res.json() }
+}
+
+describe('Table seating updates', { skip }, () => {
+  let server, db, redis
+  const players = []
+
+  before(async () => {
+    db = getDb()
+    redis = await getRedis()
+    await ensurePlayersTable(db)
+    for (let i = 1; i <= 4; i++) {
+      await insertVerifiedPlayer(db, {
+        email: `sc_player${i}@sctest.spades.invalid`,
+        username: `sctest_player${i}`,
+        password: 'password123',
+      })
+    }
+    server = await startTestServer()
+    for (let i = 1; i <= 4; i++) {
+      const data = await loginPlayer(server.baseUrl, `sc_player${i}@sctest.spades.invalid`, 'password123')
+      players.push(data)
+    }
+  })
+
+  after(async () => {
+    await server.close()
+    await closeDb()
+    await closeRedis()
+  })
+
+  it('host is auto-seated at north when creating a table', { timeout: 10000 }, async () => {
+    const host = players[0]
+    const { status, body } = await createTableApi(server.baseUrl, host.sessionId, host.playerId)
+    assert.equal(status, 201)
+    const tableId = body.tableId
+
+    const { status: stateStatus, body: state } = await getStateApi(server.baseUrl, tableId, host.sessionId, host.playerId)
+    assert.equal(stateStatus, 200)
+    assert.equal(state.status, 'waiting')
+    assert.equal(state.seats.north, host.playerId, 'host should be auto-seated at north')
+
+    // Cleanup
+    await redis.del(`table:${tableId}`)
+    await redis.hDel('lobby:tables', tableId)
+  })
+
+  it('table is deleted when the last player leaves', { timeout: 10000 }, async () => {
+    const host = players[0]
+    const { body: createBody } = await createTableApi(server.baseUrl, host.sessionId, host.playerId)
+    const tableId = createBody.tableId
+
+    // Host is now the only player; leave the table
+    const { status: leaveStatus } = await leaveTableApi(server.baseUrl, tableId, host.sessionId, host.playerId)
+    assert.equal(leaveStatus, 200)
+
+    // Table should no longer exist
+    const tableKey = await redis.get(`table:${tableId}`)
+    assert.equal(tableKey, null, 'table Redis key should be deleted')
+    const lobbyEntry = await redis.hGet('lobby:tables', tableId)
+    assert.equal(lobbyEntry, null, 'lobby index entry should be deleted')
+  })
+
+  it('host is transferred to next human when host leaves a waiting table', { timeout: 10000 }, async () => {
+    const host = players[0]
+    const guest = players[1]
+    const { body: createBody } = await createTableApi(server.baseUrl, host.sessionId, host.playerId)
+    const tableId = createBody.tableId
+
+    // Guest joins at east
+    await sitAtTableApi(server.baseUrl, tableId, 'east', guest.sessionId, guest.playerId)
+
+    // Host leaves
+    const { status: leaveStatus } = await leaveTableApi(server.baseUrl, tableId, host.sessionId, host.playerId)
+    assert.equal(leaveStatus, 200)
+
+    // Guest should now be the host
+    const { status: stateStatus, body: state } = await getStateApi(server.baseUrl, tableId, guest.sessionId, guest.playerId)
+    assert.equal(stateStatus, 200)
+    assert.equal(state.isHost, true, 'guest should now be the host')
+    assert.equal(state.seats.north, null, 'north seat should be empty after host left')
+
+    // Cleanup
+    await redis.del(`table:${tableId}`)
+    await redis.hDel('lobby:tables', tableId)
+  })
+
+  it('seated player can change to an empty seat', { timeout: 10000 }, async () => {
+    const host = players[0]
+    const { body: createBody } = await createTableApi(server.baseUrl, host.sessionId, host.playerId)
+    const tableId = createBody.tableId
+
+    // Host is at north — change to east
+    const { status, body } = await changeSeatApi(server.baseUrl, tableId, 'east', host.sessionId, host.playerId)
+    assert.equal(status, 200)
+    assert.equal(body.seat, 'east')
+
+    const { body: state } = await getStateApi(server.baseUrl, tableId, host.sessionId, host.playerId)
+    assert.equal(state.seats.north, null, 'north should be empty after moving')
+    assert.equal(state.seats.east, host.playerId, 'host should now be at east')
+
+    // Cleanup
+    await redis.del(`table:${tableId}`)
+    await redis.hDel('lobby:tables', tableId)
+  })
+
+  it('change-seat returns 409 when target seat is taken', { timeout: 10000 }, async () => {
+    const host = players[0]
+    const guest = players[1]
+    const { body: createBody } = await createTableApi(server.baseUrl, host.sessionId, host.playerId)
+    const tableId = createBody.tableId
+
+    // Guest sits at east
+    await sitAtTableApi(server.baseUrl, tableId, 'east', guest.sessionId, guest.playerId)
+
+    // Host tries to move to east (taken)
+    const { status } = await changeSeatApi(server.baseUrl, tableId, 'east', host.sessionId, host.playerId)
+    assert.equal(status, 409)
+
+    // Cleanup
+    await redis.del(`table:${tableId}`)
+    await redis.hDel('lobby:tables', tableId)
+  })
+
+  it('change-seat returns 409 when player is not seated', { timeout: 10000 }, async () => {
+    const host = players[0]
+    const unseated = players[2]
+    const { body: createBody } = await createTableApi(server.baseUrl, host.sessionId, host.playerId)
+    const tableId = createBody.tableId
+
+    const { status } = await changeSeatApi(server.baseUrl, tableId, 'east', unseated.sessionId, unseated.playerId)
+    assert.equal(status, 409)
+
+    // Cleanup
+    await redis.del(`table:${tableId}`)
+    await redis.hDel('lobby:tables', tableId)
+  })
+
+  it('change-seat returns 400 for invalid seat name', { timeout: 10000 }, async () => {
+    const host = players[0]
+    const { body: createBody } = await createTableApi(server.baseUrl, host.sessionId, host.playerId)
+    const tableId = createBody.tableId
+
+    const { status } = await changeSeatApi(server.baseUrl, tableId, 'invalid', host.sessionId, host.playerId)
+    assert.equal(status, 400)
+
+    // Cleanup
+    await redis.del(`table:${tableId}`)
+    await redis.hDel('lobby:tables', tableId)
+  })
+
+  it('change-seat returns 401 without auth', { timeout: 10000 }, async () => {
+    const res = await fetch(`${server.baseUrl}/api/tables/fake-id/change-seat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ seat: 'east' }),
+    })
+    assert.equal(res.status, 401)
+  })
+})

--- a/test/ws/lobbyEvents.test.js
+++ b/test/ws/lobbyEvents.test.js
@@ -291,16 +291,17 @@ describe('Lobby WebSocket events for Public tables', { skip }, () => {
 
     const msgPromise = waitForType(ws, 'TABLE_UPDATED')
 
+    // PLAYER_A is already at north (auto-seated); PLAYER_B sits at east to trigger TABLE_UPDATED
     await apiRequest(
       server.baseUrl,
       'POST',
       `/api/tables/${tableId}/sit`,
-      { seat: 'west' },
-      { 'x-session-id': SESSION_A, 'x-player-id': PLAYER_A },
+      { seat: 'east' },
+      { 'x-session-id': SESSION_B, 'x-player-id': PLAYER_B },
     )
 
     const [msg] = await msgPromise
-    assert.equal(msg.payload.seats.west, PLAYER_A, 'west seat should be occupied by PLAYER_A')
+    assert.equal(msg.payload.seats.east, PLAYER_B, 'east seat should be occupied by PLAYER_B')
 
     // Cleanup
     await redis.del(`table:${tableId}`)
@@ -311,7 +312,7 @@ describe('Lobby WebSocket events for Public tables', { skip }, () => {
   })
 
   it('TABLE_UPDATED is emitted to the lobby channel when a seated player logs out', { timeout: 15000 }, async () => {
-    // Create a waiting table
+    // Create a waiting table — PLAYER_A auto-seated at north
     const createRes = await apiRequest(
       server.baseUrl,
       'POST',
@@ -322,23 +323,23 @@ describe('Lobby WebSocket events for Public tables', { skip }, () => {
     assert.equal(createRes.status, 201)
     const { tableId } = createRes.body
 
-    // PLAYER_A sits at the table
+    // PLAYER_B sits at east so the table persists when PLAYER_A logs out
     await apiRequest(
       server.baseUrl,
       'POST',
       `/api/tables/${tableId}/sit`,
-      { seat: 'north' },
-      { 'x-session-id': SESSION_A, 'x-player-id': PLAYER_A },
+      { seat: 'east' },
+      { 'x-session-id': SESSION_B, 'x-player-id': PLAYER_B },
     )
 
-    // PLAYER_B subscribes to the lobby
+    // Connect a WS subscriber
     const ws = await wsConnect(server, { 'x-session-id': SESSION_B })
     ws.send(JSON.stringify({ type: 'JOIN_LOBBY', payload: {} }))
     await waitForType(ws, 'JOINED_LOBBY')
 
     const msgPromise = waitForType(ws, 'TABLE_UPDATED')
 
-    // PLAYER_A logs out — seat should be freed and TABLE_UPDATED emitted
+    // PLAYER_A logs out — seat should be freed and TABLE_UPDATED emitted (PLAYER_B still at east)
     const logoutRes = await apiRequest(
       server.baseUrl,
       'POST',


### PR DESCRIPTION
Implements all table seating updates from issue #258:

- Host is automatically seated at North when creating a table
- Table is deleted when no players remain (waiting state)
- Host is transferred to next human when host leaves a waiting table
- Terminate Game buttons removed from waiting room and in-game UI
- Seated players can change to any empty seat via new change-seat endpoint

Closes #258

Generated with [Claude Code](https://claude.ai/code)