### PR TITLE
feat: add yellow/red color states to tricks taken display

### DIFF
--- a/client/web/index.html
+++ b/client/web/index.html
@@ -479,6 +479,14 @@
         color: #66bb6a;
       }
 
+      .bid-tricks-count.bid-tricks--needs-all strong {
+        color: #f9c74f;
+      }
+
+      .bid-tricks-count.bid-tricks--impossible strong {
+        color: #e57373;
+      }
+
       .bid-tricks-sep {
         width: 1px;
         height: 28px;

--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -164,6 +164,29 @@ export function applyDelta(state, msg, playerId) {
 const TEAM = { north: 'ns', south: 'ns', east: 'ew', west: 'ew' }
 
 /**
+ * Determine the CSS modifier class for the tricks-taken count based on bid progress.
+ *
+ * Priority (highest → lowest):
+ *   bid-tricks--met        : tricks >= bid (team already made their bid)
+ *   bid-tricks--impossible : tricks + remaining < bid (cannot make bid)
+ *   bid-tricks--needs-all  : tricks + remaining === bid (must win every remaining trick)
+ *   ''                     : still achievable with tricks to spare
+ *
+ * @param {number|null|undefined} bid - Team's bid target
+ * @param {number} tricks - Tricks taken so far this hand
+ * @param {number} completedCount - Number of tricks completed so far (0–13)
+ * @returns {string} CSS class modifier (without leading space)
+ */
+export function tricksCountClass(bid, tricks, completedCount) {
+  if (typeof bid !== 'number') return ''
+  if (tricks >= bid) return 'bid-tricks--met'
+  const remaining = 13 - completedCount
+  if (tricks + remaining < bid) return 'bid-tricks--impossible'
+  if (tricks + remaining === bid) return 'bid-tricks--needs-all'
+  return ''
+}
+
+/**
  * Render the team bid target and current tricks bar shown below the scoreboard during play.
  * Provides a quick at-a-glance view: each team's bid target vs. tricks taken this hand.
  * @param {object} state
@@ -175,13 +198,14 @@ function teamBidTricksHtml(state) {
     { label: 'E/W', key: 'ew', seats: ['east', 'west'] },
   ]
 
+  const completedCount = state.completedTricks?.length ?? 0
+
   const cols = teams.map(({ label, key, seats }) => {
     const bid = state.teamBids?.[key]
     const tricks = (state.tricksWon?.[seats[0]] ?? 0) + (state.tricksWon?.[seats[1]] ?? 0)
     const bidDisplay = bid !== null && bid !== undefined ? bid : '–'
-    const needsMore = typeof bid === 'number' && tricks < bid
-    const metBid = typeof bid === 'number' && tricks >= bid
-    const tricksCls = metBid ? ' bid-tricks--met' : (needsMore ? '' : '')
+    const cls = tricksCountClass(bid, tricks, completedCount)
+    const tricksCls = cls ? ` ${cls}` : ''
     return `<div class="bid-tricks-team">
       <span class="bid-tricks-label">${esc(label)}</span>
       <span class="bid-tricks-target">Bid <strong>${bidDisplay}</strong></span>

--- a/test/unit/web/tricksCountClass.test.js
+++ b/test/unit/web/tricksCountClass.test.js
@@ -1,0 +1,71 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { tricksCountClass } from '../../../client/web/src/screens/game.js'
+
+// tricksCountClass(bid, tricks, completedCount) returns the CSS modifier class
+// for the tricks-taken number based on bid progress.
+//
+// Rules:
+//   - 'bid-tricks--met'       : tricks >= bid (team made or exceeded their bid)
+//   - 'bid-tricks--impossible': tricks + remaining < bid (cannot make bid)
+//   - 'bid-tricks--needs-all' : tricks + remaining === bid (need every remaining trick)
+//   - ''                      : otherwise (still achievable with room to spare)
+//
+// remaining = 13 - completedCount
+// Priority: met > impossible > needs-all > default
+
+describe('tricksCountClass', { timeout: 2000 }, () => {
+  // ── bid met ──────────────────────────────────────────────────────────────
+  it('returns bid-tricks--met when tricks equal bid', { timeout: 2000 }, () => {
+    assert.equal(tricksCountClass(5, 5, 8), 'bid-tricks--met')
+  })
+
+  it('returns bid-tricks--met when tricks exceed bid (bags)', { timeout: 2000 }, () => {
+    assert.equal(tricksCountClass(5, 7, 10), 'bid-tricks--met')
+  })
+
+  it('returns bid-tricks--met even when no tricks remain', { timeout: 2000 }, () => {
+    assert.equal(tricksCountClass(5, 5, 13), 'bid-tricks--met')
+  })
+
+  // ── impossible ───────────────────────────────────────────────────────────
+  it('returns bid-tricks--impossible when tricks + remaining < bid', { timeout: 2000 }, () => {
+    // bid=8, tricks=3, remaining=4 → 3+4=7 < 8
+    assert.equal(tricksCountClass(8, 3, 9), 'bid-tricks--impossible')
+  })
+
+  it('returns bid-tricks--impossible with zero tricks remaining', { timeout: 2000 }, () => {
+    // bid=6, tricks=4, remaining=0 → cannot make 6
+    assert.equal(tricksCountClass(6, 4, 13), 'bid-tricks--impossible')
+  })
+
+  // ── needs all ────────────────────────────────────────────────────────────
+  it('returns bid-tricks--needs-all when team needs every remaining trick', { timeout: 2000 }, () => {
+    // bid=8, tricks=5, remaining=3 → 5+3=8 exactly
+    assert.equal(tricksCountClass(8, 5, 10), 'bid-tricks--needs-all')
+  })
+
+  it('returns bid-tricks--needs-all at start of hand when bid equals 13', { timeout: 2000 }, () => {
+    // bid=13, tricks=0, remaining=13 → 0+13=13 exactly
+    assert.equal(tricksCountClass(13, 0, 0), 'bid-tricks--needs-all')
+  })
+
+  // ── default (achievable with room to spare) ───────────────────────────────
+  it('returns empty string when bid is achievable with room to spare', { timeout: 2000 }, () => {
+    // bid=5, tricks=2, remaining=7 → 2+7=9 > 5, no pressure
+    assert.equal(tricksCountClass(5, 2, 6), '')
+  })
+
+  it('returns empty string at start of hand with reasonable bid', { timeout: 2000 }, () => {
+    assert.equal(tricksCountClass(4, 0, 0), '')
+  })
+
+  // ── no bid set ────────────────────────────────────────────────────────────
+  it('returns empty string when bid is null', { timeout: 2000 }, () => {
+    assert.equal(tricksCountClass(null, 0, 0), '')
+  })
+
+  it('returns empty string when bid is undefined', { timeout: 2000 }, () => {
+    assert.equal(tricksCountClass(undefined, 3, 5), '')
+  })
+})


### PR DESCRIPTION
Add yellow/red color states to the tricks taken number shown at the top during play:

- 🟡 Yellow: team must win every remaining trick to make their bid
- 🔴 Red: team cannot make their bid even if they win all remaining tricks

Extracts a testable `tricksCountClass()` helper and adds 11 unit tests.

Closes #283

Generated with [Claude Code](https://claude.ai/code)