### PR TITLE
fix: compute validCards client-side to prevent hand information leak

### DIFF
--- a/client/web/src/legalPlays.js
+++ b/client/web/src/legalPlays.js
@@ -1,0 +1,52 @@
+/**
+ * Pure game-rule helpers shared between client-side delta handling and
+ * server-side logic.  Must have zero Node.js / server-only dependencies so
+ * that it can be imported directly by the browser bundle.
+ */
+
+/**
+ * Return the subset of cards in hand that the player may legally play.
+ *
+ * Mirrors server/game/trick.js:getLegalPlays — keep the two in sync if the
+ * rules ever change.
+ *
+ * @param {Card[]} hand - The player's current hand
+ * @param {Array<{seat: string, card: Card}>} currentTrick - Cards already played this trick
+ * @param {boolean} spadesbroken - Whether spades have been broken this hand
+ * @param {boolean} isFirstTrick - Whether this is the very first trick of the hand
+ * @returns {Card[]}
+ */
+export function getLegalPlays(hand, currentTrick, spadesbroken, isFirstTrick) {
+  const isLeading = currentTrick.length === 0
+
+  if (isLeading) {
+    if (isFirstTrick) {
+      // Cannot lead spades on the first trick of a hand
+      const nonSpades = hand.filter((c) => c.suit !== 'spades')
+      return nonSpades.length > 0 ? nonSpades : hand
+    }
+    if (!spadesbroken) {
+      // Cannot lead spades until they are broken
+      const nonSpades = hand.filter((c) => c.suit !== 'spades')
+      return nonSpades.length > 0 ? nonSpades : hand
+    }
+    // Spades are broken — any card is legal to lead
+    return hand
+  }
+
+  // Following a trick — must follow the led suit if possible
+  const ledSuit = currentTrick[0].card.suit
+  const canFollow = hand.filter((c) => c.suit === ledSuit)
+  if (canFollow.length > 0) {
+    return canFollow
+  }
+
+  // Cannot follow suit — on the first trick, may not play spades if alternatives exist
+  if (isFirstTrick) {
+    const nonSpades = hand.filter((c) => c.suit !== 'spades')
+    if (nonSpades.length > 0) return nonSpades
+  }
+
+  // No suit-follow requirement and not restricted — any card is legal
+  return hand
+}

--- a/client/web/src/screens/game.js
+++ b/client/web/src/screens/game.js
@@ -16,6 +16,7 @@ import { HOLD_DURATIONS, detectCompletedTrick, isHandTransition, trickHoldHtml }
 import { createInputBlocker } from '../inputBlock.js'
 import { endOfHandSummaryHtml } from '../endOfHandSummary.js'
 import { BAG_ICON, CROWN_ICON } from '../icons.js'
+import { getLegalPlays } from '../legalPlays.js'
 
 const SUIT_SYMBOL = { spades: '\u2660', hearts: '\u2665', diamonds: '\u2666', clubs: '\u2663' }
 const PARTNER = { north: 'south', south: 'north', east: 'west', west: 'east' }
