### PR TITLE
feat: wire up build indicator in main.js

### DIFF
--- a/client/web/src/main.js
+++ b/client/web/src/main.js
@@ -1,4 +1,5 @@
 import { addRoute, init } from './router.js'
+import { renderBuildIndicator } from './buildIndicator.js'
 import { renderLoginScreen } from './screens/login.js'
 import { renderRegisterScreen } from './screens/register.js'
 import { renderVerifyEmailSuccess, renderVerifyEmailError, renderVerifyEmailExpired } from './screens/verifyEmail.js'
@@ -49,3 +50,7 @@ if (sessionId && authOnlyScreens.has(currentRoute)) {
 }
 
 init(app)
+
+renderBuildIndicator().then(html => {
+  if (html) document.body.insertAdjacentHTML('beforeend', html)
+})


### PR DESCRIPTION
Import renderBuildIndicator from buildIndicator.js and call it after init(app) so the git commit hash overlay is appended to the DOM on page load.

Closes #301

Generated with [Claude Code](https://claude.ai/code)