### PR TITLE
fix: add railway.toml to set correct start command

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,2 @@
+[deploy]
+startCommand = "node server/app.js"


### PR DESCRIPTION
Railway's Railpack auto-detected `node server/ws/index.js` as the start command, but that file only exports a factory function — it is not a standalone server. Running it directly causes the process to exit immediately with no HTTP server or WebSocket listener started.

Adds `railway.toml` to pin the start command to `node server/app.js` so Railpack always uses the correct entry point.

Closes #273

Generated with [Claude Code](https://claude.ai/code)