### PR TITLE
docs: add completed task entry for issue #291 in TASKS.md

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -28,6 +28,7 @@
 - [x] `P1` Add logout button to the lobby screen (`client/web/src/screens/lobby.js`): calls `POST /api/auth/logout`, clears `sessionStorage`, and redirects to the login screen
 - [x] `DEV` Host terminate game — `POST /api/tables/:tableId/terminate` lets the table host immediately end a game at any point (waiting or in progress). Deletes the table and game state from Redis. All seated players are redirected to the lobby on their next poll (404 from state endpoint). A "Terminate Game" button with a browser confirm prompt is shown to the host on both the waiting screen and during active play (`server/lobby/table.js`, `server/server.js`, `client/web/src/api.js`, `client/web/src/screens/game.js`).
 - [x] `P1` Leave table — `POST /api/tables/:tableId/leave` removes the requesting player from their seat. If the table is 'waiting', the seat is vacated. If a game is in progress, the vacated seat is immediately filled by a bot (`bot:<seat>`) and the game continues uninterrupted (see PRD Section 6.4.7). A "Leave Table" button on the waiting screen calls this endpoint and redirects the player to the lobby on success (`server/lobby/table.js`, `server/server.js`, `client/web/src/api.js`, `client/web/src/screens/game.js`).
+- [x] `P2` Remove redundant mid-bar team bid summary (issue #291): removed `teamBidSummaryHtml` function and its render call from `client/web/src/screens/game.js`; the middle-bar display of individual bid contributions was redundant with the scoreboard. Associated tests in `test/unit/web/bidSummary.test.js` also removed.
 
 ---
 


### PR DESCRIPTION
Mark issue #291 (remove redundant mid-bar team bid summary) as complete in docs/TASKS.md as required by CLAUDE.md guidelines.

Closes #294

Generated with [Claude Code](https://claude.ai/code)