@@ -88,19 +89,35 @@ export function applyDelta(state, msg, playerId) {
     case 'CARD_PLAYED': {
       const { seat, card, currentTrick, nextPlayerSeat, spadesBroken } = payload
       let myHand = state.myHand
+      let mySeat
       if (myHand && state.players) {
-        const mySeat = Object.entries(state.players).find(([, id]) => id === playerId)?.[0]
+        mySeat = Object.entries(state.players).find(([, id]) => id === playerId)?.[0]
         if (seat === mySeat) {
           const cardKey = `${card.suit}-${card.rank}`
           myHand = myHand.filter((c) => `${c.suit}-${c.rank}` !== cardKey)
         }
       }
+
+      const updatedTrick = currentTrick ?? state.currentTrick
+      const updatedSpadesBroken = spadesBroken ?? state.spadesbroken
+      const isFirstTrick = (state.completedTricks?.length ?? 0) === 0
+
+      let validCards
+      if (mySeat !== undefined && nextPlayerSeat === mySeat && myHand) {
+        // It's my turn next. If the trick already has 4 cards the hand is about
+        // to complete (TRICK_COMPLETE will follow) and I will lead — treat it as
+        // an empty trick so the legal-play check is correct.
+        const trickForCheck = updatedTrick.length === 4 ? [] : updatedTrick
+        validCards = getLegalPlays(myHand, trickForCheck, updatedSpadesBroken, isFirstTrick)
+      }
+
       return {
         ...state,
-        currentTrick: currentTrick ?? state.currentTrick,
+        currentTrick: updatedTrick,
         currentPlayerSeat: nextPlayerSeat ?? state.currentPlayerSeat,
-        spadesbroken: spadesBroken ?? state.spadesbroken,
+        spadesbroken: updatedSpadesBroken,
         myHand,
+        validCards,
       }
     }
 
@@ -119,11 +136,23 @@ export function applyDelta(state, msg, playerId) {
       const trick = { winner: winnerSeat, plays }
       const newTricksWon = { ...state.tricksWon }
       newTricksWon[winnerSeat] = (newTricksWon[winnerSeat] ?? 0) + 1
+
+      // Recompute validCards for the winner who now leads the next trick.
+      // After this trick completes, isFirstTrick is always false (at least one trick done).
+      let validCards
+      if (state.players && state.myHand) {
+        const mySeat = Object.entries(state.players).find(([, id]) => id === playerId)?.[0]
+        if (winnerSeat === mySeat) {
+          validCards = getLegalPlays(state.myHand, [], state.spadesbroken, false)
+        }
+      }
+
       return {
         ...state,
         currentTrick: [],
         completedTricks: [...(state.completedTricks || []), trick],
         tricksWon: newTricksWon,
+        validCards,
       }
     }
 
@@ -603,7 +632,7 @@ export function renderGameScreen(container) {
           const isValid = state.validCards.some((c) => `${c.suit}-${c.rank}` === key)
           return isValid ? 'card-valid' : 'card-invalid'
         }
-        return 'card-play'  // fallback when server hasn't sent validCards
+        return 'card-play'  // fallback when validCards hasn't been computed yet
       }
       return ''
     }

--- a/test/unit/web/gameEventHandling.test.js
+++ b/test/unit/web/gameEventHandling.test.js
@@ -173,6 +173,67 @@ describe('applyDelta', { timeout: 2000 }, () => {
       assert.equal(result.spadesbroken, false)
     })
 
