### PR TITLE
fix: guard change-seat WebSocket broadcasts against same-seat no-op

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -616,10 +616,12 @@ export function handler(app, { mailer, passwordResetMailer, redis, rateLimitConf
       const redisClient = await getRedis()
       const session = await validateAuthHeaders(redisClient, req)
       const result = await changeSeat(redisClient, tableId, session.playerId, seat)
-      emitLobbyTableUpdated(wss, result.table)
-      if (wss) {
-        wss.broadcast(tableId, 'SEAT_VACATED', { seat: result.oldSeat })
-        wss.broadcast(tableId, 'SEAT_TAKEN', { seat: result.newSeat })
+      if (result.oldSeat !== result.newSeat) {
+        emitLobbyTableUpdated(wss, result.table)
+        if (wss) {
+          wss.broadcast(tableId, 'SEAT_VACATED', { seat: result.oldSeat })
+          wss.broadcast(tableId, 'SEAT_TAKEN', { seat: result.newSeat })
+        }
       }
       sendJSON(res, 200, { tableId, seat: result.newSeat })
     } catch (err) {

--- a/test/integration/game/seatChange.test.js
+++ b/test/integration/game/seatChange.test.js
@@ -266,4 +266,22 @@ describe('Table seating updates', { skip }, () => {
     })
     assert.equal(res.status, 401)
   })
+
+  it('change-seat with same seat is a no-op and returns 200 with unchanged seat', { timeout: 10000 }, async () => {
+    const host = players[0]
+    const { body: createBody } = await createTableApi(server.baseUrl, host.sessionId, host.playerId)
+    const tableId = createBody.tableId
+
+    // Host is at north — change to north again (same seat)
+    const { status, body } = await changeSeatApi(server.baseUrl, tableId, 'north', host.sessionId, host.playerId)
+    assert.equal(status, 200)
+    assert.equal(body.seat, 'north')
+
+    const { body: state } = await getStateApi(server.baseUrl, tableId, host.sessionId, host.playerId)
+    assert.equal(state.seats.north, host.playerId, 'host should still be at north')
+
+    // Cleanup
+    await redis.del(`table:${tableId}`)
+    await redis.hDel('lobby:tables', tableId)
+  })
 })


### PR DESCRIPTION
When a player calls `POST /api/tables/:tableId/change-seat` with their current seat, `changeSeat` returns a no-op result where `oldSeat === newSeat`. The handler was unconditionally broadcasting `SEAT_VACATED` and `SEAT_TAKEN` events in this case, firing two spurious WebSocket messages to all connected clients.

Guard the broadcasts and lobby update with `result.oldSeat !== result.newSeat` so they only fire when the seat actually changed. Added a regression test covering the same-seat no-op path.

Closes #279

Generated with [Claude Code](https://claude.ai/code)