### PR TITLE
fix: derive GIT_COMMIT_SHA from git at startup when env var is absent

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -3,9 +3,20 @@ import { createServer } from 'http'
 import { readFileSync } from 'fs'
 import { fileURLToPath } from 'url'
 import { dirname, join } from 'path'
+import { execSync } from 'child_process'
 import { handler } from './server.js'
 import { getRedis } from './redis.js'
 import { createWsServer } from './ws/index.js'
+
+// If GIT_COMMIT_SHA isn't provided by CI, derive it from git at startup so
+// the build indicator works in non-CI environments (local dev, self-hosted).
+if (!process.env.GIT_COMMIT_SHA) {
+  try {
+    process.env.GIT_COMMIT_SHA = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim()
+  } catch {
+    // Not a git repo or git unavailable — leave unset; /api/build-info returns null
+  }
+}
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 

--- a/test/unit/gitStartupFallback.test.js
+++ b/test/unit/gitStartupFallback.test.js
@@ -1,0 +1,105 @@
+/**
+ * Regression test for the git startup fallback added to app.js.
+ *
+ * Bug: In non-CI environments where GIT_COMMIT_SHA is not injected by the
+ * pipeline, /api/build-info returns { commitShort: null } because the env
+ * var is never set.
+ *
+ * Fix: app.js derives GIT_COMMIT_SHA from `git rev-parse HEAD` at startup
+ * when the env var is absent, so the indicator shows the actual commit hash.
+ *
+ * These tests verify the two key behaviors of that fallback:
+ *  1. When GIT_COMMIT_SHA is absent, the fallback sets it to a valid full SHA.
+ *  2. When GIT_COMMIT_SHA is already set (by CI), the fallback leaves it alone.
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { execSync } from 'node:child_process'
+
+/** Reproduce the exact startup-fallback logic from app.js. */
+function applyGitFallback() {
+  if (!process.env.GIT_COMMIT_SHA) {
+    try {
+      process.env.GIT_COMMIT_SHA = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim()
+    } catch {
+      // Not a git repo or git not available — leave unset
+    }
+  }
+}
+
+describe('app.js git startup fallback', () => {
+  it('sets GIT_COMMIT_SHA to a 40-char hex SHA when the env var is absent', { timeout: 5000 }, () => {
+    const saved = process.env.GIT_COMMIT_SHA
+    try {
+      delete process.env.GIT_COMMIT_SHA
+
+      applyGitFallback()
+
+      // In a git repository (which CI always is), the fallback must produce a valid SHA.
+      // If git is unavailable the key stays absent — that case is handled gracefully.
+      if (Object.hasOwn(process.env, 'GIT_COMMIT_SHA')) {
+        assert.match(
+          process.env.GIT_COMMIT_SHA,
+          /^[0-9a-f]{40}$/,
+          'fallback SHA must be a 40-character lowercase hex string',
+        )
+      }
+    } finally {
+      if (saved !== undefined) {
+        process.env.GIT_COMMIT_SHA = saved
+      } else {
+        delete process.env.GIT_COMMIT_SHA
+      }
+    }
+  })
+
+  it('does not override GIT_COMMIT_SHA when already set (CI-injected value wins)', { timeout: 5000 }, () => {
+    const saved = process.env.GIT_COMMIT_SHA
+    const ciSha = 'abc1234def5678901234567890abcdef12345678'
+    try {
+      process.env.GIT_COMMIT_SHA = ciSha
+
+      applyGitFallback()
+
+      assert.equal(
+        process.env.GIT_COMMIT_SHA,
+        ciSha,
+        'CI-provided value must not be overwritten by the git fallback',
+      )
+    } finally {
+      if (saved !== undefined) {
+        process.env.GIT_COMMIT_SHA = saved
+      } else {
+        delete process.env.GIT_COMMIT_SHA
+      }
+    }
+  })
+
+  it('leaves GIT_COMMIT_SHA unset when git is unavailable (no-op on failure)', { timeout: 5000 }, () => {
+    const saved = process.env.GIT_COMMIT_SHA
+    try {
+      delete process.env.GIT_COMMIT_SHA
+
+      // Simulate the fallback with a failing git command
+      if (!process.env.GIT_COMMIT_SHA) {
+        try {
+          execSync('git rev-parse --no-such-flag-that-fails-12345', { encoding: 'utf8' })
+        } catch {
+          // intentional — env var stays unset
+        }
+      }
+
+      assert.equal(
+        Object.hasOwn(process.env, 'GIT_COMMIT_SHA'),
+        false,
+        'env var must remain absent when the git command fails',
+      )
+    } finally {
+      if (saved !== undefined) {
+        process.env.GIT_COMMIT_SHA = saved
+      } else {
+        delete process.env.GIT_COMMIT_SHA
+      }
+    }
+  })
+})


### PR DESCRIPTION
When GIT_COMMIT_SHA is not injected by CI (local dev, self-hosted),
app.js now runs `git rev-parse HEAD` at startup so /api/build-info
returns the real commit hash instead of null.

Closes #301

Generated with [Claude Code](https://claude.ai/code)