### PR TITLE
feat: wire InfoPanel as a persistent right-side drawer

### DIFF
--- a/client/web/index.html
+++ b/client/web/index.html
@@ -1493,6 +1493,117 @@
         color: #e06b6b;
         border: 1px solid #7a3a3a;
       }
+
+      /* ── Info Panel — right-side collapsible drawer ──────────────────── */
+      #info-panel-root {
+        position: fixed;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 50;
+        pointer-events: none;
+        overflow: visible;
+      }
+
+      .info-panel {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        width: 260px;
+        background: #1e1e1e;
+        border-left: 1px solid #2e2e2e;
+        display: flex;
+        flex-direction: column;
+        transform: translateX(0);
+        transition: transform 0.2s ease;
+        pointer-events: all;
+        box-shadow: -2px 0 8px rgba(0, 0, 0, 0.4);
+      }
+
+      .info-panel.collapsed {
+        transform: translateX(260px);
+      }
+
+      .info-panel-toggle {
+        position: absolute;
+        right: 100%;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 28px;
+        height: 56px;
+        background: #1e1e1e;
+        border: 1px solid #2e2e2e;
+        border-right: none;
+        border-radius: 6px 0 0 6px;
+        cursor: pointer;
+        color: #888;
+        font-size: 0.8rem;
+        padding: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        pointer-events: all;
+        box-shadow: -2px 0 6px rgba(0, 0, 0, 0.3);
+      }
+
+      .info-panel-toggle:hover {
+        background: #252525;
+        color: #e8e8e8;
+      }
+
+      .info-panel-toggle::before {
+        content: '\25B6';
+      }
+
+      .info-panel.collapsed .info-panel-toggle::before {
+        content: '\25C0';
+      }
+
+      .info-tab-bar {
+        display: flex;
+        border-bottom: 1px solid #2e2e2e;
+        flex-shrink: 0;
+      }
+
+      .info-tab-btn {
+        flex: 1;
+        padding: 0.5rem 0.25rem;
+        background: transparent;
+        color: #888;
+        border: none;
+        border-bottom: 2px solid transparent;
+        font-size: 0.78rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: color 0.15s, border-color 0.15s;
+        margin-bottom: -1px;
+      }
+
+      .info-tab-btn:hover {
+        color: #e8e8e8;
+      }
+
+      .info-tab-btn.active {
+        color: #66bb6a;
+        border-bottom-color: #66bb6a;
+      }
+
+      .info-tab-content {
+        flex: 1;
+        overflow-y: auto;
+        padding: 0.75rem;
+      }
+
+      .info-tab-content .friends-list {
+        max-height: none;
+      }
+
+      .history-content p {
+        color: #888;
+        font-size: 0.85rem;
+        padding: 0.5rem 0;
+      }
     </style>
   </head>
   <body>

--- a/client/web/src/main.js
+++ b/client/web/src/main.js
@@ -9,6 +9,7 @@ import { renderLobbyScreen } from './screens/lobby.js'
 import { renderCreateTableScreen } from './screens/createTable.js'
 import { renderJoinTableScreen } from './screens/joinTable.js'
 import { renderGameScreen } from './screens/game.js'
+import { renderInfoPanel } from './infoPanel.js'
 
 const app = document.getElementById('app')
 
@@ -54,3 +55,33 @@ init(app)
 renderBuildIndicator().then(html => {
   if (html) document.body.insertAdjacentHTML('beforeend', html)
 })
+
+// Global info panel — persists across screen navigation, visible on all authenticated screens.
+let globalInfoPanel = null
+
+function syncInfoPanel() {
+  const sessionId = sessionStorage.getItem('sessionId')
+  const playerId = sessionStorage.getItem('playerId')
+  const route = window.location.hash.split('?')[0]
+
+  if (!sessionId || !playerId || authOnlyScreens.has(route)) {
+    if (globalInfoPanel) { globalInfoPanel.stop(); globalInfoPanel = null }
+    const root = document.getElementById('info-panel-root')
+    if (root) root.innerHTML = ''
+    return
+  }
+
+  if (globalInfoPanel) return
+
+  let root = document.getElementById('info-panel-root')
+  if (!root) {
+    root = document.createElement('div')
+    root.id = 'info-panel-root'
+    document.body.appendChild(root)
+  }
+
+  globalInfoPanel = renderInfoPanel({ mountEl: root, sessionId, playerId })
+}
+
+syncInfoPanel()
+window.addEventListener('hashchange', syncInfoPanel)

--- a/client/web/src/screens/lobby.js
+++ b/client/web/src/screens/lobby.js
@@ -2,7 +2,6 @@ import { navigate } from '../router.js'
 import { logoutUser, listLobbyTables } from '../api.js'
 import { redirectIfSeated } from '../redirectIfSeated.js'
 import { createLobbySocket, buildWsUrl } from '../gameSocket.js'
-import { renderInfoPanel } from '../infoPanel.js'
 
 /**
  * Apply a single lobby WebSocket event to a table map.
@@ -67,7 +66,6 @@ export async function renderLobbyScreen(container) {
           <p class="table-list-empty">Loading tables\u2026</p>
         </div>
       </div>
-      <div id="info-panel-mount"></div>
       <div class="lobby-actions">
         <button id="create-table-btn" class="btn-primary">Create Table</button>
         <button id="logout-btn" class="btn-link">Log out</button>
@@ -215,16 +213,9 @@ export async function renderLobbyScreen(container) {
     },
   })
 
-  // Mount the tabbed info panel (friends + history) with periodic polling
-  const infoPanelMount = container.querySelector('#info-panel-mount')
-  const infoPanel = infoPanelMount
-    ? renderInfoPanel({ mountEl: infoPanelMount, sessionId, playerId })
-    : null
-
   // Unsubscribe when the lobby screen is navigated away from
   window.addEventListener('hashchange', () => {
     lobbySocket.close()
-    if (infoPanel) infoPanel.stop()
   }, { once: true })
 }
 


### PR DESCRIPTION
Closes #693

Mount the tabbed InfoPanel globally in main.js as a fixed right-side collapsible drawer so it persists across all authenticated screens.

- Remove the inline InfoPanel mount from lobby.js (was embedded inside the lobby .auth-card, not a separate panel)
- Import and mount renderInfoPanel in main.js after init(), appending a fixed #info-panel-root to document.body
- syncInfoPanel() handles login/logout lifecycle via hashchange
- Add CSS for the fixed drawer: panel slides in/out with transform, toggle button stays at right edge when collapsed

Generated with [Claude Code](https://claude.ai/code)