+    it('sets validCards when nextPlayerSeat is the current player', { timeout: 2000 }, () => {
+      // East played a heart; north (me) is next to follow suit or play off-suit
+      const trick = [{ seat: 'east', card: { suit: 'hearts', rank: '7' } }]
+      const result = applyDelta(baseState, {
+        type: 'CARD_PLAYED',
+        payload: {
+          seat: 'east',
+          card: { suit: 'hearts', rank: '7' },
+          currentTrick: trick,
+          nextPlayerSeat: 'north',
+          spadesBroken: false,
+        },
+      }, playerId)
+      // myHand has a heart (K), so only that card should be legal
+      assert.ok(Array.isArray(result.validCards), 'validCards should be an array')
+      assert.ok(result.validCards.some((c) => c.suit === 'hearts' && c.rank === 'K'),
+        'should include the heart from hand (must follow suit)')
+      assert.ok(!result.validCards.some((c) => c.suit === 'spades'),
+        'should not include spades when hearts can be followed')
+    })
+
+    it('clears validCards when nextPlayerSeat is another player', { timeout: 2000 }, () => {
+      const trick = [{ seat: 'north', card: { suit: 'hearts', rank: 'K' } }]
+      const result = applyDelta({ ...baseState, validCards: [{ suit: 'hearts', rank: 'K' }] }, {
+        type: 'CARD_PLAYED',
+        payload: {
+          seat: 'north',
+          card: { suit: 'hearts', rank: 'K' },
+          currentTrick: trick,
+          nextPlayerSeat: 'east',
+          spadesBroken: false,
+        },
+      }, playerId)
+      assert.equal(result.validCards, undefined)
+    })
+
+    it('excludes spades from validCards when spades not broken and leading', { timeout: 2000 }, () => {
+      // Three cards played — north (me) wins and will lead next (treat 4-card trick as empty)
+      const fourCardTrick = [
+        { seat: 'east', card: { suit: 'hearts', rank: '7' } },
+        { seat: 'south', card: { suit: 'hearts', rank: '2' } },
+        { seat: 'west', card: { suit: 'hearts', rank: '3' } },
+        { seat: 'north', card: { suit: 'hearts', rank: 'K' } },
+      ]
+      const stateWithSpadeTrick = { ...baseState, completedTricks: [{ winner: 'east', plays: [] }] }
+      const result = applyDelta(stateWithSpadeTrick, {
+        type: 'CARD_PLAYED',
+        payload: {
+          seat: 'north',
+          card: { suit: 'hearts', rank: 'K' },
+          currentTrick: fourCardTrick,
+          nextPlayerSeat: 'north',
+          spadesBroken: false,
+        },
+      }, playerId)
+      // Player is about to lead; spades not broken — spade A should be excluded
+      assert.ok(Array.isArray(result.validCards))
+      assert.ok(!result.validCards.some((c) => c.suit === 'spades'),
+        'should exclude spades when not broken and player is leading')
+    })
+
     it('removes played card from myHand when it is the current player\'s card', { timeout: 2000 }, () => {
       const card = { suit: 'hearts', rank: 'K' }
       const result = applyDelta(baseState, {
@@ -334,6 +395,39 @@ describe('applyDelta', { timeout: 2000 }, () => {
       assert.equal(result.completedTricks.length, 2)
       assert.equal(result.tricksWon.north, 1)
       assert.equal(result.tricksWon.east, 1)
+    })
+
+    it('sets validCards when I win the trick and will lead next', { timeout: 2000 }, () => {
+      // north (me) wins — should get validCards for leading next trick
+      const result = applyDelta({ ...playingState, spadesbroken: false }, {
+        type: 'TRICK_COMPLETE',
+        payload: { winnerSeat: 'north', plays: playingState.currentTrick },
+      }, playerId)
+      assert.ok(Array.isArray(result.validCards), 'validCards should be set for trick winner')
+      // myHand has spades A, hearts K, clubs 7. Spades not broken → spade should be excluded.
+      assert.ok(!result.validCards.some((c) => c.suit === 'spades'),
+        'should exclude spades when not broken and player leads')
+      assert.ok(result.validCards.some((c) => c.suit === 'hearts' || c.suit === 'clubs'),
+        'should include non-spade cards')
+    })
+
+    it('clears validCards when another player wins the trick', { timeout: 2000 }, () => {
+      const stateWithValidCards = { ...playingState, validCards: [{ suit: 'hearts', rank: 'K' }] }
+      const result = applyDelta(stateWithValidCards, {
+        type: 'TRICK_COMPLETE',
+        payload: { winnerSeat: 'east', plays: playingState.currentTrick },
+      }, playerId)
+      assert.equal(result.validCards, undefined)
+    })
+
+    it('includes spades in validCards when spades are broken and I lead', { timeout: 2000 }, () => {
+      const result = applyDelta({ ...playingState, spadesbroken: true }, {
+        type: 'TRICK_COMPLETE',
+        payload: { winnerSeat: 'north', plays: playingState.currentTrick },
+      }, playerId)
+      assert.ok(Array.isArray(result.validCards))
+      // All cards should be legal when leading after spades broken
+      assert.equal(result.validCards.length, playingState.myHand.length)
     })
   })
 


### PR DESCRIPTION
Including `validCards` in a broadcast `CARD_PLAYED` event would expose the next player's legal cards to all other players at the table — a card visibility security violation.

Instead, compute `validCards` entirely on the client in `applyDelta`:
- `CARD_PLAYED`: when `nextPlayerSeat` is me, call `getLegalPlays` with the current trick (or empty trick if 4 cards played, meaning I lead next)
- `TRICK_COMPLETE`: when I win the trick, call `getLegalPlays` with an empty trick since I lead the next one

A shared `legalPlays.js` module mirrors `server/game/trick.js:getLegalPlays` with no Node.js dependencies so the browser bundle can import it directly.

Closes #295

Generated with [Claude Code](https://claude.ai/code)